### PR TITLE
Fix: windows platform support build target to Android.

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ By contributing to Kraken, you agree that your contributions will be licensed un
 
     **Android**
 
+    > For Windows Users, Make sure to run this command under MINGW64 environmen(For Example: Git Bash is a MINGW64 env).
+
     ```shell
     $ npm run build:bridge:android
     ```

--- a/bridge/CMakeLists.txt
+++ b/bridge/CMakeLists.txt
@@ -48,11 +48,11 @@ if ($ENV{KRAKEN_JS_ENGINE} MATCHES "jsc")
 
   if (${IS_ANDROID})
     list(APPEND BRIDGE_INCLUDE
-            ${CMAKE_CURRENT_SOURCE_DIR}/third_party/JavaScriptCore/include
+            ${CMAKE_CURRENT_SOURCE_DIR}/../third_party/JavaScriptCore/include
             )
     add_library(JavaScriptCore SHARED IMPORTED)
     set_target_properties(JavaScriptCore PROPERTIES IMPORTED_LOCATION
-            "${CMAKE_CURRENT_SOURCE_DIR}/third_party/JavaScriptCore/lib/android/${ANDROID_ABI}/libjsc.so"
+            "${CMAKE_CURRENT_SOURCE_DIR}/../third_party/JavaScriptCore/lib/android/${ANDROID_ABI}/libjsc.so"
             )
     list(APPEND BRIDGE_LINK_LIBS
             JavaScriptCore
@@ -198,7 +198,7 @@ string(REGEX REPLACE "\n$" "" APP_VER "${APP_VER}")
 string(REPLACE \n "" APP_VER ${APP_VER}) # Remove last \n
 add_definitions(-DAPP_VERSION="${APP_VER}") # Read from dartfm version
 execute_process(
-  COMMAND /usr/bin/git rev-parse --short HEAD
+  COMMAND git rev-parse --short HEAD
   WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
   OUTPUT_VARIABLE GIT_HEAD
 )

--- a/scripts/build_android_so.js
+++ b/scripts/build_android_so.js
@@ -2,17 +2,30 @@ const { paths } = require('./tasks');
 const { series, task } = require('gulp');
 const chalk = require('chalk');
 const { execSync } = require('child_process');
+const os = require('os');
+const path = require('path');
+const { copyFileSync } = require('fs');
 
 task('android-so-clean', (done) => {
   execSync(`rm -rf ${paths.bridge}/build/android`, { stdio: 'inherit' });
   done();
 });
 
-// Run tasks
-series(
+const buildTasks = [
   'android-so-clean',
   'compile-polyfill',
   'build-android-kraken-lib'
+];
+
+if (os.platform() == 'win32') {
+  buildTasks.push(
+    'patch-windows-symbol-link-for-android'
+  );
+}
+
+// Run tasks
+series(
+  buildTasks
 )((err) => {
   if (err) {
     console.log(err);

--- a/scripts/build_android_so.js
+++ b/scripts/build_android_so.js
@@ -6,10 +6,6 @@ const os = require('os');
 const path = require('path');
 const { copyFileSync } = require('fs');
 
-task('android-so-clean', (done) => {
-  execSync(`rm -rf ${paths.bridge}/build/android`, { stdio: 'inherit' });
-  done();
-});
 
 const buildTasks = [
   'android-so-clean',

--- a/scripts/prepare_kraken_release_binary.js
+++ b/scripts/prepare_kraken_release_binary.js
@@ -1,14 +1,26 @@
 require('./tasks');
 const chalk = require('chalk');
 const { series } = require('gulp');
+const os = require('os');
 
-series(
+let buildTasks = [
   'sdk-clean',
   'compile-polyfill',
-  'build-darwin-kraken-lib',
-  'build-ios-kraken-lib',
   'build-android-kraken-lib',
-)((err) => {
+];
+
+if (os.platform() == 'win32') {
+  buildTasks.push(
+    'patch-windows-symbol-link-for-android'
+  );
+} else {
+  buildTasks.push(
+    'build-darwin-kraken-lib',
+    'build-ios-kraken-lib',
+  );
+}
+
+series(buildTasks)((err) => {
   if (err) {
     console.log(err);
   } else {

--- a/scripts/tasks.js
+++ b/scripts/tasks.js
@@ -31,6 +31,15 @@ const paths = {
 
 exports.paths = paths;
 
+let winShell = null;
+if (platform == 'win32') {
+  winShell = path.join(process.env.ProgramW6432, '\\Git\\bin\\bash.exe');
+ 
+  if (!fs.existsSync(winShell)) {
+    return done(new Error('Can not location bash.exe, Please install Git for Windows at C:\\Program Files. \n https://git-scm.com/download/win'));
+  }
+}
+
 function resolveKraken(submodule) {
   return resolve(KRAKEN_ROOT, submodule);
 }
@@ -364,7 +373,7 @@ task('build-android-kraken-lib', (done) => {
   let androidHome;
 
   if (platform == 'win32') {
-    androidHome = path.join(process.env.HOME, '\\AppData\\Local\\Android\\Sdk');
+    androidHome = path.join(process.env.LOCALAPPDATA, 'Android\\Sdk');
   } else {
     androidHome = path.join(process.env.HOME, 'Library/Android/sdk')  
   }
@@ -440,12 +449,6 @@ task('macos-dylib-clean', (done) => {
 
 task('patch-windows-symbol-link-for-android', done => {
   const jniLibsDir = path.join(paths.kraken, 'android/jniLibs');
-  const winShell = path.join(process.env.ProgramW6432, '\\Git\\bin\\bash.exe');
- 
-  if (!fs.existsSync(winShell)) {
-    return done(new Error('Can not location bash.exe, Please install Git for Windows at C:\\Program Files. \n https://git-scm.com/download/win'));
-  }
-
   const archs = ['arm64-v8a', 'armeabi-v7a'];
 
   for(let arch of archs) {
@@ -460,5 +463,10 @@ task('patch-windows-symbol-link-for-android', done => {
     fs.copyFileSync(path.join(paths.bridge, `build/android/lib/${arch}/libkraken_jsc.so`), path.join(libPath, 'libkraken_jsc.so'));
   }
   
+  done();
+});
+
+task('android-so-clean', (done) => {
+  execSync(`rm -rf ${paths.bridge}/build/android`, { stdio: 'inherit', shell: winShell });
   done();
 });

--- a/scripts/tasks.js
+++ b/scripts/tasks.js
@@ -440,8 +440,8 @@ task('macos-dylib-clean', (done) => {
 
 task('patch-windows-symbol-link-for-android', done => {
   const jniLibsDir = path.join(paths.kraken, 'android/jniLibs');
-  const winShell = 'C:\\Program Files\\Git\\bin\\bash.exe';
-
+  const winShell = path.join(process.env.ProgramW6432, '\\Git\\bin\\bash.exe');
+ 
   if (!fs.existsSync(winShell)) {
     return done(new Error('Can not location bash.exe, Please install Git for Windows at C:\\Program Files. \n https://git-scm.com/download/win'));
   }

--- a/scripts/tasks.js
+++ b/scripts/tasks.js
@@ -34,9 +34,9 @@ exports.paths = paths;
 let winShell = null;
 if (platform == 'win32') {
   winShell = path.join(process.env.ProgramW6432, '\\Git\\bin\\bash.exe');
- 
+
   if (!fs.existsSync(winShell)) {
-    return done(new Error('Can not location bash.exe, Please install Git for Windows at C:\\Program Files. \n https://git-scm.com/download/win'));
+    return done(new Error(`Can not location bash.exe, Please install Git for Windows at ${process.env.ProgramW6432}. \n https://git-scm.com/download/win`));
   }
 }
 
@@ -375,7 +375,7 @@ task('build-android-kraken-lib', (done) => {
   if (platform == 'win32') {
     androidHome = path.join(process.env.LOCALAPPDATA, 'Android\\Sdk');
   } else {
-    androidHome = path.join(process.env.HOME, 'Library/Android/sdk')  
+    androidHome = path.join(process.env.HOME, 'Library/Android/sdk')
   }
 
   const ndkDir = path.join(androidHome, 'ndk');
@@ -462,7 +462,7 @@ task('patch-windows-symbol-link-for-android', done => {
     fs.copyFileSync(path.join(paths.thirdParty, `JavaScriptCore\\lib\\android\\${arch}\\libc++_shared.so`), path.join(libPath, 'libc++_shared.so'));
     fs.copyFileSync(path.join(paths.bridge, `build/android/lib/${arch}/libkraken_jsc.so`), path.join(libPath, 'libkraken_jsc.so'));
   }
-  
+
   done();
 });
 

--- a/scripts/tasks.js
+++ b/scripts/tasks.js
@@ -361,7 +361,14 @@ task('build-android-app', (done) => {
 });
 
 task('build-android-kraken-lib', (done) => {
-  const androidHome = path.join(process.env.HOME, 'Library/Android/sdk');
+  let androidHome;
+
+  if (platform == 'win32') {
+    androidHome = path.join(process.env.HOME, '\\AppData\\Local\\Android\\Sdk');
+  } else {
+    androidHome = path.join(process.env.HOME, 'Library/Android/sdk')  
+  }
+
   const ndkDir = path.join(androidHome, 'ndk');
   let installedNDK = fs.readdirSync(ndkDir).filter(d => d[0] != '.');
   if (installedNDK.length == 0) {
@@ -377,18 +384,19 @@ task('build-android-kraken-lib', (done) => {
   const archs = ['arm64-v8a', 'armeabi-v7a'];
   const buildType = buildMode == 'Release' ? 'Relwithdebinfo' : 'Debug';
 
+  const cmakeGeneratorTemplate = platform == 'win32' ? 'Ninja' : 'Unix Makefiles';
   archs.forEach(arch => {
     const soBinaryDirectory = path.join(paths.bridge, `build/android/lib/${arch}`);
-
+    const bridgeCmakeDir = path.join(paths.bridge, 'cmake-build-android-' + arch);
     // generate project
     execSync(`cmake -DCMAKE_BUILD_TYPE=${buildType} \
-    -DCMAKE_TOOLCHAIN_FILE=${androidHome}/ndk/${ndkVersion}/build/cmake/android.toolchain.cmake \
-    -DANDROID_NDK=${androidHome}/ndk/${ndkVersion} \
+    -DCMAKE_TOOLCHAIN_FILE=${path.join(androidHome, 'ndk', ndkVersion, '/build/cmake/android.toolchain.cmake')} \
+    -DANDROID_NDK=${path.join(androidHome, '/ndk/', ndkVersion)} \
     -DIS_ANDROID=TRUE \
     -DANDROID_ABI="${arch}" \
     -DANDROID_PLATFORM="android-16" \
     -DANDROID_STL=c++_shared \
-    -G "Unix Makefiles" \
+    -G "${cmakeGeneratorTemplate}" \
     -B ${paths.bridge}/cmake-build-android-${arch} -S ${paths.bridge}`,
       {
         cwd: paths.bridge,
@@ -401,7 +409,7 @@ task('build-android-kraken-lib', (done) => {
       });
 
     // build
-    execSync(`cmake --build ${paths.bridge}/cmake-build-android-${arch} --target kraken -- -j 12`, {
+    execSync(`cmake --build ${bridgeCmakeDir} --target kraken -- -j 12`, {
       stdio: 'inherit'
     });
   });
@@ -427,5 +435,30 @@ task('build-android-sdk', (done) => {
 
 task('macos-dylib-clean', (done) => {
   execSync(`rm -rf ${paths.bridge}/build/macos`, { stdio: 'inherit' });
+  done();
+});
+
+task('patch-windows-symbol-link-for-android', done => {
+  const jniLibsDir = path.join(paths.kraken, 'android/jniLibs');
+  const winShell = 'C:\\Program Files\\Git\\bin\\bash.exe';
+
+  if (!fs.existsSync(winShell)) {
+    return done(new Error('Can not location bash.exe, Please install Git for Windows at C:\\Program Files. \n https://git-scm.com/download/win'));
+  }
+
+  const archs = ['arm64-v8a', 'armeabi-v7a'];
+
+  for(let arch of archs) {
+    const libPath = path.join(jniLibsDir, arch);
+    execSync('rm -f ./*', {
+      cwd: libPath,
+      shell: winShell,
+      stdio: 'inherit'
+    });
+    fs.copyFileSync(path.join(paths.thirdParty, `JavaScriptCore\\lib\\android\\${arch}\\libjsc.so`), path.join(libPath, 'libjsc.so'));
+    fs.copyFileSync(path.join(paths.thirdParty, `JavaScriptCore\\lib\\android\\${arch}\\libc++_shared.so`), path.join(libPath, 'libc++_shared.so'));
+    fs.copyFileSync(path.join(paths.bridge, `build/android/lib/${arch}/libkraken_jsc.so`), path.join(libPath, 'libkraken_jsc.so'));
+  }
+  
   done();
 });


### PR DESCRIPTION
1. 修复构建脚本，让 Windows 用户可以在本地构建编译 kraken 到 Android 设备上运行。