### PR TITLE
fix: element size not change when widget size change

### DIFF
--- a/kraken/lib/src/launcher/controller.dart
+++ b/kraken/lib/src/launcher/controller.dart
@@ -30,9 +30,9 @@ typedef TraverseElementCallback = void Function(Element element);
 
 // Traverse DOM element.
 void traverseElement(Element element, TraverseElementCallback callback) {
+  callback(element);
   if (element != null) {
     for (Element el in element.children) {
-      callback(el);
       traverseElement(el, callback);
     }
   }

--- a/kraken/lib/widget.dart
+++ b/kraken/lib/widget.dart
@@ -11,6 +11,7 @@ import 'package:flutter/rendering.dart';
 import 'package:kraken/kraken.dart';
 import 'package:kraken/module.dart';
 import 'package:kraken/gesture.dart';
+import 'package:kraken/css.dart';
 
 class Kraken extends StatelessWidget {
   // The background color for viewport, default to transparent.
@@ -179,15 +180,18 @@ class _KrakenRenderObjectWidget extends SingleChildRenderObjectWidget {
 
     if (viewportWidthHasChanged) {
       controller.view.viewportWidth = _krakenWidget.viewportWidth;
+      controller.view.document.body.style.setProperty(WIDTH, controller.view.viewportWidth.toString() + 'px');
     }
 
     if (viewportHeightHasChanged) {
       controller.view.viewportHeight = _krakenWidget.viewportHeight;
+      controller.view.document.body.style.setProperty(HEIGHT, controller.view.viewportHeight.toString() + 'px');
     }
 
     if (viewportWidthHasChanged || viewportHeightHasChanged) {
       traverseElement(controller.view.document.body, (element) {
         element.style.applyTargetProperties();
+        element.renderBoxModel.markNeedsLayout();
       });
     }
   }


### PR DESCRIPTION
 Closes https://github.com/openkraken/kraken/issues/85  
修复 widget resize 时 element size 未 change：
1. viewportSize change 时 body element 的 style 未更新
2. element tree 向下递归对 element 重新设置 style 时未包含 body
3. 给 element 设置 style 时不一定会触发 markNeedsLayout（如 style 中只有 backgroundColor)，需要手动 markNeedsLayout