### PR TITLE
Fix/bridge node op

### DIFF
--- a/bridge/bindings/jsc/DOM/element.cc
+++ b/bridge/bindings/jsc/DOM/element.cc
@@ -4,12 +4,12 @@
  */
 
 #include "element.h"
+#include "bindings/jsc/KOM/blob.h"
 #include "bridge_jsc.h"
 #include "dart_methods.h"
 #include "event_target.h"
 #include "foundation/ui_command_queue.h"
 #include "text_node.h"
-#include "bindings/jsc/KOM/blob.h"
 
 namespace kraken::binding::jsc {
 using namespace foundation;
@@ -312,17 +312,14 @@ JSValueRef ElementInstance::getProperty(std::string &name, JSValueRef *exception
                                                 nativeElement, static_cast<int64_t>(ViewModuleProperty::scrollWidth)));
   }
   case JSElement::ElementProperty::children: {
-    JSValueRef arguments[childNodes.size()];
-
-    size_t elementCount = 0;
-    for (int i = 0; i < childNodes.size(); i++) {
-      if (childNodes[i]->nodeType == NodeType::ELEMENT_NODE) {
-        arguments[i] = childNodes[i]->object;
-        elementCount++;
+    std::vector<JSValueRef> arguments;
+    for (auto &childNode : childNodes) {
+      if (childNode->nodeType == NodeType::ELEMENT_NODE) {
+        arguments.emplace_back(childNode->object);
       }
     }
 
-    return JSObjectMakeArray(_hostClass->ctx, elementCount, arguments, nullptr);
+    return JSObjectMakeArray(_hostClass->ctx, arguments.size(), arguments.data(), nullptr);
   }
   }
 

--- a/bridge/bindings/jsc/DOM/node.cc
+++ b/bridge/bindings/jsc/DOM/node.cc
@@ -100,7 +100,7 @@ NodeInstance *NodeInstance::previousSibling() {
     return nullptr;
   }
 
-  if ((it - 1) != parentChildNodes.end()) {
+  if (it != parentChildNodes.begin()) {
     return *(it - 1);
   }
 

--- a/integration_tests/specs/dom/nodes/element.ts
+++ b/integration_tests/specs/dom/nodes/element.ts
@@ -40,4 +40,21 @@ describe('DOM Element API', () => {
     div.removeAttribute('foo');
     expect(div.hasAttribute('foo')).toBeFalse();
   });
+
+  it('children should only contain elements', () => {
+    let container = document.createElement('div');
+    let a = document.createElement('div');
+    let b = document.createElement('div');
+    let text = document.createTextNode('test');
+    let comment = document.createTextNode('#comment');
+    container.appendChild(a);
+    container.appendChild(text);
+    container.appendChild(b);
+    container.appendChild(comment);
+
+    expect(container.childNodes.length).toBe(4);
+    expect(container.children.length).toBe(2);
+    expect(container.children[0]).toBe(a);
+    expect(container.children[1]).toBe(b);
+  });
 });

--- a/integration_tests/specs/dom/nodes/node.ts
+++ b/integration_tests/specs/dom/nodes/node.ts
@@ -62,6 +62,21 @@ describe('Node API', () => {
     expect(child.isConnected).toBe(true, 'child is connected');
   });
 
+  it('previousSibling should to null when child is firstChild and children.size() > 2', () => {
+    let container = document.createElement('div');
+    let a = document.createElement('div');
+    let b = document.createElement('div');
+    let c = document.createElement('div');
+    let d = document.createElement('div');
+    container.appendChild(a);
+    container.appendChild(b);
+    container.appendChild(c);
+    container.appendChild(d);
+    document.body.appendChild(container);
+    expect(a.previousSibling).toBe(null, 'firstChild should be null');
+    expect(a.isConnected).toBe(true, 'isConnected should be true');
+  });
+
   it('next sibling should to null when child is lastChild of multiple children list', () => {
     let container = document.createElement('div');
     let child = document.createElement('div');


### PR DESCRIPTION
fix: fix access Node.previousSibling crashed when target node at top of childNodes.
fix: fix access Element.children crashed when contains non-element nodes in childNodes.