### PR TITLE
refactor: rename snapshot helper method in testing

### DIFF
--- a/bridge/polyfill/src/test/jasmine.js
+++ b/bridge/polyfill/src/test/jasmine.js
@@ -4037,7 +4037,7 @@ getJasmineRequireObj().toBeResolvedTo = function (j$) {
   };
 };
 
-getJasmineRequireObj().toMatchImageSnapshot = function (j$) {
+getJasmineRequireObj().toMatchSnapshot = function (j$) {
   const _matchImageSnapshotCounter = {};
   /**
    * Expect a element to be equal with it's screenshot image.
@@ -4046,11 +4046,11 @@ getJasmineRequireObj().toMatchImageSnapshot = function (j$) {
    * @name async-matchers#toBeResolvedTo
    * @param {Object} expected - DOM element
    * @example
-   * await expectAsync(document.body).toMatchImageSnapshot();
+   * await expectAsync(document.body).toMatchSnapshot();
    * @example
-   * await expectAsync(document.body).toMatchImageSnapshot('imageName');
+   * await expectAsync(document.body).toMatchSnapshot('imageName');
    */
-  return function toMatchImageSnapshot(util, customEqualityTesters) {
+  return function toMatchSnapshot(util, customEqualityTesters) {
     return {
       compare: function (blobP, snapshotName) {
         const currentSpec = j$.getEnv().currentRunnable();
@@ -4680,7 +4680,7 @@ getJasmineRequireObj().requireAsyncMatchers = function (jRequire, j$) {
     'toBeResolved',
     'toBeRejected',
     'toBeResolvedTo',
-    'toMatchImageSnapshot',
+    'toMatchSnapshot',
     'toBeRejectedWith',
     'toBeRejectedWithError'
   ],

--- a/integration_tests/runtime/global.ts
+++ b/integration_tests/runtime/global.ts
@@ -30,17 +30,6 @@ function sleep(second: number) {
   return new Promise(done => setTimeout(done, second * 1000));
 }
 
-function createElementWithStyle(tag: string, style: { [key: string]: string | number }, child?: Node | Array<Node>): any {
-  const el = document.createElement(tag);
-  setElementStyle(el, style);
-  if (Array.isArray(child)) {
-    child.forEach(c => el.appendChild(c));
-  } else if (child) {
-    el.appendChild(child);
-  }
-  return el;
-}
-
 type ElementProps = {
   [key: string]: any;
   style?: {
@@ -62,6 +51,17 @@ function setElementProps(el: HTMLElement, props: ElementProps) {
 function createElement(tag: string, props: ElementProps, child?: Node | Array<Node>) {
   const el = document.createElement(tag);
   setElementProps(el, props);
+  if (Array.isArray(child)) {
+    child.forEach(c => el.appendChild(c));
+  } else if (child) {
+    el.appendChild(child);
+  }
+  return el;
+}
+
+function createElementWithStyle(tag: string, style: { [key: string]: string | number }, child?: Node | Array<Node>): any {
+  const el = document.createElement(tag);
+  setElementStyle(el, style);
   if (Array.isArray(child)) {
     child.forEach(c => el.appendChild(c));
   } else if (child) {
@@ -180,13 +180,13 @@ function append(parent: HTMLElement, child: Node) {
   parent.appendChild(child);
 }
 
-async function matchViewportSnapshot(wait: number = 0.0) {
-  await sleep(wait);
-  await matchElementImageSnapshot(document.body);
-}
-
-async function matchElementImageSnapshot(element: HTMLElement) {
-  return await expectAsync(element.toBlob(1.0)).toMatchImageSnapshot();
+async function snapshot(target: HTMLElement | number = 0.0) {
+  if (typeof target == 'number') {
+    await sleep(target);
+    await expectAsync(document.body.toBlob(1.0)).toMatchSnapshot();
+  } else {
+    await expectAsync(target.toBlob(1.0)).toMatchSnapshot(); 
+  }
 }
 
 // Compatible to tests that use global variables.
@@ -199,10 +199,9 @@ Object.assign(global, {
   createText,
   createViewElement,
   setElementStyle,
-  matchElementImageSnapshot,
-  matchViewportSnapshot,
   setElementProps,
   simulateSwipe,
   simulateClick,
   sleep,
+  snapshot,
 });

--- a/integration_tests/runtime/jasmine.d.ts
+++ b/integration_tests/runtime/jasmine.d.ts
@@ -671,7 +671,7 @@ declare namespace jasmine {
          * Expect a element to match a image.
          * @param screenShotName
          */
-        toMatchImageSnapshot(screenShotName?: any): Promise<boolean>;
+        toMatchSnapshot(screenShotName?: any): Promise<boolean>;
 
         /**
          * Expect a promise to be resolved.

--- a/integration_tests/specs/cookie/cookie.ts
+++ b/integration_tests/specs/cookie/cookie.ts
@@ -3,6 +3,6 @@ describe('Cookie', () => {
     document.cookie = "name=oeschger";
     document.cookie = "favorite_food=tripe";
     document.body.appendChild(document.createTextNode(document.cookie));
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-align/baseline-rules.ts
+++ b/integration_tests/specs/css/css-align/baseline-rules.ts
@@ -36,7 +36,7 @@ describe('Baseline-rules flexbox', () => {
     append(wrapper, box);
     append(BODY, wrapper);
 
-    await matchElementImageSnapshot(wrapper);
+    await snapshot(wrapper);
   });
 
   it('synthesized-baseline-flexbox-002', async () => {
@@ -54,7 +54,7 @@ describe('Baseline-rules flexbox', () => {
     });
     append(magenta, box);
     append(BODY, wrapper);
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('synthesized-baseline-flexbox-003', async () => {
@@ -72,7 +72,7 @@ describe('Baseline-rules flexbox', () => {
     });
     append(magenta, box);
     append(BODY, wrapper);
-    await matchElementImageSnapshot(wrapper);
+    await snapshot(wrapper);
   });
 
   it('synthesized-baseline-flexbox-004', async () => {
@@ -89,7 +89,7 @@ describe('Baseline-rules flexbox', () => {
     });
     append(magenta, box);
     append(BODY, wrapper);
-    await matchElementImageSnapshot(wrapper);
+    await snapshot(wrapper);
   });
 
   it('synthesized-baseline-flexbox-005', async () => {
@@ -107,7 +107,7 @@ describe('Baseline-rules flexbox', () => {
     });
     append(magenta, box);
     append(BODY, wrapper);
-    await matchElementImageSnapshot(wrapper);
+    await snapshot(wrapper);
   });
 
   it('synthesized-baseline-flexbox-006', async () => {
@@ -128,7 +128,7 @@ describe('Baseline-rules flexbox', () => {
     });
     append(magenta, box);
     append(BODY, wrapper);
-    await matchElementImageSnapshot(wrapper);
+    await snapshot(wrapper);
   });
 
   it('synthesized-baseline-flexbox-007', async () => {
@@ -149,7 +149,7 @@ describe('Baseline-rules flexbox', () => {
     });
     append(magenta, box);
     append(BODY, wrapper);
-    await matchElementImageSnapshot(wrapper);
+    await snapshot(wrapper);
   });
 
   it('flex layout nest flow layout', async () => {
@@ -276,7 +276,7 @@ describe('Baseline-rules flexbox', () => {
     );
     BODY.appendChild(test);
 
-    await matchViewportSnapshot(0.1);
+    await snapshot(0.1);
   });
 
   it('flex layout nest flex layout', async () => {
@@ -403,7 +403,7 @@ describe('Baseline-rules flexbox', () => {
     );
     BODY.appendChild(test);
 
-    await matchViewportSnapshot(0.1);
+    await snapshot(0.1);
   });
 
   it('flow layout nest flex layout', async () => {
@@ -528,7 +528,7 @@ describe('Baseline-rules flexbox', () => {
     );
     BODY.appendChild(test);
 
-    await matchViewportSnapshot(0.1);
+    await snapshot(0.1);
   });
 
   it('flow layout nest flow layout', async () => {
@@ -653,47 +653,47 @@ describe('Baseline-rules flexbox', () => {
     );
     BODY.appendChild(test);
 
-    await matchViewportSnapshot(0.1);
+    await snapshot(0.1);
   });
 });
 
 // @TODO: deps on inline-block features.
-// describe('Baseline-rules inline-block', () => {
-//   const wrapperStyle = {
-//     border: '1px solid block',
-//     position: 'relative',
-//     width: '200px',
-//     height: '150px',
-//     margin: '10px'
-//   };
-//
-//   const canvasStyle = {
-//     width: '50px',
-//     height: '50px',
-//     backgroundColor: 'blue'
-//   };
-//
-//   const magentaBorderStyle = {
-//     border: '5px solid magenta'
-//   };
-//
-//   const borderPaddingMargin = {
-//     border: '10px solid cyan',
-//     padding: '15px',
-//     margin: '20px 0px',
-//     backgroundColor: 'yellow'
-//   };
-//
-//   xit('synthesized-baseline-inline-block-001', async () => {
-//     let wrapper = create('div', wrapperStyle);
-//     let left = create('canvas', canvasStyle);
-//     let box = create('div', {
-//       borderPaddingMargin,
-//       display: 'inline-flex'
-//     });
-//     append(wrapper, left);
-//     append(wrapper, box);
-//     append(BODY, wrapper);
-//     await matchViewportSnapshot();
-//   });
-// });
+xdescribe('Baseline-rules inline-block', () => {
+  const wrapperStyle = {
+    border: '1px solid block',
+    position: 'relative',
+    width: '200px',
+    height: '150px',
+    margin: '10px'
+  };
+
+  const canvasStyle = {
+    width: '50px',
+    height: '50px',
+    backgroundColor: 'blue'
+  };
+
+  const magentaBorderStyle = {
+    border: '5px solid magenta'
+  };
+
+  const borderPaddingMargin = {
+    border: '10px solid cyan',
+    padding: '15px',
+    margin: '20px 0px',
+    backgroundColor: 'yellow'
+  };
+
+  xit('synthesized-baseline-inline-block-001', async () => {
+    let wrapper = create('div', wrapperStyle);
+    let left = create('canvas', canvasStyle);
+    let box = create('div', {
+      borderPaddingMargin,
+      display: 'inline-flex'
+    });
+    append(wrapper, left);
+    append(wrapper, box);
+    append(BODY, wrapper);
+    await snapshot();
+  });
+});

--- a/integration_tests/specs/css/css-align/text-align.ts
+++ b/integration_tests/specs/css/css-align/text-align.ts
@@ -44,6 +44,6 @@ describe('Align text-align', () => {
 
     document.body.appendChild(container);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-backgrounds/background-attachment.ts
+++ b/integration_tests/specs/css/css-backgrounds/background-attachment.ts
@@ -17,7 +17,7 @@ describe('background-attachment', () => {
     append(container, text);
     append(BODY, container);
     await sleep(1);
-    await matchElementImageSnapshot(container);
+    await snapshot(container);
   });
 
   it('local', async () => {
@@ -39,9 +39,9 @@ describe('background-attachment', () => {
     append(container, text);
     append(BODY, container);
     await sleep(1);
-    await matchViewportSnapshot();
+    await snapshot();
     container.scrollTo(0, 100);
-    await matchViewportSnapshot(0.1);
+    await snapshot(0.1);
   });
 
   it('scroll', async () => {
@@ -73,6 +73,6 @@ describe('background-attachment', () => {
     append(container, text);
     append(BODY, container);
     await sleep(1);
-    await matchElementImageSnapshot(container);
+    await snapshot(container);
   });
 });

--- a/integration_tests/specs/css/css-backgrounds/background-clip.ts
+++ b/integration_tests/specs/css/css-backgrounds/background-clip.ts
@@ -19,7 +19,7 @@ describe('Background-clip', () => {
       ]
     );
     append(BODY, div);
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('works with border-box', async () => {
@@ -43,7 +43,7 @@ describe('Background-clip', () => {
       ]
     );
     append(BODY, div);
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('works with padding-box', async () => {
@@ -67,7 +67,7 @@ describe('Background-clip', () => {
       ]
     );
     append(BODY, div);
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('works with content-box', async () => {
@@ -91,6 +91,6 @@ describe('Background-clip', () => {
       ]
     );
     append(BODY, div);
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-backgrounds/background-color-padding-box.ts
+++ b/integration_tests/specs/css/css-backgrounds/background-color-padding-box.ts
@@ -19,6 +19,6 @@ describe('Background-color-padding-box', function() {
     let div = createElementWithStyle('div', divStyle);
     append(parent, div);
     append(BODY, parent);
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-backgrounds/background-color.ts
+++ b/integration_tests/specs/css/css-backgrounds/background-color.ts
@@ -8,7 +8,7 @@ describe('Background-color', () => {
     });
 
     document.body.appendChild(div);
-    await expectAsync(div.toBlob(1.0)).toMatchImageSnapshot();
+    await expectAsync(div.toBlob(1.0)).toMatchSnapshot();
   });
 
   xit('red with display none', async () => {
@@ -19,13 +19,13 @@ describe('Background-color', () => {
       height: '100px',
     });
     append(BODY, div);
-    await matchElementImageSnapshot(div);
+    await snapshot(div);
   });
 
   xit('red with display when window.onload', done => {
     window.onload = async () => {
       div.style.display = 'none';
-      await matchViewportSnapshot();
+      await snapshot();
       done();
     };
     const div = createElementWithStyle('div', {
@@ -54,7 +54,7 @@ describe('Background-color', () => {
     append(BODY, red);
     append(BODY, green);
     await sleep(1);
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('red and remove', async (done) => {
@@ -68,7 +68,7 @@ describe('Background-color', () => {
 
     requestAnimationFrame(async () => {
       div.style.backgroundColor = '';
-      await expectAsync(div.toBlob(1.0)).toMatchImageSnapshot();
+      await expectAsync(div.toBlob(1.0)).toMatchSnapshot();
       done();
     });
   });

--- a/integration_tests/specs/css/css-backgrounds/background-image.ts
+++ b/integration_tests/specs/css/css-backgrounds/background-image.ts
@@ -22,7 +22,7 @@ describe('background image', function() {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot(0.1);
+    await snapshot(0.1);
   });
 
   it('should work with image of base64', async () => {
@@ -48,6 +48,6 @@ describe('background image', function() {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot(0.1);
+    await snapshot(0.1);
   });
 });

--- a/integration_tests/specs/css/css-backgrounds/background-origin.ts
+++ b/integration_tests/specs/css/css-backgrounds/background-origin.ts
@@ -21,7 +21,7 @@ describe('Background-origin', () => {
       ]
     );
     append(BODY, div);
-    await matchViewportSnapshot(0.2);
+    await snapshot(0.2);
   });
 
   it('works with border-box', async () => {
@@ -47,7 +47,7 @@ describe('Background-origin', () => {
       ]
     );
     append(BODY, div);
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('works with padding-box', async () => {
@@ -73,7 +73,7 @@ describe('Background-origin', () => {
       ]
     );
     append(BODY, div);
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('works with content-box', async () => {
@@ -99,6 +99,6 @@ describe('Background-origin', () => {
       ]
     );
     append(BODY, div);
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-backgrounds/background-position.ts
+++ b/integration_tests/specs/css/css-backgrounds/background-position.ts
@@ -21,7 +21,7 @@ describe('Background-position', () => {
     });
     position.appendChild(position1);
     append(BODY, position);
-    await matchViewportSnapshot(0.1);
+    await snapshot(0.1);
   });
 
   it('left', async () => {
@@ -39,15 +39,14 @@ describe('Background-position', () => {
     setElementStyle(position2, {
       width: '360px',
       height: '200px',
-      backgroundImage:
-        'url(assets/rax.png)',
+      backgroundImage: 'url(assets/rax.png)',
       backgroundPosition: 'left',
       backgroundRepeat: 'no-repeat',
     });
     position.appendChild(position2);
 
     append(BODY, position);
-    await matchViewportSnapshot(0.5);
+    await snapshot(0.1);
   });
 
   it('top', async () => {
@@ -74,7 +73,7 @@ describe('Background-position', () => {
 
     append(BODY, position);
     await sleep(1);
-    await matchViewportSnapshot(0.5);
+    await snapshot();
   });
 
   it('right', async () => {
@@ -101,7 +100,7 @@ describe('Background-position', () => {
 
     append(BODY, position);
     await sleep(1);
-    await matchViewportSnapshot(0.5);
+    await snapshot();
   });
 
   it('bottom', async () => {
@@ -126,7 +125,7 @@ describe('Background-position', () => {
     position.appendChild(position5);
     append(BODY, position);
     await sleep(1);
-    await matchViewportSnapshot(0.5);
+    await snapshot();
   });
 
   it('right center', async () => {
@@ -150,6 +149,6 @@ describe('Background-position', () => {
     append(position, div);
     append(BODY, position);
     await sleep(1);
-    await matchViewportSnapshot(0.5);
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-backgrounds/background-repeat.ts
+++ b/integration_tests/specs/css/css-backgrounds/background-repeat.ts
@@ -19,7 +19,7 @@ describe('background-repeat', () => {
     });
     repeat.appendChild(div1);
     document.body.appendChild(repeat);
-    await expectAsync(repeat.toBlob(1.0)).toMatchImageSnapshot(0.5);
+    await expectAsync(repeat.toBlob(1.0)).toMatchSnapshot(0.5);
   });
 
   it('none-repeat', async () => {
@@ -43,7 +43,7 @@ describe('background-repeat', () => {
     });
     repeat.appendChild(div1);
     document.body.appendChild(repeat);
-    await expectAsync(repeat.toBlob(1.0)).toMatchImageSnapshot(0.5);
+    await expectAsync(repeat.toBlob(1.0)).toMatchSnapshot(0.5);
   });
 
   it('repeat-x', async () => {
@@ -67,7 +67,7 @@ describe('background-repeat', () => {
     repeat.appendChild(div2);
     append(BODY, repeat);
 
-    await expectAsync(repeat.toBlob(1.0)).toMatchImageSnapshot(0.5);
+    await expectAsync(repeat.toBlob(1.0)).toMatchSnapshot(0.5);
   });
 
   it('repeat-y', async () => {
@@ -90,7 +90,7 @@ describe('background-repeat', () => {
     });
     repeat.appendChild(div3);
     append(BODY, repeat);
-    await expectAsync(repeat.toBlob(1.0)).toMatchImageSnapshot(0.5);
+    await expectAsync(repeat.toBlob(1.0)).toMatchSnapshot(0.5);
   });
 
   it('repeat', async () => {
@@ -113,7 +113,7 @@ describe('background-repeat', () => {
     });
     repeat.appendChild(div4);
     append(BODY, repeat);
-    await expectAsync(repeat.toBlob(1.0)).toMatchImageSnapshot(0.5);
+    await expectAsync(repeat.toBlob(1.0)).toMatchSnapshot(0.5);
   });
 
   xit('round', async () => {
@@ -127,7 +127,7 @@ describe('background-repeat', () => {
     });
     append(BODY, div);
     await sleep(0.5);
-    await matchElementImageSnapshot(div);
+    await snapshot(div);
   });
 
   xit('no-repeat will stop round to repeat', async () => {
@@ -141,6 +141,6 @@ describe('background-repeat', () => {
     });
     append(BODY, div);
     await sleep(0.5);
-    await matchElementImageSnapshot(div);
+    await snapshot(div);
   });
 });

--- a/integration_tests/specs/css/css-backgrounds/background-shorthand.ts
+++ b/integration_tests/specs/css/css-backgrounds/background-shorthand.ts
@@ -8,7 +8,7 @@ describe('background-shorthand', () => {
     });
     document.body.appendChild(div);
     await sleep(0.5);
-    await matchElementImageSnapshot(div);
+    await snapshot(div);
   });
 
   it('background gradient', async () => {
@@ -19,7 +19,7 @@ describe('background-shorthand', () => {
       background: 'center/contain repeat radial-gradient(crimson,skyblue)'
     });
     document.body.appendChild(div);
-    await matchElementImageSnapshot(div);
+    await snapshot(div);
   });
 
   it('background color', async () => {
@@ -30,7 +30,7 @@ describe('background-shorthand', () => {
       background: 'red'
     });
     document.body.appendChild(div);
-    await matchElementImageSnapshot(div);
+    await snapshot(div);
   });
 
   it('background color rgb', async () => {
@@ -41,7 +41,7 @@ describe('background-shorthand', () => {
       background: 'rgb(255, 0, 0)'
     });
     document.body.appendChild(div);
-    await matchElementImageSnapshot(div);
+    await snapshot(div);
   });
 
   it("background gradient with space", async () => {
@@ -72,6 +72,6 @@ describe('background-shorthand', () => {
     document.body.appendChild(flexbox);
 
 
-    await matchViewportSnapshot();
+    await snapshot();
   })
 });

--- a/integration_tests/specs/css/css-backgrounds/background.ts
+++ b/integration_tests/specs/css/css-backgrounds/background.ts
@@ -64,6 +64,6 @@ xdescribe('background-331', () => {
     div.style.height = '100px';
     div.style.backgroundImage = 'URL(https://gw.alicdn.com/tfs/TB1E5GzToz1gK0jSZLeXXb9kVXa-750-595.png)';
     document.body.appendChild(div);
-    await matchViewportSnapshot(1);
+    await snapshot(1);
   });
 });

--- a/integration_tests/specs/css/css-backgrounds/border-radius.ts
+++ b/integration_tests/specs/css/css-backgrounds/border-radius.ts
@@ -24,7 +24,7 @@ describe('border_radius', () => {
 
     document.body.appendChild(container);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('works with image', async () => {
@@ -40,7 +40,7 @@ describe('border_radius', () => {
     );
     BODY.appendChild(image);
 
-    await matchViewportSnapshot(0.1);
+    await snapshot(0.1);
   });
 
   it('should work with percentage of one value', async () => {
@@ -68,7 +68,7 @@ describe('border_radius', () => {
     );
 
     BODY.appendChild(div);
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('should work with percentage of two values', async () => {
@@ -96,7 +96,7 @@ describe('border_radius', () => {
     );
 
     BODY.appendChild(div);
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('should work with percentage border-radius and percentage sizing in flow layout', async () => {
@@ -124,7 +124,7 @@ describe('border_radius', () => {
     );
 
     BODY.appendChild(div);
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('should work with percentage border-radius and percentage sizing of multiple children in flow layout', async () => {
@@ -159,7 +159,7 @@ describe('border_radius', () => {
     );
 
     BODY.appendChild(div);
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('should work with percentage border-radius and percentage sizing in flex layout', async () => {
@@ -188,7 +188,7 @@ describe('border_radius', () => {
     );
 
     BODY.appendChild(div);
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('should work with percentage border-radius and percentage sizing of multiple children in flex layout', async () => {
@@ -224,7 +224,7 @@ describe('border_radius', () => {
     );
 
     BODY.appendChild(div);
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('should work with border and percentage border-radius', async () => {
@@ -254,6 +254,6 @@ describe('border_radius', () => {
     );
 
     BODY.appendChild(div);
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-backgrounds/linear-gradient.ts
+++ b/integration_tests/specs/css/css-backgrounds/linear-gradient.ts
@@ -9,7 +9,7 @@ describe('Background linear-gradient', () => {
     });
 
     append(BODY, div1);
-    await matchElementImageSnapshot(div1);
+    await snapshot(div1);
   });
 
   it('linear-gradient and remove', async (done) => {
@@ -22,10 +22,10 @@ describe('Background linear-gradient', () => {
     });
 
     append(BODY, div1);
-    await matchElementImageSnapshot(div1);
+    await snapshot(div1);
     requestAnimationFrame(async () => {
       div1.style.backgroundImage = '';
-      await expectAsync(div1.toBlob(1.0)).toMatchImageSnapshot();
+      await expectAsync(div1.toBlob(1.0)).toMatchSnapshot();
       done();
     });
   });
@@ -40,7 +40,7 @@ describe('Background linear-gradient', () => {
     });
 
     append(BODY, div2);
-    await matchElementImageSnapshot(div2);
+    await snapshot(div2);
   });
 
   it('radial-gradient', async () => {
@@ -52,7 +52,7 @@ describe('Background linear-gradient', () => {
     });
 
     append(BODY, div3);
-    await matchElementImageSnapshot(div3);
+    await snapshot(div3);
   });
 
   it('linear-gradient-rotate', async () => {
@@ -64,7 +64,7 @@ describe('Background linear-gradient', () => {
       'linear-gradient(135deg, red, red 10%, blue 75%, yellow 75%)',
     });
     append(BODY, div4);
-    await matchElementImageSnapshot(div4);
+    await snapshot(div4);
   });
 
   it("linear-gradient to right with color stop of px", async () => {
@@ -88,7 +88,7 @@ describe('Background linear-gradient', () => {
     );
     BODY.appendChild(flexbox);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it("linear-gradient to right with color stop of px and width not set", async () => {
@@ -111,7 +111,7 @@ describe('Background linear-gradient', () => {
     );
     BODY.appendChild(flexbox);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it("linear-gradient to bottom with color stop of px", async () => {
@@ -135,7 +135,7 @@ describe('Background linear-gradient', () => {
     );
     BODY.appendChild(flexbox);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it("linear-gradient to bottom with color stop of px and height not set", async () => {
@@ -167,7 +167,7 @@ describe('Background linear-gradient', () => {
     container.appendChild(flexbox);
     BODY.appendChild(container);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it("linear-gradient to right with color stop not set", async () => {
@@ -189,7 +189,7 @@ describe('Background linear-gradient', () => {
     );
     BODY.appendChild(flexbox);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it("linear-gradient to bottom with color stop not set", async () => {
@@ -211,6 +211,6 @@ describe('Background linear-gradient', () => {
     );
     BODY.appendChild(flexbox);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-borders/border-005.ts
+++ b/integration_tests/specs/css/css-borders/border-005.ts
@@ -32,6 +32,6 @@ describe('border-005', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot(0.1);
+    await snapshot(0.1);
   });
 });

--- a/integration_tests/specs/css/css-borders/border-006.ts
+++ b/integration_tests/specs/css/css-borders/border-006.ts
@@ -32,6 +32,6 @@ describe('border-006', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot(0.1);
+    await snapshot(0.1);
   });
 });

--- a/integration_tests/specs/css/css-borders/border-applies.ts
+++ b/integration_tests/specs/css/css-borders/border-applies.ts
@@ -25,7 +25,7 @@ describe('border-applies', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot(0.1);
+    await snapshot(0.1);
   });
   it('to-009', async () => {
     let p;
@@ -63,7 +63,7 @@ describe('border-applies', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot(0.1);
+    await snapshot(0.1);
   });
   xit('to-012', async () => {
     let p;
@@ -135,6 +135,6 @@ describe('border-applies', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot(0.1);
+    await snapshot(0.1);
   });
 });

--- a/integration_tests/specs/css/css-borders/border-bottom.ts
+++ b/integration_tests/specs/css/css-borders/border-bottom.ts
@@ -24,7 +24,7 @@ describe('border-bottom', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot(0.1);
+    await snapshot(0.1);
   });
   xit('001', async () => {
     let p;
@@ -52,7 +52,7 @@ describe('border-bottom', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot(0.1);
+    await snapshot(0.1);
   });
   xit('003', async () => {
     let p;
@@ -79,7 +79,7 @@ describe('border-bottom', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot(0.1);
+    await snapshot(0.1);
   });
   it('005-ref', async () => {
     let p;
@@ -105,7 +105,7 @@ describe('border-bottom', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot(0.1);
+    await snapshot(0.1);
   });
   it('005', async () => {
     let p;
@@ -132,7 +132,7 @@ describe('border-bottom', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot(0.1);
+    await snapshot(0.1);
   });
   it('006', async () => {
     let p;
@@ -159,7 +159,7 @@ describe('border-bottom', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot(0.1);
+    await snapshot(0.1);
   });
   it('008', async () => {
     let p;
@@ -186,7 +186,7 @@ describe('border-bottom', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot(0.1);
+    await snapshot(0.1);
   });
   it('010', async () => {
     let p;
@@ -212,7 +212,7 @@ describe('border-bottom', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot(0.1);
+    await snapshot(0.1);
   });
   it('016-ref', async () => {
     let p;
@@ -246,7 +246,7 @@ describe('border-bottom', () => {
     BODY.appendChild(div);
     BODY.appendChild(div_1);
 
-    await matchViewportSnapshot(0.1);
+    await snapshot(0.1);
   });
   it('016', async () => {
     let p;
@@ -285,7 +285,7 @@ describe('border-bottom', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot(0.1);
+    await snapshot(0.1);
   });
   it('018-ref', async () => {
     let p;
@@ -319,7 +319,7 @@ describe('border-bottom', () => {
     BODY.appendChild(div);
     BODY.appendChild(div_1);
 
-    await matchViewportSnapshot(0.1);
+    await snapshot(0.1);
   });
   it('018', async () => {
     let p;
@@ -358,7 +358,7 @@ describe('border-bottom', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot(0.1);
+    await snapshot(0.1);
   });
   it('applies-to-001-ref', async () => {
     let p;
@@ -382,7 +382,7 @@ describe('border-bottom', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot(0.1);
+    await snapshot(0.1);
   });
   it('applies-to-008', async () => {
     let div;
@@ -401,7 +401,7 @@ describe('border-bottom', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot(0.1);
+    await snapshot(0.1);
   });
   it('applies-to-009', async () => {
     let div;
@@ -426,7 +426,7 @@ describe('border-bottom', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot(0.1);
+    await snapshot(0.1);
   });
   it('applies-to-012', async () => {
     let p;
@@ -487,7 +487,7 @@ describe('border-bottom', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot(0.1);
+    await snapshot(0.1);
   });
   xit('color-001-ref', async () => {
     let p;
@@ -523,7 +523,7 @@ describe('border-bottom', () => {
     BODY.appendChild(div);
     BODY.appendChild(div_1);
 
-    await matchViewportSnapshot(0.1);
+    await snapshot(0.1);
   });
   it('color-001', async () => {
     let p;
@@ -566,7 +566,7 @@ describe('border-bottom', () => {
     BODY.appendChild(test);
     BODY.appendChild(reference);
 
-    await matchViewportSnapshot(0.1);
+    await snapshot(0.1);
   });
   it('color-002', async () => {
     let p;
@@ -609,7 +609,7 @@ describe('border-bottom', () => {
     BODY.appendChild(test);
     BODY.appendChild(reference);
 
-    await matchViewportSnapshot(0.1);
+    await snapshot(0.1);
   });
   it('color-003-ref', async () => {
     let p;
@@ -646,7 +646,7 @@ describe('border-bottom', () => {
     BODY.appendChild(div_1);
 
     await sleep(0.5);
-    await matchViewportSnapshot(0.1);
+    await snapshot(0.1);
   });
   it('color-003', async () => {
     let p;
@@ -689,7 +689,7 @@ describe('border-bottom', () => {
     BODY.appendChild(test);
     BODY.appendChild(reference);
 
-    await matchViewportSnapshot(0.1);
+    await snapshot(0.1);
   });
   it('color-004-ref', async () => {
     let p;
@@ -725,7 +725,7 @@ describe('border-bottom', () => {
     BODY.appendChild(div);
     BODY.appendChild(div_1);
 
-    await matchViewportSnapshot(0.1);
+    await snapshot(0.1);
   });
   it('color-004', async () => {
     let p;
@@ -768,7 +768,7 @@ describe('border-bottom', () => {
     BODY.appendChild(test);
     BODY.appendChild(reference);
 
-    await matchViewportSnapshot(0.1);
+    await snapshot(0.1);
   });
   xit('color-005-ref', async () => {
     let div;
@@ -794,7 +794,7 @@ describe('border-bottom', () => {
     BODY.appendChild(div);
     BODY.appendChild(div_1);
 
-    await matchViewportSnapshot(0.1);
+    await snapshot(0.1);
   });
   xit('color-005', async () => {
     let p;
@@ -838,11 +838,11 @@ describe('border-bottom', () => {
     BODY.appendChild(test);
     BODY.appendChild(reference);
 
-    await matchViewportSnapshot(0.1);
+    await snapshot(0.1);
 
-    await matchViewportSnapshot(0.1);
+    await snapshot(0.1);
 
-    await matchViewportSnapshot(0.1);
+    await snapshot(0.1);
   });
   it('color-006-ref', async () => {
     let p;
@@ -880,7 +880,7 @@ describe('border-bottom', () => {
     BODY.appendChild(div);
     BODY.appendChild(div_1);
 
-    await matchViewportSnapshot(0.1);
+    await snapshot(0.1);
   });
   it('color-006', async () => {
     let p;
@@ -924,7 +924,7 @@ describe('border-bottom', () => {
     BODY.appendChild(test);
     BODY.appendChild(reference);
 
-    await matchViewportSnapshot(0.1);
+    await snapshot(0.1);
   });
   it('color-007', async () => {
     let p;
@@ -953,7 +953,7 @@ describe('border-bottom', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot(0.1);
+    await snapshot(0.1);
   });
   xit('color-008', async () => {
     let p;
@@ -982,7 +982,7 @@ describe('border-bottom', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot(0.1);
+    await snapshot(0.1);
   });
   it('color-009-ref', async () => {
     let p;
@@ -1018,7 +1018,7 @@ describe('border-bottom', () => {
     BODY.appendChild(div);
     BODY.appendChild(div_1);
 
-    await matchViewportSnapshot(0.1);
+    await snapshot(0.1);
   });
   it('color-009', async () => {
     let p;
@@ -1061,7 +1061,7 @@ describe('border-bottom', () => {
     BODY.appendChild(test);
     BODY.appendChild(reference);
 
-    await matchViewportSnapshot(0.1);
+    await snapshot(0.1);
   });
   it('color-010-ref', async () => {
     let p;
@@ -1097,7 +1097,7 @@ describe('border-bottom', () => {
     BODY.appendChild(div);
     BODY.appendChild(div_1);
 
-    await matchViewportSnapshot(0.1);
+    await snapshot(0.1);
   });
   it('color-010', async () => {
     let p;
@@ -1140,7 +1140,7 @@ describe('border-bottom', () => {
     BODY.appendChild(test);
     BODY.appendChild(reference);
 
-    await matchViewportSnapshot(0.1);
+    await snapshot(0.1);
   });
   it('color-011-ref', async () => {
     let p;
@@ -1176,7 +1176,7 @@ describe('border-bottom', () => {
     BODY.appendChild(div);
     BODY.appendChild(div_1);
 
-    await matchViewportSnapshot(0.1);
+    await snapshot(0.1);
   });
   it('color-011', async () => {
     let p;
@@ -1219,7 +1219,7 @@ describe('border-bottom', () => {
     BODY.appendChild(test);
     BODY.appendChild(reference);
 
-    await matchViewportSnapshot(0.1);
+    await snapshot(0.1);
   });
   it('color-012-ref', async () => {
     let p;
@@ -1255,7 +1255,7 @@ describe('border-bottom', () => {
     BODY.appendChild(div);
     BODY.appendChild(div_1);
 
-    await matchViewportSnapshot(0.1);
+    await snapshot(0.1);
   });
   it('color-012', async () => {
     let p;
@@ -1298,7 +1298,7 @@ describe('border-bottom', () => {
     BODY.appendChild(test);
     BODY.appendChild(reference);
 
-    await matchViewportSnapshot(0.1);
+    await snapshot(0.1);
   });
   it('color-013', async () => {
     let p;
@@ -1327,7 +1327,7 @@ describe('border-bottom', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot(0.1);
+    await snapshot(0.1);
   });
   it('color-014-ref', async () => {
     let p;
@@ -1363,7 +1363,7 @@ describe('border-bottom', () => {
     BODY.appendChild(div);
     BODY.appendChild(div_1);
 
-    await matchViewportSnapshot(0.1);
+    await snapshot(0.1);
   });
   it('color-014', async () => {
     let p;
@@ -1406,7 +1406,7 @@ describe('border-bottom', () => {
     BODY.appendChild(test);
     BODY.appendChild(reference);
 
-    await matchViewportSnapshot(0.1);
+    await snapshot(0.1);
   });
   it('color-015-ref', async () => {
     let p;
@@ -1442,7 +1442,7 @@ describe('border-bottom', () => {
     BODY.appendChild(div);
     BODY.appendChild(div_1);
 
-    await matchViewportSnapshot(0.1);
+    await snapshot(0.1);
   });
   it('color-015', async () => {
     let p;
@@ -1485,7 +1485,7 @@ describe('border-bottom', () => {
     BODY.appendChild(test);
     BODY.appendChild(reference);
 
-    await matchViewportSnapshot(0.1);
+    await snapshot(0.1);
   });
   it('color-016-ref', async () => {
     let p;
@@ -1521,7 +1521,7 @@ describe('border-bottom', () => {
     BODY.appendChild(div);
     BODY.appendChild(div_1);
 
-    await matchViewportSnapshot(0.1);
+    await snapshot(0.1);
   });
   it('color-016', async () => {
     let p;
@@ -1564,7 +1564,7 @@ describe('border-bottom', () => {
     BODY.appendChild(test);
     BODY.appendChild(reference);
 
-    await matchViewportSnapshot(0.1);
+    await snapshot(0.1);
   });
   it('color-017-ref', async () => {
     let p;
@@ -1600,7 +1600,7 @@ describe('border-bottom', () => {
     BODY.appendChild(div);
     BODY.appendChild(div_1);
 
-    await matchViewportSnapshot(0.1);
+    await snapshot(0.1);
   });
   it('color-017', async () => {
     let p;
@@ -1643,7 +1643,7 @@ describe('border-bottom', () => {
     BODY.appendChild(test);
     BODY.appendChild(reference);
 
-    await matchViewportSnapshot(0.1);
+    await snapshot(0.1);
   });
   xit('color-018', async () => {
     let p;
@@ -1672,7 +1672,7 @@ describe('border-bottom', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot(0.1);
+    await snapshot(0.1);
   });
   it('color-019-ref', async () => {
     let p;
@@ -1708,7 +1708,7 @@ describe('border-bottom', () => {
     BODY.appendChild(div);
     BODY.appendChild(div_1);
 
-    await matchViewportSnapshot(0.1);
+    await snapshot(0.1);
   });
   it('color-019', async () => {
     let p;
@@ -1751,7 +1751,7 @@ describe('border-bottom', () => {
     BODY.appendChild(test);
     BODY.appendChild(reference);
 
-    await matchViewportSnapshot(0.1);
+    await snapshot(0.1);
   });
   it('color-020-ref', async () => {
     let p;
@@ -1787,7 +1787,7 @@ describe('border-bottom', () => {
     BODY.appendChild(div);
     BODY.appendChild(div_1);
 
-    await matchViewportSnapshot(0.1);
+    await snapshot(0.1);
   });
   it('color-020', async () => {
     let p;
@@ -1830,7 +1830,7 @@ describe('border-bottom', () => {
     BODY.appendChild(test);
     BODY.appendChild(reference);
 
-    await matchViewportSnapshot(0.1);
+    await snapshot(0.1);
   });
   it('color-021-ref', async () => {
     let p;
@@ -1866,7 +1866,7 @@ describe('border-bottom', () => {
     BODY.appendChild(div);
     BODY.appendChild(div_1);
 
-    await matchViewportSnapshot(0.1);
+    await snapshot(0.1);
   });
   it('color-021', async () => {
     let p;
@@ -1909,7 +1909,7 @@ describe('border-bottom', () => {
     BODY.appendChild(test);
     BODY.appendChild(reference);
 
-    await matchViewportSnapshot(0.1);
+    await snapshot(0.1);
   });
   it('color-022-ref', async () => {
     let p;
@@ -1945,7 +1945,7 @@ describe('border-bottom', () => {
     BODY.appendChild(div);
     BODY.appendChild(div_1);
 
-    await matchViewportSnapshot(0.1);
+    await snapshot(0.1);
   });
   it('color-022', async () => {
     let p;
@@ -1988,7 +1988,7 @@ describe('border-bottom', () => {
     BODY.appendChild(test);
     BODY.appendChild(reference);
 
-    await matchViewportSnapshot(0.1);
+    await snapshot(0.1);
   });
   xit('color-023', async () => {
     let p;
@@ -2017,7 +2017,7 @@ describe('border-bottom', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot(0.1);
+    await snapshot(0.1);
   });
   xit('color-024', async () => {
     let p;
@@ -2046,7 +2046,7 @@ describe('border-bottom', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot(0.1);
+    await snapshot(0.1);
   });
   it('color-025', async () => {
     let p;
@@ -2089,7 +2089,7 @@ describe('border-bottom', () => {
     BODY.appendChild(test);
     BODY.appendChild(reference);
 
-    await matchViewportSnapshot(0.1);
+    await snapshot(0.1);
   });
   it('color-026-ref', async () => {
     let p;
@@ -2125,7 +2125,7 @@ describe('border-bottom', () => {
     BODY.appendChild(div);
     BODY.appendChild(div_1);
 
-    await matchViewportSnapshot(0.1);
+    await snapshot(0.1);
   });
   it('color-026', async () => {
     let p;
@@ -2168,7 +2168,7 @@ describe('border-bottom', () => {
     BODY.appendChild(test);
     BODY.appendChild(reference);
 
-    await matchViewportSnapshot(0.1);
+    await snapshot(0.1);
   });
   it('color-027-ref', async () => {
     let p;
@@ -2204,7 +2204,7 @@ describe('border-bottom', () => {
     BODY.appendChild(div);
     BODY.appendChild(div_1);
 
-    await matchViewportSnapshot(0.1);
+    await snapshot(0.1);
   });
   it('color-027', async () => {
     let p;
@@ -2247,7 +2247,7 @@ describe('border-bottom', () => {
     BODY.appendChild(test);
     BODY.appendChild(reference);
 
-    await matchViewportSnapshot(0.1);
+    await snapshot(0.1);
   });
   it('color-028-ref', async () => {
     let p;
@@ -2283,7 +2283,7 @@ describe('border-bottom', () => {
     BODY.appendChild(div);
     BODY.appendChild(div_1);
 
-    await matchViewportSnapshot(0.1);
+    await snapshot(0.1);
   });
   it('color-028', async () => {
     let p;
@@ -2326,7 +2326,7 @@ describe('border-bottom', () => {
     BODY.appendChild(test);
     BODY.appendChild(reference);
 
-    await matchViewportSnapshot(0.1);
+    await snapshot(0.1);
   });
   xit('color-030', async () => {
     let p;
@@ -2373,7 +2373,7 @@ describe('border-bottom', () => {
     BODY.appendChild(p);
     BODY.appendChild(test);
 
-    await matchViewportSnapshot(0.1);
+    await snapshot(0.1);
   });
   xit('color-031', async () => {
     let p;
@@ -2402,7 +2402,7 @@ describe('border-bottom', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot(0.1);
+    await snapshot(0.1);
   });
   it('color-032-ref', async () => {
     let p;
@@ -2438,7 +2438,7 @@ describe('border-bottom', () => {
     BODY.appendChild(div);
     BODY.appendChild(div_1);
 
-    await matchViewportSnapshot(0.1);
+    await snapshot(0.1);
   });
   it('color-032', async () => {
     let p;
@@ -2481,7 +2481,7 @@ describe('border-bottom', () => {
     BODY.appendChild(test);
     BODY.appendChild(reference);
 
-    await matchViewportSnapshot(0.1);
+    await snapshot(0.1);
   });
   it('color-033', async () => {
     let p;
@@ -2524,7 +2524,7 @@ describe('border-bottom', () => {
     BODY.appendChild(test);
     BODY.appendChild(reference);
 
-    await matchViewportSnapshot(0.1);
+    await snapshot(0.1);
   });
   it('color-034-ref', async () => {
     let p;
@@ -2560,7 +2560,7 @@ describe('border-bottom', () => {
     BODY.appendChild(div);
     BODY.appendChild(div_1);
 
-    await matchViewportSnapshot(0.1);
+    await snapshot(0.1);
   });
   it('color-034', async () => {
     let p;
@@ -2603,7 +2603,7 @@ describe('border-bottom', () => {
     BODY.appendChild(test);
     BODY.appendChild(reference);
 
-    await matchViewportSnapshot(0.1);
+    await snapshot(0.1);
   });
   it('color-035', async () => {
     let p;
@@ -2646,7 +2646,7 @@ describe('border-bottom', () => {
     BODY.appendChild(test);
     BODY.appendChild(reference);
 
-    await matchViewportSnapshot(0.1);
+    await snapshot(0.1);
   });
   xit('color-036', async () => {
     let p;
@@ -2675,7 +2675,7 @@ describe('border-bottom', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot(0.1);
+    await snapshot(0.1);
   });
   it('color-037-ref', async () => {
     let p;
@@ -2713,7 +2713,7 @@ describe('border-bottom', () => {
 
     await sleep(0.5);
 
-    await matchViewportSnapshot(0.1);
+    await snapshot(0.1);
   });
   it('color-037', async () => {
     let p;
@@ -2756,7 +2756,7 @@ describe('border-bottom', () => {
     BODY.appendChild(test);
     BODY.appendChild(reference);
 
-    await matchViewportSnapshot(0.1);
+    await snapshot(0.1);
   });
   it('color-038-ref', async () => {
     let p;
@@ -2792,7 +2792,7 @@ describe('border-bottom', () => {
     BODY.appendChild(div);
     BODY.appendChild(div_1);
 
-    await matchViewportSnapshot(0.1);
+    await snapshot(0.1);
   });
   it('color-038', async () => {
     let p;
@@ -2835,7 +2835,7 @@ describe('border-bottom', () => {
     BODY.appendChild(test);
     BODY.appendChild(reference);
 
-    await matchViewportSnapshot(0.1);
+    await snapshot(0.1);
   });
   it('color-039-ref', async () => {
     let p;
@@ -2871,7 +2871,7 @@ describe('border-bottom', () => {
     BODY.appendChild(div);
     BODY.appendChild(div_1);
 
-    await matchViewportSnapshot(0.1);
+    await snapshot(0.1);
   });
   it('color-039', async () => {
     let p;
@@ -2914,7 +2914,7 @@ describe('border-bottom', () => {
     BODY.appendChild(test);
     BODY.appendChild(reference);
 
-    await matchViewportSnapshot(0.1);
+    await snapshot(0.1);
   });
   it('color-040', async () => {
     let p;
@@ -2957,7 +2957,7 @@ describe('border-bottom', () => {
     BODY.appendChild(test);
     BODY.appendChild(reference);
 
-    await matchViewportSnapshot(0.1);
+    await snapshot(0.1);
   });
   xit('color-041', async () => {
     let p;
@@ -2986,7 +2986,7 @@ describe('border-bottom', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot(0.1);
+    await snapshot(0.1);
   });
   it('color-042-ref', async () => {
     let p;
@@ -3022,7 +3022,7 @@ describe('border-bottom', () => {
     BODY.appendChild(div);
     BODY.appendChild(div_1);
 
-    await matchViewportSnapshot(0.1);
+    await snapshot(0.1);
   });
   it('color-042', async () => {
     let p;
@@ -3065,7 +3065,7 @@ describe('border-bottom', () => {
     BODY.appendChild(test);
     BODY.appendChild(reference);
 
-    await matchViewportSnapshot(0.1);
+    await snapshot(0.1);
   });
   it('color-043', async () => {
     let p;
@@ -3108,7 +3108,7 @@ describe('border-bottom', () => {
     BODY.appendChild(test);
     BODY.appendChild(reference);
 
-    await matchViewportSnapshot(0.1);
+    await snapshot(0.1);
   });
   it('color-044-ref', async () => {
     let p;
@@ -3144,7 +3144,7 @@ describe('border-bottom', () => {
     BODY.appendChild(div);
     BODY.appendChild(div_1);
 
-    await matchViewportSnapshot(0.1);
+    await snapshot(0.1);
   });
   it('color-044', async () => {
     let p;
@@ -3187,7 +3187,7 @@ describe('border-bottom', () => {
     BODY.appendChild(test);
     BODY.appendChild(reference);
 
-    await matchViewportSnapshot(0.1);
+    await snapshot(0.1);
   });
   it('color-045', async () => {
     let p;
@@ -3230,7 +3230,7 @@ describe('border-bottom', () => {
     BODY.appendChild(test);
     BODY.appendChild(reference);
 
-    await matchViewportSnapshot(0.1);
+    await snapshot(0.1);
   });
   xit('color-046', async () => {
     let p;
@@ -3259,7 +3259,7 @@ describe('border-bottom', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot(0.1);
+    await snapshot(0.1);
   });
   it('color-047', async () => {
     let p;
@@ -3302,7 +3302,7 @@ describe('border-bottom', () => {
     BODY.appendChild(test);
     BODY.appendChild(reference);
 
-    await matchViewportSnapshot(0.1);
+    await snapshot(0.1);
   });
   it('color-048', async () => {
     let p;
@@ -3345,7 +3345,7 @@ describe('border-bottom', () => {
     BODY.appendChild(test);
     BODY.appendChild(reference);
 
-    await matchViewportSnapshot(0.1);
+    await snapshot(0.1);
   });
   it('color-049-ref', async () => {
     let p;
@@ -3385,7 +3385,7 @@ describe('border-bottom', () => {
     BODY.appendChild(div);
     BODY.appendChild(div_1);
 
-    await matchViewportSnapshot(0.1);
+    await snapshot(0.1);
   });
   it('color-049', async () => {
     let p;
@@ -3428,7 +3428,7 @@ describe('border-bottom', () => {
     BODY.appendChild(test);
     BODY.appendChild(reference);
 
-    await matchViewportSnapshot(0.1);
+    await snapshot(0.1);
   });
   it('color-050', async () => {
     let p;
@@ -3471,7 +3471,7 @@ describe('border-bottom', () => {
     BODY.appendChild(test);
     BODY.appendChild(reference);
 
-    await matchViewportSnapshot(0.1);
+    await snapshot(0.1);
   });
   it('color-051', async () => {
     let p;
@@ -3514,7 +3514,7 @@ describe('border-bottom', () => {
     BODY.appendChild(test);
     BODY.appendChild(reference);
 
-    await matchViewportSnapshot(0.1);
+    await snapshot(0.1);
   });
   xit('color-052-ref', async () => {
     let p;
@@ -3554,7 +3554,7 @@ describe('border-bottom', () => {
     BODY.appendChild(div);
     BODY.appendChild(div_1);
 
-    await matchViewportSnapshot(0.1);
+    await snapshot(0.1);
   });
   xit('color-053', async () => {
     let p;
@@ -3597,7 +3597,7 @@ describe('border-bottom', () => {
     BODY.appendChild(test);
     BODY.appendChild(reference);
 
-    await matchViewportSnapshot(0.1);
+    await snapshot(0.1);
   });
   xit('color-054-ref', async () => {
     let p;
@@ -3638,7 +3638,7 @@ describe('border-bottom', () => {
     BODY.appendChild(div);
     BODY.appendChild(div_1);
 
-    await matchViewportSnapshot(0.1);
+    await snapshot(0.1);
   });
   xit('color-054', async () => {
     let p;
@@ -3682,7 +3682,7 @@ describe('border-bottom', () => {
     BODY.appendChild(test);
     BODY.appendChild(reference);
 
-    await matchViewportSnapshot(0.1);
+    await snapshot(0.1);
   });
   it('color-063-ref', async () => {
     let p;
@@ -3718,7 +3718,7 @@ describe('border-bottom', () => {
     BODY.appendChild(div);
     BODY.appendChild(div_1);
 
-    await matchViewportSnapshot(0.1);
+    await snapshot(0.1);
   });
   it('color-063', async () => {
     let p;
@@ -3761,7 +3761,7 @@ describe('border-bottom', () => {
     BODY.appendChild(test);
     BODY.appendChild(reference);
 
-    await matchViewportSnapshot(0.1);
+    await snapshot(0.1);
   });
   xit('color-064', async () => {
     let p;
@@ -3804,7 +3804,7 @@ describe('border-bottom', () => {
     BODY.appendChild(test);
     BODY.appendChild(reference);
 
-    await matchViewportSnapshot(0.1);
+    await snapshot(0.1);
   });
   xit('color-070-ref', async () => {
     let p;
@@ -3844,7 +3844,7 @@ describe('border-bottom', () => {
     BODY.appendChild(div);
     BODY.appendChild(div_1);
 
-    await matchViewportSnapshot(0.1);
+    await snapshot(0.1);
   });
   xit('color-070', async () => {
     let p;
@@ -3887,7 +3887,7 @@ describe('border-bottom', () => {
     BODY.appendChild(test);
     BODY.appendChild(reference);
 
-    await matchViewportSnapshot(0.1);
+    await snapshot(0.1);
   });
   xit('color-071', async () => {
     let p;
@@ -3930,10 +3930,10 @@ describe('border-bottom', () => {
     BODY.appendChild(test);
     BODY.appendChild(reference);
 
-    await matchViewportSnapshot(0.1);
+    await snapshot(0.1);
   });
   xit('color-072', async () => {
-    await matchViewportSnapshot(0.1);
+    await snapshot(0.1);
   });
   xit('color-073-ref', async () => {
     let p;
@@ -3973,7 +3973,7 @@ describe('border-bottom', () => {
     BODY.appendChild(div);
     BODY.appendChild(div_1);
 
-    await matchViewportSnapshot(0.1);
+    await snapshot(0.1);
   });
   xit('color-073', async () => {
     let p;
@@ -4016,7 +4016,7 @@ describe('border-bottom', () => {
     BODY.appendChild(test);
     BODY.appendChild(reference);
 
-    await matchViewportSnapshot(0.1);
+    await snapshot(0.1);
   });
   xit('color-074', async () => {
     let p;
@@ -4059,7 +4059,7 @@ describe('border-bottom', () => {
     BODY.appendChild(test);
     BODY.appendChild(reference);
 
-    await matchViewportSnapshot(0.1);
+    await snapshot(0.1);
   });
   xit('color-075-ref', async () => {
     let p;
@@ -4099,7 +4099,7 @@ describe('border-bottom', () => {
     BODY.appendChild(div);
     BODY.appendChild(div_1);
 
-    await matchViewportSnapshot(0.1);
+    await snapshot(0.1);
   });
   xit('color-075', async () => {
     let p;
@@ -4142,7 +4142,7 @@ describe('border-bottom', () => {
     BODY.appendChild(test);
     BODY.appendChild(reference);
 
-    await matchViewportSnapshot(0.1);
+    await snapshot(0.1);
   });
   xit('color-076', async () => {
     let p;
@@ -4185,7 +4185,7 @@ describe('border-bottom', () => {
     BODY.appendChild(test);
     BODY.appendChild(reference);
 
-    await matchViewportSnapshot(0.1);
+    await snapshot(0.1);
   });
   xit('color-077', async () => {
     let p;
@@ -4228,7 +4228,7 @@ describe('border-bottom', () => {
     BODY.appendChild(test);
     BODY.appendChild(reference);
 
-    await matchViewportSnapshot(0.1);
+    await snapshot(0.1);
   });
   xit('color-078', async () => {
     let p;
@@ -4271,7 +4271,7 @@ describe('border-bottom', () => {
     BODY.appendChild(test);
     BODY.appendChild(reference);
 
-    await matchViewportSnapshot(0.1);
+    await snapshot(0.1);
   });
   xit('color-079', async () => {
     let p;
@@ -4314,7 +4314,7 @@ describe('border-bottom', () => {
     BODY.appendChild(test);
     BODY.appendChild(reference);
 
-    await matchViewportSnapshot(0.1);
+    await snapshot(0.1);
   });
   xit('color-080', async () => {
     let p;
@@ -4357,7 +4357,7 @@ describe('border-bottom', () => {
     BODY.appendChild(test);
     BODY.appendChild(reference);
 
-    await matchViewportSnapshot(0.1);
+    await snapshot(0.1);
   });
   xit('color-081', async () => {
     let p;
@@ -4400,7 +4400,7 @@ describe('border-bottom', () => {
     BODY.appendChild(test);
     BODY.appendChild(reference);
 
-    await matchViewportSnapshot(0.1);
+    await snapshot(0.1);
   });
   xit('color-082', async () => {
     let p;
@@ -4443,7 +4443,7 @@ describe('border-bottom', () => {
     BODY.appendChild(test);
     BODY.appendChild(reference);
 
-    await matchViewportSnapshot(0.1);
+    await snapshot(0.1);
   });
   it('color-083-ref', async () => {
     let p;
@@ -4479,7 +4479,7 @@ describe('border-bottom', () => {
     BODY.appendChild(div);
     BODY.appendChild(div_1);
 
-    await matchViewportSnapshot(0.2);
+    await snapshot(0.2);
   });
   it('color-083', async () => {
     let p;
@@ -4522,7 +4522,7 @@ describe('border-bottom', () => {
     BODY.appendChild(test);
     BODY.appendChild(reference);
 
-    await matchViewportSnapshot(0.1);
+    await snapshot(0.1);
   });
   xit('color-084', async () => {
     let p;
@@ -4565,7 +4565,7 @@ describe('border-bottom', () => {
     BODY.appendChild(test);
     BODY.appendChild(reference);
 
-    await matchViewportSnapshot(0.1);
+    await snapshot(0.1);
   });
   it('color-085', async () => {
     let p;
@@ -4608,7 +4608,7 @@ describe('border-bottom', () => {
     BODY.appendChild(test);
     BODY.appendChild(reference);
 
-    await matchViewportSnapshot(0.1);
+    await snapshot(0.1);
   });
   it('color-086', async () => {
     let p;
@@ -4651,7 +4651,7 @@ describe('border-bottom', () => {
     BODY.appendChild(test);
     BODY.appendChild(reference);
 
-    await matchViewportSnapshot(0.1);
+    await snapshot(0.1);
   });
   xit('color-087', async () => {
     let p;
@@ -4694,7 +4694,7 @@ describe('border-bottom', () => {
     BODY.appendChild(test);
     BODY.appendChild(reference);
 
-    await matchViewportSnapshot(0.1);
+    await snapshot(0.1);
   });
   it('color-088', async () => {
     let p;
@@ -4737,7 +4737,7 @@ describe('border-bottom', () => {
     BODY.appendChild(test);
     BODY.appendChild(reference);
 
-    await matchViewportSnapshot(0.1);
+    await snapshot(0.1);
   });
   it('color-089', async () => {
     let p;
@@ -4780,7 +4780,7 @@ describe('border-bottom', () => {
     BODY.appendChild(test);
     BODY.appendChild(reference);
 
-    await matchViewportSnapshot(0.1);
+    await snapshot(0.1);
   });
   xit('color-090-ref', async () => {
     let p;
@@ -4820,7 +4820,7 @@ describe('border-bottom', () => {
     BODY.appendChild(div);
     BODY.appendChild(div_1);
 
-    await matchViewportSnapshot(0.1);
+    await snapshot(0.1);
   });
   xit('color-090', async () => {
     let p;
@@ -4863,7 +4863,7 @@ describe('border-bottom', () => {
     BODY.appendChild(test);
     BODY.appendChild(reference);
 
-    await matchViewportSnapshot(0.1);
+    await snapshot(0.1);
   });
   xit('color-093-ref', async () => {
     let p;
@@ -4903,7 +4903,7 @@ describe('border-bottom', () => {
     BODY.appendChild(div);
     BODY.appendChild(div_1);
 
-    await matchViewportSnapshot(0.1);
+    await snapshot(0.1);
   });
   xit('color-093', async () => {
     let p;
@@ -4946,7 +4946,7 @@ describe('border-bottom', () => {
     BODY.appendChild(test);
     BODY.appendChild(reference);
 
-    await matchViewportSnapshot(0.1);
+    await snapshot(0.1);
   });
   xit('color-094', async () => {
     let p;
@@ -4989,7 +4989,7 @@ describe('border-bottom', () => {
     BODY.appendChild(test);
     BODY.appendChild(reference);
 
-    await matchViewportSnapshot(0.1);
+    await snapshot(0.1);
   });
   xit('color-095-ref', async () => {
     let p;
@@ -5029,7 +5029,7 @@ describe('border-bottom', () => {
     BODY.appendChild(div);
     BODY.appendChild(div_1);
 
-    await matchViewportSnapshot(0.1);
+    await snapshot(0.1);
   });
   xit('color-095', async () => {
     let p;
@@ -5072,7 +5072,7 @@ describe('border-bottom', () => {
     BODY.appendChild(test);
     BODY.appendChild(reference);
 
-    await matchViewportSnapshot(0.1);
+    await snapshot(0.1);
   });
   xit('color-096', async () => {
     let p;
@@ -5115,7 +5115,7 @@ describe('border-bottom', () => {
     BODY.appendChild(test);
     BODY.appendChild(reference);
 
-    await matchViewportSnapshot(0.1);
+    await snapshot(0.1);
   });
   xit('color-097', async () => {
     let p;
@@ -5158,7 +5158,7 @@ describe('border-bottom', () => {
     BODY.appendChild(test);
     BODY.appendChild(reference);
 
-    await matchViewportSnapshot(0.1);
+    await snapshot(0.1);
   });
   xit('color-098', async () => {
     let p;
@@ -5201,7 +5201,7 @@ describe('border-bottom', () => {
     BODY.appendChild(test);
     BODY.appendChild(reference);
 
-    await matchViewportSnapshot(0.1);
+    await snapshot(0.1);
   });
   xit('color-099', async () => {
     let p;
@@ -5244,7 +5244,7 @@ describe('border-bottom', () => {
     BODY.appendChild(test);
     BODY.appendChild(reference);
 
-    await matchViewportSnapshot(0.1);
+    await snapshot(0.1);
   });
   it('color-100-ref', async () => {
     let p;
@@ -5280,9 +5280,9 @@ describe('border-bottom', () => {
     BODY.appendChild(div);
     BODY.appendChild(div_1);
 
-    await matchViewportSnapshot(0.1);
+    await snapshot(0.1);
 
-    await matchViewportSnapshot(0.1);
+    await snapshot(0.1);
   });
   it('color-100', async () => {
     let p;
@@ -5325,7 +5325,7 @@ describe('border-bottom', () => {
     BODY.appendChild(test);
     BODY.appendChild(reference);
 
-    await matchViewportSnapshot(0.1);
+    await snapshot(0.1);
   });
   it('color-101', async () => {
     let p;
@@ -5368,7 +5368,7 @@ describe('border-bottom', () => {
     BODY.appendChild(test);
     BODY.appendChild(reference);
 
-    await matchViewportSnapshot(0.1);
+    await snapshot(0.1);
   });
   it('color-102', async () => {
     let p;
@@ -5411,7 +5411,7 @@ describe('border-bottom', () => {
     BODY.appendChild(test);
     BODY.appendChild(reference);
 
-    await matchViewportSnapshot(0.1);
+    await snapshot(0.1);
   });
   it('color-103-ref', async () => {
     let p;
@@ -5447,7 +5447,7 @@ describe('border-bottom', () => {
     BODY.appendChild(div);
     BODY.appendChild(div_1);
 
-    await matchViewportSnapshot(0.1);
+    await snapshot(0.1);
   });
   it('color-103', async () => {
     let p;
@@ -5490,7 +5490,7 @@ describe('border-bottom', () => {
     BODY.appendChild(test);
     BODY.appendChild(reference);
 
-    await matchViewportSnapshot(0.1);
+    await snapshot(0.1);
   });
   it('color-105', async () => {
     let p;
@@ -5533,7 +5533,7 @@ describe('border-bottom', () => {
     BODY.appendChild(test);
     BODY.appendChild(reference);
 
-    await matchViewportSnapshot(0.1);
+    await snapshot(0.1);
   });
   it('color-106', async () => {
     let p;
@@ -5576,7 +5576,7 @@ describe('border-bottom', () => {
     BODY.appendChild(test);
     BODY.appendChild(reference);
 
-    await matchViewportSnapshot(0.1);
+    await snapshot(0.1);
   });
   xit('color-107', async () => {
     let p;
@@ -5619,7 +5619,7 @@ describe('border-bottom', () => {
     BODY.appendChild(test);
     BODY.appendChild(reference);
 
-    await matchViewportSnapshot(0.1);
+    await snapshot(0.1);
   });
   xit('color-108', async () => {
     let p;
@@ -5662,7 +5662,7 @@ describe('border-bottom', () => {
     BODY.appendChild(test);
     BODY.appendChild(reference);
 
-    await matchViewportSnapshot(0.1);
+    await snapshot(0.1);
   });
   xit('color-109', async () => {
     let p;
@@ -5705,7 +5705,7 @@ describe('border-bottom', () => {
     BODY.appendChild(test);
     BODY.appendChild(reference);
 
-    await matchViewportSnapshot(0.1);
+    await snapshot(0.1);
   });
   it('color-110-ref', async () => {
     let p;
@@ -5745,7 +5745,7 @@ describe('border-bottom', () => {
     BODY.appendChild(div);
     BODY.appendChild(div_1);
 
-    await matchViewportSnapshot(0.1);
+    await snapshot(0.1);
   });
   it('color-110', async () => {
     let p;
@@ -5788,7 +5788,7 @@ describe('border-bottom', () => {
     BODY.appendChild(test);
     BODY.appendChild(reference);
 
-    await matchViewportSnapshot(0.1);
+    await snapshot(0.1);
   });
   it('color-111', async () => {
     let p;
@@ -5831,7 +5831,7 @@ describe('border-bottom', () => {
     BODY.appendChild(test);
     BODY.appendChild(reference);
 
-    await matchViewportSnapshot(0.1);
+    await snapshot(0.1);
   });
   it('color-112', async () => {
     let p;
@@ -5874,7 +5874,7 @@ describe('border-bottom', () => {
     BODY.appendChild(test);
     BODY.appendChild(reference);
 
-    await matchViewportSnapshot(0.1);
+    await snapshot(0.1);
   });
   xit('color-113-ref', async () => {
     let p;
@@ -5914,7 +5914,7 @@ describe('border-bottom', () => {
     BODY.appendChild(div);
     BODY.appendChild(div_1);
 
-    await matchViewportSnapshot(0.1);
+    await snapshot(0.1);
   });
   xit('color-113', async () => {
     let p;
@@ -5956,7 +5956,7 @@ describe('border-bottom', () => {
     BODY.appendChild(test);
     BODY.appendChild(reference);
 
-    await matchViewportSnapshot(0.1);
+    await snapshot(0.1);
   });
   xit('color-115-ref', async () => {
     let p;
@@ -5996,6 +5996,6 @@ describe('border-bottom', () => {
     BODY.appendChild(div);
     BODY.appendChild(div_1);
 
-    await matchViewportSnapshot(0.1);
+    await snapshot(0.1);
   });
 });

--- a/integration_tests/specs/css/css-borders/border.ts
+++ b/integration_tests/specs/css/css-borders/border.ts
@@ -15,7 +15,7 @@ describe('border', () => {
     });
     BODY.appendChild(div);
 
-    await matchViewportSnapshot(0.1);
+    await snapshot(0.1);
   });
   it('003', async () => {
     let div;
@@ -32,7 +32,7 @@ describe('border', () => {
     });
     BODY.appendChild(div);
 
-    await matchViewportSnapshot(0.1);
+    await snapshot(0.1);
   });
   xit('005', async () => {
     let reference;
@@ -75,7 +75,7 @@ describe('border', () => {
     );
     BODY.appendChild(wrapper);
 
-    await matchViewportSnapshot(0.1);
+    await snapshot(0.1);
   });
   xit('006', async () => {
     let reference;
@@ -118,7 +118,7 @@ describe('border', () => {
     );
     BODY.appendChild(wrapper);
 
-    await matchViewportSnapshot(0.1);
+    await snapshot(0.1);
   });
   it('008', async () => {
     let reference;
@@ -161,7 +161,7 @@ describe('border', () => {
     );
     BODY.appendChild(wrapper);
 
-    await matchViewportSnapshot(0.1);
+    await snapshot(0.1);
   });
   it('010', async () => {
     let p;
@@ -192,7 +192,7 @@ describe('border', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot(0.1);
+    await snapshot(0.1);
   });
 
   it('border will not appear if border width is 0.0', async () => {
@@ -226,7 +226,7 @@ describe('border', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot(0.1);
+    await snapshot(0.1);
   });
 
   it('borderSide should handle hitTest', async () => {
@@ -291,11 +291,11 @@ describe('border', () => {
     );
 
     BODY.appendChild(div);
-    await matchViewportSnapshot();
+    await snapshot();
 
     requestAnimationFrame(async () => {
        div.style.borderWidth = '10px';
-      await matchViewportSnapshot(0.1);
+      await snapshot(0.1);
       done();
     });
   });

--- a/integration_tests/specs/css/css-box/block-nesting.ts
+++ b/integration_tests/specs/css/css-box/block-nesting.ts
@@ -12,6 +12,6 @@ describe('Box nesting', () => {
 
     container.appendChild(box);
     document.body.appendChild(container);
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-box/border.ts
+++ b/integration_tests/specs/css/css-box/border.ts
@@ -10,7 +10,7 @@ describe('Box border', () => {
 
     document.body.appendChild(div);
     div.style.border = '4px solid blue';
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('test pass if there is a hollow black square', async () => {
@@ -22,7 +22,7 @@ describe('Box border', () => {
       borderColor: 'black',
     });
     append(BODY, div);
-    await matchElementImageSnapshot(div);
+    await snapshot(div);
   });
 
   xit('dashed border', async () => {
@@ -32,7 +32,7 @@ describe('Box border', () => {
       border: '2px dashed red',
     });
     append(BODY, div);
-    await matchElementImageSnapshot(div);
+    await snapshot(div);
   });
 
   xit('dashed with backgroundColor', async () => {
@@ -43,7 +43,7 @@ describe('Box border', () => {
       backgroundColor: 'green',
     });
     append(BODY, div);
-    await matchElementImageSnapshot(div);
+    await snapshot(div);
   });
 
   it('border-bottom-left-radius', async () => {
@@ -54,7 +54,7 @@ describe('Box border', () => {
       backgroundColor: 'red',
     });
     append(BODY, div);
-    await matchElementImageSnapshot(div);
+    await snapshot(div);
   });
 
   it('border-bottom-right-radius', async () => {
@@ -65,7 +65,7 @@ describe('Box border', () => {
       backgroundColor: 'red',
     });
     append(BODY, div);
-    await matchElementImageSnapshot(div);
+    await snapshot(div);
   });
 
   it('border-top-left-radius', async () => {
@@ -76,7 +76,7 @@ describe('Box border', () => {
       backgroundColor: 'red',
     });
     append(BODY, div);
-    await matchElementImageSnapshot(div);
+    await snapshot(div);
   });
 
   it('border-top-right-radius', async () => {
@@ -87,7 +87,7 @@ describe('Box border', () => {
       backgroundColor: 'red',
     });
     append(BODY, div);
-    await matchElementImageSnapshot(div);
+    await snapshot(div);
   });
 
   it('border radius with absolute', async () => {
@@ -116,6 +116,6 @@ describe('Box border', () => {
     append(container, red);
     append(container, green);
     append(BODY, container);
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-box/box-shadow.ts
+++ b/integration_tests/specs/css/css-box/box-shadow.ts
@@ -16,7 +16,7 @@ describe('BoxShadow', () => {
     });
     append(reference, div);
     append(BODY, reference);
-    await matchElementImageSnapshot(reference);
+    await snapshot(reference);
   });
 
   it('with background color', async () => {
@@ -35,7 +35,7 @@ describe('BoxShadow', () => {
       },
     );
     BODY.appendChild(div);
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('without background color and shadow offset', async () => {
@@ -53,7 +53,7 @@ describe('BoxShadow', () => {
       },
     );
     BODY.appendChild(div);
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('with shadow blur and spread radius', async () => {
@@ -71,7 +71,7 @@ describe('BoxShadow', () => {
       },
     );
     BODY.appendChild(div);
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('with border radius', async () => {
@@ -90,7 +90,7 @@ describe('BoxShadow', () => {
       },
     );
     BODY.appendChild(div);
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('remove box-shadow', async () => {
@@ -103,11 +103,11 @@ describe('BoxShadow', () => {
       boxShadow: '0 0 8px black',
     });
     append(BODY, div);
-    await matchViewportSnapshot();
+    await snapshot();
 
     div.style.boxShadow = null;
     // BoxShadow has been removed.
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('change from not none to none', async (done) => {
@@ -126,11 +126,11 @@ describe('BoxShadow', () => {
     );
     append(BODY, cont);
 
-    await matchViewportSnapshot();
+    await snapshot();
 
     requestAnimationFrame(async () => {
       cont.style.boxShadow = 'none';
-      await matchViewportSnapshot(0.1);
+      await snapshot(0.1);
       done();
     });
   });

--- a/integration_tests/specs/css/css-box/box.ts
+++ b/integration_tests/specs/css/css-box/box.ts
@@ -31,6 +31,6 @@ describe('Box', () => {
     container2.appendChild(container3);
     container3.appendChild(textNode);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-box/horizontal-formatting.ts
+++ b/integration_tests/specs/css/css-box/horizontal-formatting.ts
@@ -81,6 +81,6 @@ describe('Horizontal formatting', () => {
     document.body.appendChild(bottomRuler);
 
     await Promise.all([ruleImgP, ruleImg2P]);
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-box/left-ltr.ts
+++ b/integration_tests/specs/css/css-box/left-ltr.ts
@@ -41,6 +41,6 @@ describe('left-ltr', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-box/left-rtl.ts
+++ b/integration_tests/specs/css/css-box/left-rtl.ts
@@ -41,6 +41,6 @@ describe('left-rtl', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-box/margin-auto.ts
+++ b/integration_tests/specs/css/css-box/margin-auto.ts
@@ -25,7 +25,7 @@ describe('Box margin auto', () => {
       ]
     );
     BODY.appendChild(div);
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('should not align center vertical with margin-top and margin-bottom of block element in flow layout', async () => {
@@ -54,7 +54,7 @@ describe('Box margin auto', () => {
       ]
     );
     BODY.appendChild(div);
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('should not work with inline and inline-block element in flow layout', async () => {
@@ -94,7 +94,7 @@ describe('Box margin auto', () => {
       ]
     );
     BODY.appendChild(div);
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('should work with margin-left of block element in flow layout', async () => {
@@ -123,7 +123,7 @@ describe('Box margin auto', () => {
       ]
     );
     BODY.appendChild(div);
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('should work with positioned element in horizontal direction with left, right and width not auto', async () => {
@@ -154,7 +154,7 @@ describe('Box margin auto', () => {
       ]
     );
     BODY.appendChild(div);
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('should work with positioned element in horizontal direction with top, bottom and height not auto', async () => {
@@ -185,7 +185,7 @@ describe('Box margin auto', () => {
       ]
     );
     BODY.appendChild(div);
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('should work with positioned element in both direction in flow layout', async () => {
@@ -217,7 +217,7 @@ describe('Box margin auto', () => {
       ]
     );
     BODY.appendChild(div);
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('should work with positioned element in both direction in flex layout', async () => {
@@ -250,7 +250,7 @@ describe('Box margin auto', () => {
       ]
     );
     BODY.appendChild(div);
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('should work with flex item in row direction', async () => {
@@ -299,7 +299,7 @@ describe('Box margin auto', () => {
       ]
     );
     BODY.appendChild(div);
-    await matchViewportSnapshot();
+    await snapshot();
 
   });
 
@@ -350,7 +350,7 @@ describe('Box margin auto', () => {
       ]
     );
     BODY.appendChild(div);
-    await matchViewportSnapshot();
+    await snapshot();
 
   });
 
@@ -400,7 +400,7 @@ describe('Box margin auto', () => {
       ]
     );
     BODY.appendChild(div);
-    await matchViewportSnapshot();
+    await snapshot();
 
   });
 
@@ -450,7 +450,7 @@ describe('Box margin auto', () => {
       ]
     );
     BODY.appendChild(div);
-    await matchViewportSnapshot();
+    await snapshot();
 
   });
 
@@ -483,7 +483,7 @@ describe('Box margin auto', () => {
       ]
     );
     BODY.appendChild(container);
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('should work with flex item of margin-bottom auto with no height in row direction', async () => {
@@ -515,7 +515,7 @@ describe('Box margin auto', () => {
       ]
     );
     BODY.appendChild(container);
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('should work with flex item of margin-top auto with no height in column direction', async () => {
@@ -547,7 +547,7 @@ describe('Box margin auto', () => {
       ]
     );
     BODY.appendChild(container);
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('should work with flex item of margin-bottom auto with no height in column direction', async () => {
@@ -579,6 +579,6 @@ describe('Box margin auto', () => {
       ]
     );
     BODY.appendChild(container);
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-box/margin-negative.ts
+++ b/integration_tests/specs/css/css-box/margin-negative.ts
@@ -39,7 +39,7 @@ describe('Box margin negative', () => {
       ]
     );
     BODY.appendChild(div);
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('should work with bottom in flow layout', async () => {
@@ -82,7 +82,7 @@ describe('Box margin negative', () => {
       ]
     );
     BODY.appendChild(div);
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('should work with left in flow layout', async () => {
@@ -128,7 +128,7 @@ describe('Box margin negative', () => {
       ]
     );
     BODY.appendChild(div);
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('should work with right in flow layout', async () => {
@@ -174,7 +174,7 @@ describe('Box margin negative', () => {
       ]
     );
     BODY.appendChild(div);
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('should work with top in flex layout and row direction', async () => {
@@ -219,7 +219,7 @@ describe('Box margin negative', () => {
       ]
     );
     BODY.appendChild(div);
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('should work with bottom in flex layout and row direction', async () => {
@@ -264,7 +264,7 @@ describe('Box margin negative', () => {
       ]
     );
     BODY.appendChild(div);
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('should work with left in flex layout and row direction', async () => {
@@ -309,7 +309,7 @@ describe('Box margin negative', () => {
       ]
     );
     BODY.appendChild(div);
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('should work with right in flex layout and row direction', async () => {
@@ -354,7 +354,7 @@ describe('Box margin negative', () => {
       ]
     );
     BODY.appendChild(div);
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('should work with top in flex layout and column direction', async () => {
@@ -399,7 +399,7 @@ describe('Box margin negative', () => {
       ]
     );
     BODY.appendChild(div);
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('should work with bottom in flex layout and column direction', async () => {
@@ -444,7 +444,7 @@ describe('Box margin negative', () => {
       ]
     );
     BODY.appendChild(div);
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('should work with left in flex layout and column direction', async () => {
@@ -489,7 +489,7 @@ describe('Box margin negative', () => {
       ]
     );
     BODY.appendChild(div);
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('should work with right in flex layout and column direction', async () => {
@@ -534,7 +534,7 @@ describe('Box margin negative', () => {
       ]
     );
     BODY.appendChild(div);
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('should work with flex-wrap wrap in flex layout and row direction', async () => {
@@ -582,7 +582,7 @@ describe('Box margin negative', () => {
       ]
     );
     BODY.appendChild(div);
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('should work with flex-wrap wrap in flex layout and column direction', async () => {
@@ -630,6 +630,6 @@ describe('Box margin negative', () => {
       ]
     );
     BODY.appendChild(div);
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-box/margin.ts
+++ b/integration_tests/specs/css/css-box/margin.ts
@@ -20,7 +20,7 @@ describe('Box margin', () => {
 
     document.body.appendChild(div3);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('should work with basic samples', async () => {
@@ -34,7 +34,7 @@ describe('Box margin', () => {
 
     document.body.appendChild(div);
     div.style.margin = '20px';
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('should work with basic samples', async () => {
@@ -48,7 +48,7 @@ describe('Box margin', () => {
 
     document.body.appendChild(div);
     div.style.margin = '20px';
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('should work with shorthand', async () => {
@@ -62,7 +62,7 @@ describe('Box margin', () => {
     });
 
     document.body.appendChild(div);
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('should can be removed', async () => {
@@ -75,10 +75,10 @@ describe('Box margin', () => {
     });
 
     document.body.appendChild(container1);
-    await matchViewportSnapshot();
+    await snapshot();
 
     container1.style.margin = '';
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('should work with percentage', async () => {
@@ -121,7 +121,7 @@ describe('Box margin', () => {
     );
 
     BODY.appendChild(div);
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('should work with percentage of parents width and height not equal', async () => {
@@ -149,7 +149,7 @@ describe('Box margin', () => {
     );
 
     BODY.appendChild(div);
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
 });

--- a/integration_tests/specs/css/css-box/overflow.ts
+++ b/integration_tests/specs/css/css-box/overflow.ts
@@ -54,7 +54,7 @@ describe('Overflow', () => {
 
     document.body.appendChild(container);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('scrollTo', async (done) => {
@@ -79,7 +79,7 @@ describe('Overflow', () => {
 
     requestAnimationFrame(async () => {
       div1.scroll(20, 20);
-      await matchViewportSnapshot();
+      await snapshot();
       done();
     });
     document.body.appendChild(container);
@@ -103,11 +103,11 @@ describe('Overflow', () => {
       ],
     );
     BODY.appendChild(div);
-    await matchViewportSnapshot();
+    await snapshot();
 
     requestAnimationFrame(async () => {
       div.scroll(0, 20);
-      await matchViewportSnapshot();
+      await snapshot();
       done();
     });
   });
@@ -131,11 +131,11 @@ describe('Overflow', () => {
       ],
     );
     BODY.appendChild(div);
-    await matchViewportSnapshot();
+    await snapshot();
 
     requestAnimationFrame(async () => {
       div.scroll(0, 20);
-      await matchViewportSnapshot();
+      await snapshot();
     });
   });
 
@@ -163,7 +163,7 @@ describe('Overflow', () => {
     requestAnimationFrame(async () => {
       div1.scrollLeft = 20;
       div1.scrollTop = 20;
-      await matchViewportSnapshot();
+      await snapshot();
       done();
     });
   });
@@ -184,7 +184,7 @@ describe('Overflow', () => {
     container.style.overflow = 'hidden';
     document.body.appendChild(container);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('overflow with absolute positioned elements', async (done) => {
@@ -223,11 +223,11 @@ describe('Overflow', () => {
     ]);
 
     document.body.appendChild(container);
-    await matchViewportSnapshot();
+    await snapshot();
 
     requestAnimationFrame(async () => {
       scroller.scroll(20, 550);
-      await matchViewportSnapshot(0.2);
+      await snapshot(0.2);
       done();
     });
   });
@@ -268,14 +268,14 @@ describe('Overflow', () => {
 
     BODY.appendChild(container);
 
-    await matchViewportSnapshot();
+    await snapshot();
 
     requestAnimationFrame(async () => {
       container.scrollTop = 30;
-      await matchViewportSnapshot();
+      await snapshot();
       requestAnimationFrame(async () => {
         container.scrollTop = 10000;
-        await matchViewportSnapshot();
+        await snapshot();
 
         done();
       });
@@ -308,12 +308,12 @@ describe('Overflow', () => {
 
     BODY.appendChild(container);
 
-    await matchViewportSnapshot();
+    await snapshot();
 
     requestAnimationFrame(async () => {
       document.body.scrollLeft = 50;
       document.body.scrollTop = 300;
-      await matchViewportSnapshot();
+      await snapshot();
       doneFn();
     });
   });

--- a/integration_tests/specs/css/css-box/padding.ts
+++ b/integration_tests/specs/css/css-box/padding.ts
@@ -20,7 +20,7 @@ describe('Box padding', () => {
     container1.appendChild(container2);
     container1.style.padding = '20px';
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('should work with background-color', async () => {
@@ -38,7 +38,7 @@ describe('Box padding', () => {
       backgroundColor: 'red',
     });
     append(div, box);
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
 
@@ -51,10 +51,10 @@ describe('Box padding', () => {
     });
 
     document.body.appendChild(container1);
-    await matchViewportSnapshot();
+    await snapshot();
 
     container1.style.padding = '';
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('should work with percentage', async () => {
@@ -90,7 +90,7 @@ describe('Box padding', () => {
     );
 
     BODY.appendChild(div);
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('should work with percentage of parents width and height not equal', async () => {
@@ -126,7 +126,7 @@ describe('Box padding', () => {
     );
 
     BODY.appendChild(div);
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
 });

--- a/integration_tests/specs/css/css-box/position.ts
+++ b/integration_tests/specs/css/css-box/position.ts
@@ -29,6 +29,6 @@ describe('Box position', () => {
     container.appendChild(div2);
     document.body.appendChild(container);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-color/current-color.ts
+++ b/integration_tests/specs/css/css-color/current-color.ts
@@ -16,7 +16,7 @@ describe('Color currentColor', () => {
     });
     container1.appendChild(text1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it(`should update currentColor value`, async () => {
@@ -41,7 +41,7 @@ describe('Color currentColor', () => {
       });
     });
 
-    await matchViewportSnapshot(0.1);
+    await snapshot(0.1);
   });
 
 });

--- a/integration_tests/specs/css/css-color/rgb.ts
+++ b/integration_tests/specs/css/css-color/rgb.ts
@@ -21,7 +21,7 @@ describe('Color RGB and RGBA', () => {
       );
       append(BODY, div);
 
-      return matchElementImageSnapshot(div);
+      return snapshot(div);
     });
   });
 });

--- a/integration_tests/specs/css/css-color/text.ts
+++ b/integration_tests/specs/css/css-color/text.ts
@@ -21,7 +21,7 @@ describe('Color text', () => {
       append(container, p2);
       append(container, p3);
       append(BODY, container);
-      await matchElementImageSnapshot(container);
+      await snapshot(container);
     });
   }
 
@@ -203,6 +203,6 @@ describe('Color text', () => {
     });
     append(test, div);
     append(BODY, test);
-    await matchElementImageSnapshot(test);
+    await snapshot(test);
   });
 });

--- a/integration_tests/specs/css/css-display/anonymous-box.ts
+++ b/integration_tests/specs/css/css-display/anonymous-box.ts
@@ -40,7 +40,7 @@ describe('anonymous-box', () => {
     BODY.appendChild(div);
     BODY.appendChild(div_1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('generation-001', async () => {
     let child;
@@ -73,6 +73,6 @@ describe('anonymous-box', () => {
     );
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-display/anonymous-boxes.ts
+++ b/integration_tests/specs/css/css-display/anonymous-boxes.ts
@@ -44,7 +44,7 @@ describe('anonymous-boxes', () => {
     BODY.appendChild(blue);
     BODY.appendChild(orange);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('inheritance-001', async () => {
     let p;
@@ -101,6 +101,6 @@ describe('anonymous-boxes', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-display/anonymous-inline.ts
+++ b/integration_tests/specs/css/css-display/anonymous-inline.ts
@@ -24,6 +24,6 @@ describe('anonymous-inline', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-display/block-in-inline.ts
+++ b/integration_tests/specs/css/css-display/block-in-inline.ts
@@ -22,7 +22,7 @@ describe('Display block in inline', () => {
     div2.appendChild(div3);
     div3.appendChild(document.createTextNode('There should be no red.'));
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('style changes 001', async () => {
@@ -49,7 +49,7 @@ describe('Display block in inline', () => {
     div1.addEventListener('click', () => {
       div3.style.display = div3.style.display == 'inline' ? 'block' : 'inline';
     });
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('style changes 002', async () => {
@@ -79,7 +79,7 @@ describe('Display block in inline', () => {
       div2.style.display = div2.style.display == 'inline' ? 'block' : 'inline';
       div3.style.display = div3.style.display == 'inline' ? 'block' : 'inline';
     });
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('relative positioning', async () => {
@@ -115,7 +115,7 @@ describe('Display block in inline', () => {
     });
     div3.appendChild(div4);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   xit('there should be no red', async () => {
@@ -137,7 +137,7 @@ describe('Display block in inline', () => {
     append(inline, innerBlock);
     append(block, inline);
     append(BODY, block);
-    await matchElementImageSnapshot(block);
+    await snapshot(block);
   });
 
   it('text should all coolapse into one line when click', async done => {
@@ -160,12 +160,12 @@ describe('Display block in inline', () => {
 
     document.body.addEventListener('click', async function listener() {
       toggleBlock.style.display = 'inline';
-      await matchElementImageSnapshot(block);
+      await snapshot(block);
       document.body.removeEventListener('click', listener);
       done();
     });
 
-    await matchElementImageSnapshot(block);
+    await snapshot(block);
 
     document.body.click();
   });
@@ -190,12 +190,12 @@ describe('Display block in inline', () => {
 
     document.body.addEventListener('click', async function listener() {
       toggleBlock.style.display = 'block';
-      await matchViewportSnapshot();
+      await snapshot();
       document.body.removeEventListener('click', listener);
       done();
     });
 
-    await matchViewportSnapshot();
+    await snapshot();
 
     document.body.click();
   });
@@ -227,7 +227,7 @@ describe('Display block in inline', () => {
     append(wrap, inline);
     append(BODY, control);
     append(BODY, wrap);
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('sliver boxs', async () => {
@@ -269,6 +269,6 @@ describe('Display block in inline', () => {
     append(container, bControl2);
     append(BODY, container);
 
-    await matchElementImageSnapshot(container);
+    await snapshot(container);
   });
 });

--- a/integration_tests/specs/css/css-display/block-in.ts
+++ b/integration_tests/specs/css/css-display/block-in.ts
@@ -14,7 +14,7 @@ describe('block-in', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('inline-003', async () => {
     let block;
@@ -67,7 +67,7 @@ describe('block-in', () => {
     BODY.appendChild(block);
     BODY.appendChild(block_1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('inline-004', async () => {
     let block;
@@ -123,7 +123,7 @@ describe('block-in', () => {
     BODY.appendChild(block);
     BODY.appendChild(block_1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('inline-005', async () => {
     let test;
@@ -178,7 +178,7 @@ describe('block-in', () => {
     );
     BODY.appendChild(block);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('inline-008-ref', async () => {
     let p;
@@ -202,7 +202,7 @@ describe('block-in', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('inline-008', async () => {
     let p;
@@ -269,7 +269,7 @@ describe('block-in', () => {
     BODY.appendChild(control);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('inline-relpos-001-ref', async () => {
     let p;
@@ -413,7 +413,7 @@ describe('block-in', () => {
     BODY.appendChild(container);
     BODY.appendChild(container_1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('inline-relpos-001', async () => {
     let p;
@@ -557,6 +557,6 @@ describe('block-in', () => {
     BODY.appendChild(container);
     BODY.appendChild(container_1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-display/block.ts
+++ b/integration_tests/specs/css/css-display/block.ts
@@ -12,7 +12,7 @@ describe('Display block', () => {
 
     container.appendChild(box);
     document.body.appendChild(container);
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('002', async () => {
@@ -22,6 +22,6 @@ describe('Display block', () => {
     container.style.backgroundColor = 'red';
 
     document.body.appendChild(container);
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-display/containing-block-legacy.ts
+++ b/integration_tests/specs/css/css-display/containing-block-legacy.ts
@@ -14,7 +14,7 @@ describe('containing-block legacy', () => {
     });
     append(div1, child);
     append(BODY, div1);
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('003', async () => {
@@ -35,7 +35,7 @@ describe('containing-block legacy', () => {
     });
     append(div1, child);
     append(BODY, div1);
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   xit('004', async () => {
@@ -53,7 +53,7 @@ describe('containing-block legacy', () => {
     });
     append(div1, child);
     append(BODY, div1);
-    await matchElementImageSnapshot(div1);
+    await snapshot(div1);
   });
 
   it('007', async () => {
@@ -71,7 +71,7 @@ describe('containing-block legacy', () => {
     });
     append(div1, child);
     append(BODY, div1);
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('008', async () => {
@@ -97,7 +97,7 @@ describe('containing-block legacy', () => {
     append(div2, div3);
     append(div1, div2);
     append(BODY, div1);
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('009', async () => {
     let div1 = createElementWithStyle('div', {
@@ -122,7 +122,7 @@ describe('containing-block legacy', () => {
     append(div2, div3);
     append(div1, div2);
     append(BODY, div1);
-    await matchElementImageSnapshot(BODY);
+    await snapshot(BODY);
   });
   it('010', async () => {
     let div1 = createElementWithStyle('div', {
@@ -147,7 +147,7 @@ describe('containing-block legacy', () => {
     append(div2, div3);
     append(div1, div2);
     append(BODY, div1);
-    await matchElementImageSnapshot(BODY);
+    await snapshot(BODY);
   });
   xit('011', async () => {
     let div2 = createElementWithStyle('div', {
@@ -164,7 +164,7 @@ describe('containing-block legacy', () => {
     });
     append(div2, span);
     append(BODY, div2);
-    await matchElementImageSnapshot(BODY);
+    await snapshot(BODY);
   });
   xit('013', async () => {
     let div2 = createElementWithStyle('div', {
@@ -181,7 +181,7 @@ describe('containing-block legacy', () => {
     });
     append(div2, span);
     append(BODY, div2);
-    await matchElementImageSnapshot(BODY);
+    await snapshot(BODY);
   });
   xit('015', async () => {
     let div2 = createElementWithStyle('div', {
@@ -198,7 +198,7 @@ describe('containing-block legacy', () => {
     });
     append(div2, span);
     append(BODY, div2);
-    await matchElementImageSnapshot(BODY);
+    await snapshot(BODY);
   });
 
   xit('017', async () => {
@@ -272,7 +272,7 @@ describe('containing-block legacy', () => {
     append(test, lastBox);
     append(container, test);
     append(BODY, container);
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   xit('018', async () => {
@@ -342,7 +342,7 @@ describe('containing-block legacy', () => {
     append(test, lastBox);
     append(container, test);
     append(BODY, container);
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   xit('019', async () => {
@@ -367,7 +367,7 @@ describe('containing-block legacy', () => {
     append(span, spanSpan);
     append(div, span);
     append(BODY, div);
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('023', async () => {
@@ -390,7 +390,7 @@ describe('containing-block legacy', () => {
     append(div2, div3);
     append(div1, div2);
     append(BODY, div1);
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('026', async () => {
@@ -409,7 +409,7 @@ describe('containing-block legacy', () => {
     let wrapper = createElementWithStyle('div', divStyle);
     append(wrapper, child);
     append(BODY, wrapper);
-    await matchElementImageSnapshot(wrapper);
+    await snapshot(wrapper);
   });
 
   it('027', async () => {
@@ -431,7 +431,7 @@ describe('containing-block legacy', () => {
     let wrapper = createElementWithStyle('div', divStyle);
     append(wrapper, child);
     append(BODY, wrapper);
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('028', async () => {
@@ -455,7 +455,7 @@ describe('containing-block legacy', () => {
     let wrapper = createElementWithStyle('div', divStyle);
     append(wrapper, child);
     append(BODY, wrapper);
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('030', async () => {
@@ -474,7 +474,7 @@ describe('containing-block legacy', () => {
     let container = createElementWithStyle('div', containingBlockStyle);
     append(container, div);
     append(BODY, container);
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('relative positioned elements near block-level ancestor', async () => {
@@ -504,7 +504,7 @@ describe('containing-block legacy', () => {
     });
     div1.appendChild(div2);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('relative positioned elements near inline-block ancestor', async () => {
@@ -537,7 +537,7 @@ describe('containing-block legacy', () => {
     });
     div1.appendChild(div2);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('static positioned elements near block-level ancestor', async () => {
@@ -567,7 +567,7 @@ describe('containing-block legacy', () => {
     });
     div1.appendChild(div2);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('static positioned elements near block-level ancestor', async () => {
@@ -597,7 +597,7 @@ describe('containing-block legacy', () => {
     });
     div1.appendChild(div2);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('fixed positioned elements', async () => {
@@ -627,7 +627,7 @@ describe('containing-block legacy', () => {
     });
     div1.appendChild(div2);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('absolute positioned elements near absolute ancestor', async () => {

--- a/integration_tests/specs/css/css-display/containing-block.ts
+++ b/integration_tests/specs/css/css-display/containing-block.ts
@@ -54,7 +54,7 @@ describe('containing-block', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('003', async () => {
     let div1;
@@ -91,7 +91,7 @@ describe('containing-block', () => {
     );
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('004', async () => {
     let p;
@@ -147,7 +147,7 @@ describe('containing-block', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('006', async () => {
     let p;
@@ -203,7 +203,7 @@ describe('containing-block', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('007-ref', async () => {
     let p;
@@ -231,7 +231,7 @@ describe('containing-block', () => {
     );
     BODY.appendChild(p);
 
-    await matchViewportSnapshot(0.5);
+    await snapshot(0.5);
   });
   it('007', async () => {
     let p;
@@ -277,7 +277,7 @@ describe('containing-block', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('008-ref', async () => {
     let p;
@@ -329,7 +329,7 @@ describe('containing-block', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot(0.5);
+    await snapshot(0.5);
   });
   it('008', async () => {
     let p;
@@ -405,7 +405,7 @@ describe('containing-block', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('009-ref', async () => {
     let div;
@@ -432,7 +432,7 @@ describe('containing-block', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot(0.5);
+    await snapshot(0.5);
   });
   it('009', async () => {
     let p;
@@ -506,7 +506,7 @@ describe('containing-block', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('010', async () => {
     let p;
@@ -580,7 +580,7 @@ describe('containing-block', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('011', async () => {
     let p;
@@ -647,7 +647,7 @@ describe('containing-block', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('013', async () => {
     let p;
@@ -714,7 +714,7 @@ describe('containing-block', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('015', async () => {
     let p;
@@ -781,7 +781,7 @@ describe('containing-block', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('017', async () => {
     let p;
@@ -914,10 +914,10 @@ describe('containing-block', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('018', async () => {
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('019-ref', async () => {
     let div;
@@ -945,7 +945,7 @@ describe('containing-block', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot(0.5);
+    await snapshot(0.5);
   });
   it('019', async () => {
     let p;
@@ -1016,7 +1016,7 @@ describe('containing-block', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('020-ref', async () => {
     let p;
@@ -1063,7 +1063,7 @@ describe('containing-block', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot(0.5);
+    await snapshot(0.5);
   });
   it('020', async () => {
     let p;
@@ -1134,7 +1134,7 @@ describe('containing-block', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('021', async () => {
     let p;
@@ -1205,7 +1205,7 @@ describe('containing-block', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('022', async () => {
     let p;
@@ -1276,7 +1276,7 @@ describe('containing-block', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('023', async () => {
     let p;
@@ -1345,7 +1345,7 @@ describe('containing-block', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('026', async () => {
     let p;
@@ -1397,7 +1397,7 @@ describe('containing-block', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('027', async () => {
     let p;
@@ -1445,7 +1445,7 @@ describe('containing-block', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('028', async () => {
     let p;
@@ -1495,7 +1495,7 @@ describe('containing-block', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('030', async () => {
     let p;
@@ -1539,7 +1539,7 @@ describe('containing-block', () => {
     BODY.appendChild(p);
     BODY.appendChild(containingBlock);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('with transform', async () => {
@@ -1583,7 +1583,7 @@ describe('containing-block', () => {
     BODY.appendChild(root);
     root.appendChild(containingBlock);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('without transform', async () => {
@@ -1626,6 +1626,6 @@ describe('containing-block', () => {
     BODY.appendChild(root);
     root.appendChild(containingBlock);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-display/content-visibility.ts
+++ b/integration_tests/specs/css/css-display/content-visibility.ts
@@ -41,7 +41,7 @@ describe('Content Visibility', () => {
       ]
     );
     BODY.appendChild(container);
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('should hidden', async () => {
@@ -87,7 +87,7 @@ describe('Content Visibility', () => {
       ]
     );
     BODY.appendChild(container);
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('should auto visible', async () => {
@@ -107,7 +107,7 @@ describe('Content Visibility', () => {
     });
 
     await sleep(0.1);
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('should auto hidden', async () => {
@@ -131,7 +131,7 @@ describe('Content Visibility', () => {
     container1.appendChild(text);
 
     // Should be empty blob
-    await matchElementImageSnapshot(container1);
+    await snapshot(container1);
   });
 
 });

--- a/integration_tests/specs/css/css-display/delete-block-in-inlines.ts
+++ b/integration_tests/specs/css/css-display/delete-block-in-inlines.ts
@@ -21,7 +21,7 @@ describe('delete-block-in-inlines', () => {
 
     async function onClick() {
       container.removeChild(nodeToDelete);
-      await matchViewportSnapshot();
+      await snapshot();
       BODY.removeEventListener('click', onClick);
       done();
     }
@@ -42,7 +42,7 @@ describe('delete-block-in-inlines', () => {
 
     append(BODY, container);
     append(BODY, container2);
-    await matchViewportSnapshot();
+    await snapshot();
 
     BODY.click();
   });
@@ -69,7 +69,7 @@ describe('delete-block-in-inlines', () => {
 
     async function onClick() {
       container.removeChild(nodeToDelete);
-      await matchViewportSnapshot();
+      await snapshot();
       BODY.removeEventListener('click', onClick);
       done();
     }
@@ -90,7 +90,7 @@ describe('delete-block-in-inlines', () => {
 
     append(BODY, container);
     append(BODY, container2);
-    await matchViewportSnapshot();
+    await snapshot();
 
     BODY.click();
   });
@@ -117,7 +117,7 @@ describe('delete-block-in-inlines', () => {
 
     async function onClick() {
       container.removeChild(nodeToDelete);
-      await matchViewportSnapshot();
+      await snapshot();
       BODY.removeEventListener('click', onClick);
       done();
     }
@@ -138,7 +138,7 @@ describe('delete-block-in-inlines', () => {
 
     append(BODY, container);
     append(BODY, container2);
-    await matchViewportSnapshot();
+    await snapshot();
 
     BODY.click();
   });

--- a/integration_tests/specs/css/css-display/delete-block.ts
+++ b/integration_tests/specs/css/css-display/delete-block.ts
@@ -54,7 +54,7 @@ describe('delete-block', () => {
     BODY.appendChild(container);
     BODY.appendChild(container_1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('in-inlines-beginning-001', async () => {
     let p;
@@ -134,6 +134,6 @@ describe('delete-block', () => {
     BODY.appendChild(container);
     BODY.appendChild(container_1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-display/delete-inline-in-blocks.ts
+++ b/integration_tests/specs/css/css-display/delete-inline-in-blocks.ts
@@ -27,7 +27,7 @@ xdescribe('delete-inline-in-blocks', () => {
 
     async function onClick() {
       container1.removeChild(nodeToDelete);
-      await matchViewportSnapshot();
+      await snapshot();
       BODY.removeEventListener('click', onClick);
       done();
     }
@@ -35,7 +35,7 @@ xdescribe('delete-inline-in-blocks', () => {
     BODY.addEventListener('click', onClick);
 
     append(BODY, container1);
-    await matchViewportSnapshot();
+    await snapshot();
 
     BODY.click();
   });
@@ -68,7 +68,7 @@ xdescribe('delete-inline-in-blocks', () => {
 
     async function onClick() {
       container1.removeChild(nodeToDelete);
-      await matchViewportSnapshot();
+      await snapshot();
       BODY.removeEventListener('click', onClick);
       done();
     }
@@ -76,7 +76,7 @@ xdescribe('delete-inline-in-blocks', () => {
     BODY.addEventListener('click', onClick);
 
     append(BODY, container1);
-    await matchViewportSnapshot();
+    await snapshot();
 
     BODY.click();
   });
@@ -109,7 +109,7 @@ xdescribe('delete-inline-in-blocks', () => {
 
     async function onClick() {
       container1.removeChild(nodeToDelete);
-      await matchViewportSnapshot();
+      await snapshot();
       BODY.removeEventListener('click', onClick);
       done();
     }
@@ -117,7 +117,7 @@ xdescribe('delete-inline-in-blocks', () => {
     BODY.addEventListener('click', onClick);
 
     append(BODY, container1);
-    await matchViewportSnapshot();
+    await snapshot();
 
     BODY.click();
   });
@@ -150,7 +150,7 @@ xdescribe('delete-inline-in-blocks', () => {
 
     async function onClick() {
       container1.removeChild(nodeToDelete);
-      await matchViewportSnapshot();
+      await snapshot();
       BODY.removeEventListener('click', onClick);
       done();
     }
@@ -158,7 +158,7 @@ xdescribe('delete-inline-in-blocks', () => {
     BODY.addEventListener('click', onClick);
 
     append(BODY, container1);
-    await matchViewportSnapshot();
+    await snapshot();
 
     BODY.click();
   });
@@ -191,7 +191,7 @@ xdescribe('delete-inline-in-blocks', () => {
 
     async function onClick() {
       container1.removeChild(nodeToDelete);
-      await matchViewportSnapshot();
+      await snapshot();
       BODY.removeEventListener('click', onClick);
       done();
     }
@@ -199,7 +199,7 @@ xdescribe('delete-inline-in-blocks', () => {
     BODY.addEventListener('click', onClick);
 
     append(BODY, container1);
-    await matchViewportSnapshot();
+    await snapshot();
 
     BODY.click();
   });

--- a/integration_tests/specs/css/css-display/descendant-display.ts
+++ b/integration_tests/specs/css/css-display/descendant-display.ts
@@ -15,7 +15,7 @@ describe('descendant-display', () => {
       }),
     ]);
     append(BODY, element);
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('override-001', async () => {
@@ -35,6 +35,6 @@ describe('descendant-display', () => {
       }),
     ]);
     append(BODY, element);
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-display/display.ts
+++ b/integration_tests/specs/css/css-display/display.ts
@@ -8,7 +8,7 @@ describe('display', () => {
       createElementWithStyle('div', divStyle, createText('Filter text')),
     ]);
     append(BODY, element);
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('002', async () => {
@@ -20,7 +20,7 @@ describe('display', () => {
       createElementWithStyle('div', divStyle, createText('Filter text')),
     ]);
     append(BODY, element);
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('005', async () => {
     let divdivStyle = {
@@ -31,7 +31,7 @@ describe('display', () => {
       createElementWithStyle('div', divdivStyle, createText('Filter text')),
     ]);
     append(BODY, element);
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('016', async () => {
     let divStyle = {
@@ -40,7 +40,7 @@ describe('display', () => {
     };
     let element = createElementWithStyle('div', divStyle, createText('FAIL'));
     append(BODY, element);
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('applies-to-001', async () => {
     let spanStyle = {
@@ -52,7 +52,7 @@ describe('display', () => {
       createText('Filter text'),
     ]);
     append(BODY, element);
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('none-001', async () => {
     let divStyle = {
@@ -62,7 +62,7 @@ describe('display', () => {
     };
     let element = createElementWithStyle('div', divStyle, createText('Filter Text'));
     append(BODY, element);
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('none-002', async () => {
     let divStyle = {
@@ -72,6 +72,6 @@ describe('display', () => {
     };
     let element = createElementWithStyle('div', divStyle, createText('Filter Text'));
     append(BODY, element);
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-display/flex.ts
+++ b/integration_tests/specs/css/css-display/flex.ts
@@ -17,7 +17,7 @@ describe('Display flex', () => {
         'This text should display as the next line as the box'
       )
     );
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('002', async () => {
@@ -28,6 +28,6 @@ describe('Display flex', () => {
     container.style.backgroundColor = 'red';
 
     document.body.appendChild(container);
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-display/inline-block.ts
+++ b/integration_tests/specs/css/css-display/inline-block.ts
@@ -15,7 +15,7 @@ describe('Display inline-block', () => {
       )
     );
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   xit('inline-block box constraint is tight', async () => {
@@ -33,7 +33,7 @@ describe('Display inline-block', () => {
     });
     append(magenta, box);
     append(BODY, magenta);
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   xit('inline-block nest inline-block should behavior like inline-block', async () => {
@@ -50,7 +50,7 @@ describe('Display inline-block', () => {
     });
     append(magenta, box);
     append(BODY, magenta);
-    await matchElementImageSnapshot(magenta);
+    await snapshot(magenta);
   });
 
   xit('inline-block nest block should behavior like inline-block', async () => {
@@ -67,7 +67,7 @@ describe('Display inline-block', () => {
     });
     append(magenta, box);
     append(BODY, magenta);
-    await matchElementImageSnapshot(magenta);
+    await snapshot(magenta);
   });
 
   xit('textNode only if have one space', async () => {
@@ -97,6 +97,6 @@ describe('Display inline-block', () => {
     append(BODY, container);
     append(BODY, container2);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-display/inline-flex.ts
+++ b/integration_tests/specs/css/css-display/inline-flex.ts
@@ -18,6 +18,6 @@ describe('Display inline-flex', () => {
       )
     );
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-display/inline.ts
+++ b/integration_tests/specs/css/css-display/inline.ts
@@ -18,7 +18,7 @@ describe('Display inline', () => {
       )
     );
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   xit('textNode only if have one space', async () => {
@@ -44,6 +44,6 @@ describe('Display inline', () => {
     append(BODY, container);
     append(BODY, container2);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-display/insert-block-in-blocks-n-inlines.ts
+++ b/integration_tests/specs/css/css-display/insert-block-in-blocks-n-inlines.ts
@@ -22,10 +22,10 @@ describe('insert-block-in-blocks-n-inlines', () => {
 
     BODY.addEventListener('click', async function onClick() {
       element.insertBefore(inserted, firstBlock);
-      await matchViewportSnapshot();
+      await snapshot();
       BODY.removeEventListener('click', onClick);
       element.removeChild(inserted);
-      await matchViewportSnapshot();
+      await snapshot();
       done();
     });
 
@@ -39,7 +39,7 @@ describe('insert-block-in-blocks-n-inlines', () => {
     ]);
 
     append(BODY, element);
-    await matchViewportSnapshot();
+    await snapshot();
 
     BODY.click();
   });
@@ -67,10 +67,10 @@ describe('insert-block-in-blocks-n-inlines', () => {
 
     BODY.addEventListener('click', async function onClick() {
       element.insertBefore(inserted, insertPoint);
-      await matchViewportSnapshot();
+      await snapshot();
       BODY.removeEventListener('click', onClick);
       element.removeChild(inserted);
-      await matchViewportSnapshot();
+      await snapshot();
       done();
     });
 
@@ -84,7 +84,7 @@ describe('insert-block-in-blocks-n-inlines', () => {
     ]);
 
     append(BODY, element);
-    await matchViewportSnapshot();
+    await snapshot();
 
     BODY.click();
   });
@@ -112,10 +112,10 @@ describe('insert-block-in-blocks-n-inlines', () => {
 
     BODY.addEventListener('click', async function onClick() {
       element.insertBefore(inserted, insertPoint);
-      await matchViewportSnapshot();
+      await snapshot();
       BODY.removeEventListener('click', onClick);
       element.removeChild(inserted);
-      await matchViewportSnapshot();
+      await snapshot();
       done();
     });
 
@@ -130,7 +130,7 @@ describe('insert-block-in-blocks-n-inlines', () => {
     ]);
 
     append(BODY, element);
-    await matchViewportSnapshot();
+    await snapshot();
 
     BODY.click();
   });
@@ -158,10 +158,10 @@ describe('insert-block-in-blocks-n-inlines', () => {
 
     BODY.addEventListener('click', async function onClick() {
       element.insertBefore(inserted, insertPoint);
-      await matchViewportSnapshot();
+      await snapshot();
       BODY.removeEventListener('click', onClick);
       element.removeChild(inserted);
-      await matchViewportSnapshot();
+      await snapshot();
       done();
     });
 
@@ -176,7 +176,7 @@ describe('insert-block-in-blocks-n-inlines', () => {
     ]);
 
     append(BODY, element);
-    await matchViewportSnapshot();
+    await snapshot();
 
     BODY.click();
   });
@@ -204,10 +204,10 @@ describe('insert-block-in-blocks-n-inlines', () => {
 
     BODY.addEventListener('click', async function onClick() {
       element.insertBefore(inserted, insertPoint);
-      await matchViewportSnapshot();
+      await snapshot();
       BODY.removeEventListener('click', onClick);
       element.removeChild(inserted);
-      await matchViewportSnapshot();
+      await snapshot();
       done();
     });
 
@@ -222,7 +222,7 @@ describe('insert-block-in-blocks-n-inlines', () => {
     ]);
 
     append(BODY, element);
-    await matchViewportSnapshot();
+    await snapshot();
 
     BODY.click();
   });
@@ -250,10 +250,10 @@ describe('insert-block-in-blocks-n-inlines', () => {
 
     BODY.addEventListener('click', async function onClick() {
       element.insertBefore(inserted, insertPoint);
-      await matchViewportSnapshot();
+      await snapshot();
       BODY.removeEventListener('click', onClick);
       element.removeChild(inserted);
-      await matchViewportSnapshot();
+      await snapshot();
       done();
     });
 
@@ -268,7 +268,7 @@ describe('insert-block-in-blocks-n-inlines', () => {
     ]);
 
     append(BODY, element);
-    await matchViewportSnapshot();
+    await snapshot();
 
     BODY.click();
   });
@@ -296,10 +296,10 @@ describe('insert-block-in-blocks-n-inlines', () => {
 
     BODY.addEventListener('click', async function onClick() {
       element.insertBefore(inserted, insertPoint);
-      await matchViewportSnapshot();
+      await snapshot();
       BODY.removeEventListener('click', onClick);
       element.removeChild(inserted);
-      await matchViewportSnapshot();
+      await snapshot();
       done();
     });
 
@@ -314,7 +314,7 @@ describe('insert-block-in-blocks-n-inlines', () => {
     ]);
 
     append(BODY, element);
-    await matchViewportSnapshot();
+    await snapshot();
 
     BODY.click();
   });
@@ -342,10 +342,10 @@ describe('insert-block-in-blocks-n-inlines', () => {
 
     BODY.addEventListener('click', async function onClick() {
       element.insertBefore(inserted, insertPoint);
-      await matchViewportSnapshot();
+      await snapshot();
       BODY.removeEventListener('click', onClick);
       element.removeChild(inserted);
-      await matchViewportSnapshot();
+      await snapshot();
       done();
     });
 
@@ -362,7 +362,7 @@ describe('insert-block-in-blocks-n-inlines', () => {
     ]);
 
     append(BODY, element);
-    await matchViewportSnapshot();
+    await snapshot();
 
     BODY.click();
   });
@@ -390,10 +390,10 @@ describe('insert-block-in-blocks-n-inlines', () => {
 
     BODY.addEventListener('click', async function onClick() {
       element.insertBefore(inserted, insertPoint);
-      await matchViewportSnapshot();
+      await snapshot();
       BODY.removeEventListener('click', onClick);
       element.removeChild(inserted);
-      await matchViewportSnapshot();
+      await snapshot();
       done();
     });
 
@@ -410,7 +410,7 @@ describe('insert-block-in-blocks-n-inlines', () => {
     ]);
 
     append(BODY, element);
-    await matchViewportSnapshot();
+    await snapshot();
 
     BODY.click();
   });

--- a/integration_tests/specs/css/css-display/insert-block-in-inlines.ts
+++ b/integration_tests/specs/css/css-display/insert-block-in-inlines.ts
@@ -30,16 +30,16 @@ describe('insert-block-in-inlines', () => {
 
     BODY.addEventListener('click', async function onClick() {
       container.insertBefore(insertBlock, insertPoint);
-      await matchViewportSnapshot();
+      await snapshot();
       BODY.removeEventListener('click', onClick);
       container.removeChild(insertBlock);
-      await matchViewportSnapshot();
+      await snapshot();
       done();
     });
 
     append(BODY, container);
     append(BODY, container2);
-    await matchViewportSnapshot();
+    await snapshot();
 
     BODY.click();
   });
@@ -73,16 +73,16 @@ describe('insert-block-in-inlines', () => {
 
     BODY.addEventListener('click', async function onClick() {
       container.appendChild(insertBlock);
-      await matchViewportSnapshot();
+      await snapshot();
       BODY.removeEventListener('click', onClick);
       container.removeChild(insertBlock);
-      await matchViewportSnapshot();
+      await snapshot();
       done();
     });
 
     append(BODY, container);
     append(BODY, container2);
-    await matchViewportSnapshot();
+    await snapshot();
 
     BODY.click();
   });
@@ -119,16 +119,16 @@ describe('insert-block-in-inlines', () => {
 
     BODY.addEventListener('click', async function onClick() {
       container.insertBefore(insertBlock, insertPoint);
-      await matchViewportSnapshot();
+      await snapshot();
       BODY.removeEventListener('click', onClick);
       container.removeChild(insertBlock);
-      await matchViewportSnapshot();
+      await snapshot();
       done();
     });
 
     append(BODY, container);
     append(BODY, container2);
-    await matchViewportSnapshot();
+    await snapshot();
 
     BODY.click();
   });

--- a/integration_tests/specs/css/css-display/insert-inline-in-blocks-n-inlines.ts
+++ b/integration_tests/specs/css/css-display/insert-inline-in-blocks-n-inlines.ts
@@ -41,11 +41,11 @@ describe('insert-inline-in-blocks-n-inlines', () => {
     append(BODY, container);
     append(BODY, container2);
 
-    await matchViewportSnapshot();
+    await snapshot();
 
     container.insertBefore(createElementWithStyle('span', insertedStyle, createText('Inserted new inline')), insertPoint);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('begin-002', async () => {
@@ -92,11 +92,11 @@ describe('insert-inline-in-blocks-n-inlines', () => {
     append(BODY, container);
     append(BODY, container2);
 
-    await matchViewportSnapshot();
+    await snapshot();
 
     container.insertBefore(createElementWithStyle('span', insertedStyle, createText('Inserted new inline')), insertPoint);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('begin-003', async () => {
@@ -143,11 +143,11 @@ describe('insert-inline-in-blocks-n-inlines', () => {
     append(BODY, container);
     append(BODY, container2);
 
-    await matchViewportSnapshot();
+    await snapshot();
 
     container.insertBefore(createElementWithStyle('span', insertedStyle, createText('Inserted new inline')), insertPoint);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('end-001', async () => {
@@ -194,11 +194,11 @@ describe('insert-inline-in-blocks-n-inlines', () => {
     append(BODY, container);
     append(BODY, container2);
 
-    await matchViewportSnapshot();
+    await snapshot();
 
     container.insertBefore(createElementWithStyle('span', insertedStyle, createText('Inserted new inline')), insertPoint);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('end-002', async () => {
@@ -245,11 +245,11 @@ describe('insert-inline-in-blocks-n-inlines', () => {
     append(BODY, container);
     append(BODY, container2);
 
-    await matchViewportSnapshot();
+    await snapshot();
 
     container.insertBefore(createElementWithStyle('span', insertedStyle, createText('Inserted new inline')), insertPoint);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('end-003', async () => {
@@ -295,11 +295,11 @@ describe('insert-inline-in-blocks-n-inlines', () => {
     append(BODY, container);
     append(BODY, container2);
 
-    await matchViewportSnapshot();
+    await snapshot();
 
     container.appendChild(createElementWithStyle('span', insertedStyle, createText('Inserted new inline')));
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('middle-001', async () => {
@@ -347,11 +347,11 @@ describe('insert-inline-in-blocks-n-inlines', () => {
     append(BODY, container);
     append(BODY, container2);
 
-    await matchViewportSnapshot();
+    await snapshot();
 
     container.insertBefore(insertBlock, insertPoint);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('middle-002', async () => {
@@ -399,11 +399,11 @@ describe('insert-inline-in-blocks-n-inlines', () => {
     append(BODY, container);
     append(BODY, container2);
 
-    await matchViewportSnapshot();
+    await snapshot();
 
     container.insertBefore(insertBlock, insertPoint);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('middle-003', async () => {
@@ -451,10 +451,10 @@ describe('insert-inline-in-blocks-n-inlines', () => {
     append(BODY, container);
     append(BODY, container2);
 
-    await matchViewportSnapshot();
+    await snapshot();
 
     container.insertBefore(insertBlock, insertPoint);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-display/insert-inline-in-blocks.ts
+++ b/integration_tests/specs/css/css-display/insert-inline-in-blocks.ts
@@ -33,17 +33,17 @@ describe('insert-inline-in-blocks', () => {
 
     BODY.addEventListener('click', async function onClick() {
       container1.insertBefore(insertBlock, insertPoint);
-      await matchViewportSnapshot();
+      await snapshot();
       BODY.removeEventListener('click', onClick);
       container1.removeChild(insertBlock);
-      await matchViewportSnapshot();
+      await snapshot();
       done();
     });
 
     append(BODY, container1);
     append(BODY, container2);
 
-    await matchViewportSnapshot();
+    await snapshot();
 
     BODY.click();
   });
@@ -80,17 +80,17 @@ describe('insert-inline-in-blocks', () => {
 
     BODY.addEventListener('click', async function onClick() {
       container1.appendChild(insertBlock);
-      await matchViewportSnapshot();
+      await snapshot();
       BODY.removeEventListener('click', onClick);
       container1.removeChild(insertBlock);
-      await matchViewportSnapshot();
+      await snapshot();
       done();
     });
 
     append(BODY, container1);
     append(BODY, container2);
 
-    await matchViewportSnapshot();
+    await snapshot();
 
     BODY.click();
   });
@@ -128,17 +128,17 @@ describe('insert-inline-in-blocks', () => {
 
     BODY.addEventListener('click', async function onClick() {
       container1.insertBefore(insertBlock, insertPoint);
-      await matchViewportSnapshot();
+      await snapshot();
       BODY.removeEventListener('click', onClick);
       container1.removeChild(insertBlock);
-      await matchViewportSnapshot();
+      await snapshot();
       done();
     });
 
     append(BODY, container1);
     append(BODY, container2);
 
-    await matchViewportSnapshot();
+    await snapshot();
 
     BODY.click();
   });

--- a/integration_tests/specs/css/css-display/none.ts
+++ b/integration_tests/specs/css/css-display/none.ts
@@ -13,6 +13,6 @@ describe('Display', () => {
       document.createTextNode('The box should not display.')
     );
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-display/opacity.ts
+++ b/integration_tests/specs/css/css-display/opacity.ts
@@ -31,7 +31,7 @@ describe('Opacity', () => {
         opacity: 0.5,
       });
 
-      await matchViewportSnapshot();
+      await snapshot();
       done();
     });
   });

--- a/integration_tests/specs/css/css-display/sliver.ts
+++ b/integration_tests/specs/css/css-display/sliver.ts
@@ -21,23 +21,23 @@ describe('display sliver', () => {
 
   it('basic', async () => {
     createSliverBasicCase();
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('sliver-direction', async () => {
     const container = createSliverBasicCase();
     (container.style as any).sliverDirection = 'column';
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('scroll works', async () => {
     const container = createSliverBasicCase();
 
     container.scrollBy(0, 200);
-    await matchViewportSnapshot();
+    await snapshot();
 
     container.scrollBy(0, -150);
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-display/text-align.ts
+++ b/integration_tests/specs/css/css-display/text-align.ts
@@ -15,6 +15,6 @@ describe('text-align', () => {
     append(container, text);
     append(container, div);
     append(BODY, container);
-    await matchElementImageSnapshot(container);
+    await snapshot(container);
   });
 });

--- a/integration_tests/specs/css/css-display/visibility.ts
+++ b/integration_tests/specs/css/css-display/visibility.ts
@@ -9,7 +9,7 @@ describe('Visibility', () => {
       height: '200px',
     });
 
-    await matchViewportSnapshot();
+    await snapshot();
 
     const container2 = document.createElement('div');
     container2.appendChild(document.createTextNode('visibility test'));
@@ -21,7 +21,7 @@ describe('Visibility', () => {
 
     container1.appendChild(container2);
 
-    await matchViewportSnapshot();
+    await snapshot();
 
     container1.addEventListener('click', () => {
       console.log('container clicked');
@@ -34,6 +34,6 @@ describe('Visibility', () => {
       visibility: 'hidden',
     });
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-flexbox/abspos-autopos.ts
+++ b/integration_tests/specs/css/css-flexbox/abspos-autopos.ts
@@ -31,7 +31,7 @@ describe('abspos-autopos', () => {
     );
     BODY.appendChild(flex);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('htb-rtl', async () => {
     let flex;
@@ -64,6 +64,6 @@ describe('abspos-autopos', () => {
     );
     BODY.appendChild(flex);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-flexbox/align-baseline.ts
+++ b/integration_tests/specs/css/css-flexbox/align-baseline.ts
@@ -72,7 +72,7 @@ describe('align-baseline', () => {
     BODY.appendChild(flexbox_1);
 
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('ref', async () => {
@@ -146,6 +146,6 @@ describe('align-baseline', () => {
     BODY.appendChild(flexbox);
     BODY.appendChild(flexbox_1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-flexbox/align-content.ts
+++ b/integration_tests/specs/css/css-flexbox/align-content.ts
@@ -53,7 +53,7 @@ describe('align-content', () => {
     );
     BODY.appendChild(flexbox);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('002', async () => {
     let flexbox;
@@ -107,7 +107,7 @@ describe('align-content', () => {
     );
     BODY.appendChild(flexbox);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('003', async () => {
     let p;
@@ -172,7 +172,7 @@ describe('align-content', () => {
     BODY.appendChild(p);
     BODY.appendChild(flexbox);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('004', async () => {
     let p;
@@ -237,7 +237,7 @@ describe('align-content', () => {
     BODY.appendChild(p);
     BODY.appendChild(flexbox);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('005', async () => {
     let p;
@@ -302,7 +302,7 @@ describe('align-content', () => {
     BODY.appendChild(p);
     BODY.appendChild(flexbox);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('006', async () => {
     let p;
@@ -363,7 +363,7 @@ describe('align-content', () => {
     BODY.appendChild(p);
     BODY.appendChild(flexbox);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('wrap-001', async () => {
     let log;
@@ -577,7 +577,7 @@ describe('align-content', () => {
     BODY.appendChild(box_5);
     BODY.appendChild(box_6);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('wrap-002', async () => {
     let content1Horizontal;
@@ -989,7 +989,7 @@ describe('align-content', () => {
     BODY.appendChild(flexHorizontal_2);
     BODY.appendChild(flexVertical);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('wrap-003', async () => {
     let flexbox;
@@ -2747,7 +2747,7 @@ describe('align-content', () => {
     BODY.appendChild(flexbox_42);
     BODY.appendChild(flexbox_43);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('wrap-004', async () => {
     let flex;
@@ -2820,7 +2820,7 @@ describe('align-content', () => {
     );
     BODY.appendChild(flex);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('stretch unbound flex-item 001', async () => {
@@ -2865,7 +2865,7 @@ describe('align-content', () => {
       ]
     );
     BODY.appendChild(flexHorizontal);
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('stretch unbound flex-item 002', async () => {
@@ -2910,7 +2910,7 @@ describe('align-content', () => {
       ]
     );
     BODY.appendChild(flexHorizontal);
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('stretch unbound flex-item 003', async () => {
@@ -2955,6 +2955,6 @@ describe('align-content', () => {
       ]
     );
     BODY.appendChild(flexHorizontal);
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-flexbox/align-items.ts
+++ b/integration_tests/specs/css/css-flexbox/align-items.ts
@@ -46,7 +46,7 @@ describe('align-items', () => {
     BODY.appendChild(p);
     BODY.appendChild(flexbox);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('002', async () => {
     let p;
@@ -94,7 +94,7 @@ describe('align-items', () => {
     BODY.appendChild(p);
     BODY.appendChild(flexbox);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('003', async () => {
     let p;
@@ -142,7 +142,7 @@ describe('align-items', () => {
     BODY.appendChild(p);
     BODY.appendChild(flexbox);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('004', async () => {
     let div1;
@@ -280,7 +280,7 @@ describe('align-items', () => {
     );
     BODY.appendChild(flexbox);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('005', async () => {
     let p;
@@ -326,7 +326,7 @@ describe('align-items', () => {
     BODY.appendChild(p);
     BODY.appendChild(flexbox);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('006', async () => {
     let p;
@@ -394,7 +394,7 @@ describe('align-items', () => {
     BODY.appendChild(block);
     BODY.appendChild(flexbox);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('007', async () => {
     let div;
@@ -433,7 +433,7 @@ describe('align-items', () => {
     BODY.appendChild(div);
     BODY.appendChild(div_1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('baseline-overflow-non-visible', async () => {
     let overflow;
@@ -482,7 +482,7 @@ describe('align-items', () => {
     );
     BODY.appendChild(flex);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it("works with baseline in nested elements", async () => {
@@ -530,7 +530,7 @@ describe('align-items', () => {
     );
     BODY.appendChild(container);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it("work with baseline in nested block elements", async () => {
@@ -577,7 +577,7 @@ describe('align-items', () => {
     );
     BODY.appendChild(container);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it("work with baseline in nested block elements and contain text", async () => {
@@ -628,7 +628,7 @@ describe('align-items', () => {
     );
     BODY.appendChild(container);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it("works with stretch in row flex direction when flex-grow is set", async () => {
@@ -665,7 +665,7 @@ describe('align-items', () => {
       ]
     );
     BODY.appendChild(containingBlock);
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it("works with flex-start in row flex direction when flex-grow is set", async () => {
@@ -703,7 +703,7 @@ describe('align-items', () => {
       ]
     );
     BODY.appendChild(containingBlock);
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it("works with center in row flex direction when flex-grow is set", async () => {
@@ -741,7 +741,7 @@ describe('align-items', () => {
       ]
     );
     BODY.appendChild(containingBlock);
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it("works with flex-end in row flex direction when flex-grow is set", async () => {
@@ -779,7 +779,7 @@ describe('align-items', () => {
       ]
     );
     BODY.appendChild(containingBlock);
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it("works with stretch in column flex direction when flex-grow is set", async () => {
@@ -817,7 +817,7 @@ describe('align-items', () => {
       ]
     );
     BODY.appendChild(containingBlock);
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it("works with flex-start in column flex direction when flex-grow is set", async () => {
@@ -856,7 +856,7 @@ describe('align-items', () => {
       ]
     );
     BODY.appendChild(containingBlock);
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it("works with center in column flex direction when flex-grow is set", async () => {
@@ -895,7 +895,7 @@ describe('align-items', () => {
       ]
     );
     BODY.appendChild(containingBlock);
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it("works with flex-end in column flex direction when flex-grow is set", async () => {
@@ -935,7 +935,7 @@ describe('align-items', () => {
     );
     BODY.appendChild(containingBlock);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it("works with stretch in row direction when flex-wrap is nowrap", async () => {
@@ -961,7 +961,7 @@ describe('align-items', () => {
     );
     BODY.appendChild(containingBlock);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it("does not work with stretch in row direction when flex-wrap is wrap", async () => {
@@ -988,7 +988,7 @@ describe('align-items', () => {
     );
     BODY.appendChild(containingBlock);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('does work with stretch when min-height exists and height does not exist', async () => {
@@ -1022,7 +1022,7 @@ describe('align-items', () => {
     BODY.appendChild(flexbox);
 
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('does not work with stretch when height exists', async () => {
@@ -1056,7 +1056,7 @@ describe('align-items', () => {
     BODY.appendChild(flexbox);
 
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('does work with stretch when min-width exists and width does not exist', async () => {
@@ -1091,7 +1091,7 @@ describe('align-items', () => {
     BODY.appendChild(flexbox);
 
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('does not work with stretch when width exists', async () => {
@@ -1126,7 +1126,7 @@ describe('align-items', () => {
     BODY.appendChild(flexbox);
 
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });
 

--- a/integration_tests/specs/css/css-flexbox/align-self.ts
+++ b/integration_tests/specs/css/css-flexbox/align-self.ts
@@ -65,7 +65,7 @@ describe('align-self', () => {
     BODY.appendChild(test);
     BODY.appendChild(cover);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('002', async () => {
     let test;
@@ -132,7 +132,7 @@ describe('align-self', () => {
     BODY.appendChild(test);
     BODY.appendChild(cover);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('004', async () => {
     let test;
@@ -180,7 +180,7 @@ describe('align-self', () => {
     );
     BODY.appendChild(test);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('005', async () => {
     let p;
@@ -263,7 +263,7 @@ describe('align-self', () => {
     BODY.appendChild(test);
     BODY.appendChild(cover);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('006', async () => {
     let p;
@@ -352,7 +352,7 @@ describe('align-self', () => {
     BODY.appendChild(p);
     BODY.appendChild(test);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('007', async () => {
     let test;
@@ -420,7 +420,7 @@ describe('align-self', () => {
     BODY.appendChild(test);
     BODY.appendChild(cover);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('008', async () => {
     let p;
@@ -502,7 +502,7 @@ describe('align-self', () => {
     BODY.appendChild(test);
     BODY.appendChild(cover);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('009', async () => {
     let p;
@@ -595,7 +595,7 @@ describe('align-self', () => {
     BODY.appendChild(top);
     BODY.appendChild(bottom);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('010', async () => {
     let p;
@@ -729,7 +729,7 @@ describe('align-self', () => {
     BODY.appendChild(p);
     BODY.appendChild(test);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('011', async () => {
     let p;
@@ -796,7 +796,7 @@ describe('align-self', () => {
     BODY.appendChild(p);
     BODY.appendChild(test);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('012', async () => {
     let p;
@@ -863,7 +863,7 @@ describe('align-self', () => {
     BODY.appendChild(p);
     BODY.appendChild(test);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('013', async () => {
     let test;
@@ -928,7 +928,7 @@ describe('align-self', () => {
     BODY.appendChild(test);
     BODY.appendChild(cover);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   xit("015-ref", async () => {
@@ -1180,7 +1180,7 @@ describe('align-self', () => {
     BODY.appendChild(flexbox);
 
 
-    await matchViewportSnapshot();
+    await snapshot();
   })
 
   it("should work with center when flex-direction is column and flex-wrap is wrap", async () => {
@@ -1300,7 +1300,7 @@ describe('align-self', () => {
     BODY.appendChild(div_1);
 
 
-    await matchViewportSnapshot();
+    await snapshot();
   })
 
   it("should work with center when flex-direction is column and flex-wrap is nowrap", async () => {
@@ -1420,7 +1420,7 @@ describe('align-self', () => {
     BODY.appendChild(div_1);
 
 
-    await matchViewportSnapshot();
+    await snapshot();
   })
   it("should work with center when flex-direction is row and flex-wrap is wrap", async () => {
     let p;
@@ -1539,7 +1539,7 @@ describe('align-self', () => {
     BODY.appendChild(div_1);
 
 
-    await matchViewportSnapshot();
+    await snapshot();
   })
 
   it("should work with center when flex-direction is row and flex-wrap is nowrap", async () => {
@@ -1659,7 +1659,7 @@ describe('align-self', () => {
     BODY.appendChild(div_1);
 
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('change from center to flex-end', async (done) => {
@@ -1687,11 +1687,11 @@ describe('align-self', () => {
     );
     append(BODY, cont);
 
-    await matchViewportSnapshot();
+    await snapshot();
 
     requestAnimationFrame(async () => {
       foo.style.alignSelf = 'flex-end';
-      await matchViewportSnapshot(0.1);
+      await snapshot(0.1);
       done();
     });
   });

--- a/integration_tests/specs/css/css-flexbox/align.ts
+++ b/integration_tests/specs/css/css-flexbox/align.ts
@@ -65,7 +65,7 @@ describe('align', () => {
     );
     BODY.appendChild(test);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('content_stretch', async () => {
     let test01;
@@ -132,6 +132,6 @@ describe('align', () => {
     );
     BODY.appendChild(test);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-flexbox/align_content.ts
+++ b/integration_tests/specs/css/css-flexbox/align_content.ts
@@ -45,7 +45,7 @@ describe('flexbox align-content', () => {
     });
     container.appendChild(child4);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('should work with end when flex-direction is row', async () => {
@@ -93,7 +93,7 @@ describe('flexbox align-content', () => {
       backgroundColor: 'yellow',
     });
     container.appendChild(child4);
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('should work with center when flex-direction is row', async () => {
@@ -141,7 +141,7 @@ describe('flexbox align-content', () => {
       backgroundColor: 'yellow',
     });
     container.appendChild(child4);
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('should work with space-around when flex-direction is row', async () => {
@@ -189,7 +189,7 @@ describe('flexbox align-content', () => {
       backgroundColor: 'yellow',
     });
     container.appendChild(child4);
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('should work with space-between when flex-direction is row', async () => {
@@ -237,7 +237,7 @@ describe('flexbox align-content', () => {
       backgroundColor: 'yellow',
     });
     container.appendChild(child4);
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('should work with space-evenly when flex-direction is row', async () => {
@@ -285,6 +285,6 @@ describe('flexbox align-content', () => {
       backgroundColor: 'yellow',
     });
     container.appendChild(child4);
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-flexbox/align_items.ts
+++ b/integration_tests/specs/css/css-flexbox/align_items.ts
@@ -36,7 +36,7 @@ describe('flexbox align-items', () => {
     });
     container.appendChild(child3);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('should work with flex-end when flex-direction is row', async () => {
@@ -76,7 +76,7 @@ describe('flexbox align-items', () => {
     });
     container.appendChild(child3);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('should work with center when flex-direction is row', async () => {
@@ -116,7 +116,7 @@ describe('flexbox align-items', () => {
     });
     container.appendChild(child3);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('should work with stretch when flex-direction is row', async () => {
@@ -156,7 +156,7 @@ describe('flexbox align-items', () => {
     });
     container.appendChild(child3);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('should work with baseline when flex-direction is row', async () => {
@@ -207,7 +207,7 @@ describe('flexbox align-items', () => {
     child3.appendChild(text3);
     container.appendChild(child3);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('should work with flex-start when flex-direction is column', async () => {
@@ -247,7 +247,7 @@ describe('flexbox align-items', () => {
     });
     container.appendChild(child3);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('should work with flex-end when flex-direction is column', async () => {
@@ -287,7 +287,7 @@ describe('flexbox align-items', () => {
     });
     container.appendChild(child3);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('should work with center when flex-direction is column', async () => {
@@ -327,7 +327,7 @@ describe('flexbox align-items', () => {
     });
     container.appendChild(child3);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('should work with stretch when flex-direction is column', async () => {
@@ -367,6 +367,6 @@ describe('flexbox align-items', () => {
     });
     container.appendChild(child3);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-flexbox/anonymous-flex.ts
+++ b/integration_tests/specs/css/css-flexbox/anonymous-flex.ts
@@ -38,7 +38,7 @@ describe('anonymous-flex', () => {
 
     spanRemove.remove();
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('item-002', async () => {
     let p;
@@ -74,7 +74,7 @@ describe('anonymous-flex', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('item-003', async () => {
     let p;
@@ -112,7 +112,7 @@ describe('anonymous-flex', () => {
 
     document.body.offsetTop;
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('item-004', async () => {
     let p;
@@ -153,7 +153,7 @@ describe('anonymous-flex', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('item-005', async () => {
     let p;
@@ -204,7 +204,7 @@ describe('anonymous-flex', () => {
     // absSpan.style.position = "absolute";
     // absSpan.style.display = "inline";
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('item-006', async () => {
     let p;
@@ -261,6 +261,6 @@ describe('anonymous-flex', () => {
 
     spanRemove.parentNode.removeChild(spanRemove);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-flexbox/auto-height.ts
+++ b/integration_tests/specs/css/css-flexbox/auto-height.ts
@@ -47,7 +47,7 @@ describe('auto-height', () => {
     );
     BODY.appendChild(flexbox);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it("with flex", async () => {
@@ -88,6 +88,6 @@ describe('auto-height', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-flexbox/auto-margins.ts
+++ b/integration_tests/specs/css/css-flexbox/auto-margins.ts
@@ -67,9 +67,9 @@ describe('auto-margins', () => {
     BODY.appendChild(div_1);
 
     img.onload = async () => {
-      await matchViewportSnapshot();
+      await snapshot();
       done();
     };
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-flexbox/css-box.ts
+++ b/integration_tests/specs/css/css-flexbox/css-box.ts
@@ -111,6 +111,6 @@ describe('css-box', () => {
     BODY.appendChild(p);
     BODY.appendChild(flexbox);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-flexbox/css-flexbox.ts
+++ b/integration_tests/specs/css/css-flexbox/css-flexbox.ts
@@ -60,7 +60,7 @@ describe('css-flexbox', () => {
     BODY.appendChild(p);
     BODY.appendChild(flexbox);
 
-    await matchViewportSnapshot(0.5);
+    await snapshot(0.5);
   });
   it('row-ref', async () => {
     let p;
@@ -140,7 +140,7 @@ describe('css-flexbox', () => {
     BODY.appendChild(p);
     BODY.appendChild(container);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('img-expand-evenly-ref', async () => {
@@ -202,6 +202,6 @@ describe('css-flexbox', () => {
     BODY.appendChild(p);
     BODY.appendChild(flexbox);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-flexbox/display-flex.ts
+++ b/integration_tests/specs/css/css-flexbox/display-flex.ts
@@ -46,6 +46,6 @@ describe('display-flex', () => {
     BODY.appendChild(p);
     BODY.appendChild(flexbox);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-flexbox/dynamic-bsize.ts
+++ b/integration_tests/specs/css/css-flexbox/dynamic-bsize.ts
@@ -40,7 +40,7 @@ describe('dynamic-bsize', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('change', async () => {
     let myHeightChanges;
@@ -82,10 +82,10 @@ describe('dynamic-bsize', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
 
     myHeightChanges.style.height = '200px';
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-flexbox/dynamic-change.ts
+++ b/integration_tests/specs/css/css-flexbox/dynamic-change.ts
@@ -42,9 +42,9 @@ describe('dynamic-change', () => {
     // document.body.offsetTop;
     // document.getElementById('target').style.width = '1px';
 
-    await matchViewportSnapshot();
+    await snapshot();
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('simplified-layout', async () => {
     let child;
@@ -112,12 +112,12 @@ describe('dynamic-change', () => {
       ]
     );
     BODY.appendChild(div);
-    await matchViewportSnapshot();
+    await snapshot();
 
     it2.style.width = '50px';
     flex.style.top = '0px';
     child.style.top = '1px';
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-flexbox/fit-content.ts
+++ b/integration_tests/specs/css/css-flexbox/fit-content.ts
@@ -51,7 +51,7 @@ describe('fit-content', () => {
     );
     BODY.appendChild(flexbox);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('item-002', async () => {
     let p;
@@ -98,6 +98,6 @@ describe('fit-content', () => {
     BODY.appendChild(p);
     BODY.appendChild(flexbox);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-flexbox/flex-align.ts
+++ b/integration_tests/specs/css/css-flexbox/flex-align.ts
@@ -79,7 +79,7 @@ describe('flex-align', () => {
     BODY.appendChild(failFlag);
     BODY.appendChild(container);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('item-center space-around', async () => {
@@ -201,7 +201,7 @@ describe('flex-align', () => {
     BODY.appendChild(failFlag);
     BODY.appendChild(container);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('align-items start', async () => {
@@ -323,7 +323,7 @@ describe('flex-align', () => {
     BODY.appendChild(failFlag);
     BODY.appendChild(container);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('align-items flex-end', async () => {
@@ -445,6 +445,6 @@ describe('flex-align', () => {
     BODY.appendChild(failFlag);
     BODY.appendChild(container);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-flexbox/flex-aspect.ts
+++ b/integration_tests/specs/css/css-flexbox/flex-aspect.ts
@@ -42,7 +42,7 @@ describe('flex-aspect', () => {
     BODY.appendChild(referenceOverlappedRed);
     BODY.appendChild(constrainedFlex);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('ratio-img-column-002', async () => {
     let referenceOverlappedRed;
@@ -87,7 +87,7 @@ describe('flex-aspect', () => {
     BODY.appendChild(constrainedFlex);
 
     await sleep(0.1);
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('ratio-img-column-003', async () => {
     let testFlexItemOverlappingGreen;
@@ -118,7 +118,7 @@ describe('flex-aspect', () => {
     );
     BODY.appendChild(constrainedFlex);
     await sleep(0.5);
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('ratio-img-column-004', async () => {
     let flex;
@@ -156,7 +156,7 @@ describe('flex-aspect', () => {
     );
     BODY.appendChild(flex);
     await sleep(0.1);
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('ratio-img-column-005', async () => {
     let flex;
@@ -185,7 +185,7 @@ describe('flex-aspect', () => {
     );
     BODY.appendChild(flex);
     await sleep(0.1);
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('ratio-img-column-008', async () => {
     let referenceOverlappedRed;
@@ -240,7 +240,7 @@ describe('flex-aspect', () => {
     BODY.appendChild(div);
     BODY.appendChild(flex);
     await sleep(0.1);
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('ratio-img-row-001', async () => {
     let referenceOverlappedRed;
@@ -281,7 +281,7 @@ describe('flex-aspect', () => {
     BODY.appendChild(referenceOverlappedRed);
     BODY.appendChild(constrainedFlex);
     await sleep(0.1);
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('ratio-img-row-002', async () => {
     let referenceOverlappedRed;
@@ -322,7 +322,7 @@ describe('flex-aspect', () => {
     BODY.appendChild(referenceOverlappedRed);
     BODY.appendChild(constrainedFlex);
     await sleep(0.1);
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('ratio-img-row-003', async () => {
     let referenceOverlappedRed;
@@ -363,6 +363,6 @@ describe('flex-aspect', () => {
     BODY.appendChild(referenceOverlappedRed);
     BODY.appendChild(constrainedFlex);
     await sleep(0.1);
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-flexbox/flex-basis.ts
+++ b/integration_tests/specs/css/css-flexbox/flex-basis.ts
@@ -62,7 +62,7 @@ describe('flex-basis', () => {
     BODY.appendChild(p);
     BODY.appendChild(container);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('002', async () => {
     let p;
@@ -138,7 +138,7 @@ describe('flex-basis', () => {
     BODY.appendChild(container);
     BODY.appendChild(cover);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('003', async () => {
     let p;
@@ -214,7 +214,7 @@ describe('flex-basis', () => {
     BODY.appendChild(container);
     BODY.appendChild(cover);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('004', async () => {
     let p;
@@ -292,7 +292,7 @@ describe('flex-basis', () => {
     BODY.appendChild(container);
     BODY.appendChild(cover);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('005', async () => {
     let p;
@@ -347,7 +347,7 @@ describe('flex-basis', () => {
     BODY.appendChild(p);
     BODY.appendChild(container);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('007', async () => {
     let p;
@@ -412,7 +412,7 @@ describe('flex-basis', () => {
     BODY.appendChild(p);
     BODY.appendChild(container);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('item-margins-001', async () => {
     let p;
@@ -501,6 +501,6 @@ describe('flex-basis', () => {
     BODY.appendChild(referenceOverlappedRed);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-flexbox/flex-container.ts
+++ b/integration_tests/specs/css/css-flexbox/flex-container.ts
@@ -51,6 +51,6 @@ describe('flex-container', () => {
     );
     BODY.appendChild(flexContainer);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-flexbox/flex-direction.ts
+++ b/integration_tests/specs/css/css-flexbox/flex-direction.ts
@@ -74,7 +74,7 @@ describe('flex-direction', () => {
     );
     BODY.appendChild(flexContainer);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('with-element-insert', async () => {
     let flexItem;
@@ -442,7 +442,7 @@ describe('flex-direction', () => {
     BODY.appendChild(flexContainer_2);
     BODY.appendChild(flexContainer_3);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it("column-overlap-001", async () => {
     let p;
@@ -538,7 +538,7 @@ describe('flex-direction', () => {
     BODY.appendChild(p);
     BODY.appendChild(container);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it("row-001-visual", async () => {
@@ -629,7 +629,7 @@ describe('flex-direction', () => {
     BODY.appendChild(test);
 
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it("row-reverse-001-visual", async () => {
     let p;
@@ -719,6 +719,6 @@ describe('flex-direction', () => {
     BODY.appendChild(test);
 
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-flexbox/flex-factor.ts
+++ b/integration_tests/specs/css/css-flexbox/flex-factor.ts
@@ -871,6 +871,6 @@ describe('flex-factor', () => {
     BODY.appendChild(flexbox_20);
     BODY.appendChild(flexbox_21);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-flexbox/flex-flexitem.ts
+++ b/integration_tests/specs/css/css-flexbox/flex-flexitem.ts
@@ -82,7 +82,7 @@ describe('flex-flexitem', () => {
     BODY.appendChild(test);
 
 
-    await matchViewportSnapshot();
+    await snapshot();
   })
   it('childmargin-ref', async () => {
     let fixed;
@@ -172,7 +172,7 @@ describe('flex-flexitem', () => {
     );
     BODY.appendChild(test);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('percentage-prescation-ref', async () => {
     let test;
@@ -241,7 +241,7 @@ describe('flex-flexitem', () => {
     );
     BODY.appendChild(test_1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it("percentage-prescation", async () => {
     let test;
@@ -289,6 +289,6 @@ describe('flex-flexitem', () => {
     BODY.appendChild(test);
 
 
-    await matchViewportSnapshot();
+    await snapshot();
   })
 });

--- a/integration_tests/specs/css/css-flexbox/flex-flow.ts
+++ b/integration_tests/specs/css/css-flexbox/flex-flow.ts
@@ -45,7 +45,7 @@ describe('flexbox flex-flow', () => {
     );
 
     document.body.appendChild(container);
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('should work with wrap column', async () => {
@@ -94,7 +94,7 @@ describe('flexbox flex-flow', () => {
     );
 
     document.body.appendChild(container);
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('should work with row', async () => {
@@ -143,7 +143,7 @@ describe('flexbox flex-flow', () => {
     );
 
     document.body.appendChild(container);
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('should work with column', async () => {
@@ -192,7 +192,7 @@ describe('flexbox flex-flow', () => {
     );
 
     document.body.appendChild(container);
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it("001", async () => {
@@ -277,7 +277,7 @@ describe('flexbox flex-flow', () => {
     BODY.appendChild(test);
 
 
-    await matchViewportSnapshot();
+    await snapshot();
   })
   it("002", async () => {
     let p;
@@ -372,7 +372,7 @@ describe('flexbox flex-flow', () => {
     BODY.appendChild(test);
 
 
-    await matchViewportSnapshot();
+    await snapshot();
   })
   it("003", async () => {
     let p;
@@ -467,7 +467,7 @@ describe('flexbox flex-flow', () => {
     BODY.appendChild(test);
 
 
-    await matchViewportSnapshot();
+    await snapshot();
   })
   it("004", async () => {
     let p;
@@ -551,7 +551,7 @@ describe('flexbox flex-flow', () => {
     BODY.appendChild(test);
 
 
-    await matchViewportSnapshot();
+    await snapshot();
   })
   it("005", async () => {
     let p;
@@ -646,7 +646,7 @@ describe('flexbox flex-flow', () => {
     BODY.appendChild(test);
 
 
-    await matchViewportSnapshot();
+    await snapshot();
   })
   it("006", async () => {
     let p;
@@ -741,7 +741,7 @@ describe('flexbox flex-flow', () => {
     BODY.appendChild(test);
 
 
-    await matchViewportSnapshot();
+    await snapshot();
   })
   it("007-ref", async () => {
     let p;
@@ -817,7 +817,7 @@ describe('flexbox flex-flow', () => {
     BODY.appendChild(div_3);
 
 
-    await matchViewportSnapshot();
+    await snapshot();
   })
   it("007", async () => {
     let p;
@@ -899,7 +899,7 @@ describe('flexbox flex-flow', () => {
     BODY.appendChild(test);
 
 
-    await matchViewportSnapshot();
+    await snapshot();
   })
   it("008", async () => {
     let p;
@@ -994,7 +994,7 @@ describe('flexbox flex-flow', () => {
     BODY.appendChild(test);
 
 
-    await matchViewportSnapshot();
+    await snapshot();
   })
   it("009", async () => {
     let p;
@@ -1089,7 +1089,7 @@ describe('flexbox flex-flow', () => {
     BODY.appendChild(test);
 
 
-    await matchViewportSnapshot();
+    await snapshot();
   })
   it("010", async () => {
     let p;
@@ -1171,7 +1171,7 @@ describe('flexbox flex-flow', () => {
     BODY.appendChild(test);
 
 
-    await matchViewportSnapshot();
+    await snapshot();
   })
   it("011", async () => {
     let p;
@@ -1266,7 +1266,7 @@ describe('flexbox flex-flow', () => {
     BODY.appendChild(test);
 
 
-    await matchViewportSnapshot();
+    await snapshot();
   })
   it("012", async () => {
     let p;
@@ -1361,6 +1361,6 @@ describe('flexbox flex-flow', () => {
     BODY.appendChild(test);
 
 
-    await matchViewportSnapshot();
+    await snapshot();
   })
 });

--- a/integration_tests/specs/css/css-flexbox/flex-grow.ts
+++ b/integration_tests/specs/css/css-flexbox/flex-grow.ts
@@ -87,7 +87,7 @@ describe('flex-grow', () => {
     BODY.appendChild(container);
     BODY.appendChild(cover);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('003', async () => {
     let p;
@@ -166,7 +166,7 @@ describe('flex-grow', () => {
     BODY.appendChild(container);
     BODY.appendChild(cover);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('001', async () => {
     let child1;
@@ -217,7 +217,7 @@ describe('flex-grow', () => {
     );
     BODY.appendChild(container);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('004', async () => {
     let p;
@@ -295,7 +295,7 @@ describe('flex-grow', () => {
     BODY.appendChild(container);
     BODY.appendChild(cover);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('005', async () => {
     let p;
@@ -369,7 +369,7 @@ describe('flex-grow', () => {
     BODY.appendChild(container);
     BODY.appendChild(cover);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('006', async () => {
     let p;
@@ -452,7 +452,7 @@ describe('flex-grow', () => {
     BODY.appendChild(container);
     BODY.appendChild(container_1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('007', async () => {
     let p;
@@ -566,7 +566,7 @@ describe('flex-grow', () => {
     BODY.appendChild(container);
     BODY.appendChild(container_1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('should work with image load', async () => {
@@ -623,7 +623,7 @@ describe('flex-grow', () => {
       ]
     );
     BODY.appendChild(div);
-    await matchViewportSnapshot(0.1);
+    await snapshot(0.1);
   });
 
   it('should work with flex-item content change', async (done) => {
@@ -659,7 +659,7 @@ describe('flex-grow', () => {
 
     requestAnimationFrame(async () => {
       text.data = 6000;
-      await matchViewportSnapshot(0.1);
+      await snapshot(0.1);
       done();
     });
 

--- a/integration_tests/specs/css/css-flexbox/flex-item.ts
+++ b/integration_tests/specs/css/css-flexbox/flex-item.ts
@@ -171,7 +171,7 @@ describe('flex-item', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it("img-size", async () => {
     let flexItem;
@@ -247,7 +247,7 @@ describe('flex-item', () => {
     BODY.appendChild(div);
 
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('and-percentage-abspos', async () => {
     let div;
@@ -294,6 +294,6 @@ describe('flex-item', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-flexbox/flex-items.ts
+++ b/integration_tests/specs/css/css-flexbox/flex-items.ts
@@ -80,7 +80,7 @@ describe('flex-items', () => {
     BODY.appendChild(failFlag);
     BODY.appendChild(container);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('works with multiple relative item', async () => {
@@ -116,7 +116,7 @@ describe('flex-items', () => {
      );
     BODY.appendChild(n1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('childmargin', async () => {
@@ -199,6 +199,6 @@ describe('flex-items', () => {
       ]
     );
     BODY.appendChild(test);
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-flexbox/flex-margin.ts
+++ b/integration_tests/specs/css/css-flexbox/flex-margin.ts
@@ -73,6 +73,6 @@ describe('flex-margin', () => {
     BODY.appendChild(redBox);
     BODY.appendChild(container);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-flexbox/flex-minimum.ts
+++ b/integration_tests/specs/css/css-flexbox/flex-minimum.ts
@@ -52,7 +52,7 @@ describe('flex-minimum', () => {
     BODY.appendChild(referenceOverlappedRed);
     BODY.appendChild(constrainedFlex);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('height-flex-items-002', async () => {
     let referenceOverlappedRed;
@@ -105,7 +105,7 @@ describe('flex-minimum', () => {
     BODY.appendChild(referenceOverlappedRed);
     BODY.appendChild(constrainedFlex);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('height-flex-items-003', async () => {
     let p;
@@ -182,7 +182,7 @@ describe('flex-minimum', () => {
     BODY.appendChild(referenceOverlappedRed);
     BODY.appendChild(constrainedFlex);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('height-flex-items-004', async () => {
     let referenceOverlappedRed;
@@ -220,7 +220,7 @@ describe('flex-minimum', () => {
     BODY.appendChild(referenceOverlappedRed);
     BODY.appendChild(constrainedFlex);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('height-flex-items-005', async () => {
     let referenceOverlappedRed;
@@ -262,7 +262,7 @@ describe('flex-minimum', () => {
     BODY.appendChild(referenceOverlappedRed);
     BODY.appendChild(constrainedFlex);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('height-flex-items-006', async () => {
     let referenceOverlappedRed;
@@ -304,7 +304,7 @@ describe('flex-minimum', () => {
     BODY.appendChild(referenceOverlappedRed);
     BODY.appendChild(constrainedFlex);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('height-flex-items-007', async () => {
     let p;
@@ -366,7 +366,7 @@ describe('flex-minimum', () => {
     BODY.appendChild(referenceOverlappedRed);
     BODY.appendChild(constrainedFlex);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('height-flex-items-008', async () => {
     let p;
@@ -428,7 +428,7 @@ describe('flex-minimum', () => {
     BODY.appendChild(referenceOverlappedRed);
     BODY.appendChild(constrainedFlex);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('height-flex-items-009', async () => {
     let p;
@@ -649,7 +649,7 @@ describe('flex-minimum', () => {
     //   checkLayout('.container');
     // }
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit("width-flex-items-001", async () => {
     let p;
@@ -716,7 +716,7 @@ describe('flex-minimum', () => {
     BODY.appendChild(constrainedFlex);
 
 
-    await matchViewportSnapshot();
+    await snapshot();
   })
   xit("width-flex-items-002", async () => {
     let p;
@@ -790,7 +790,7 @@ describe('flex-minimum', () => {
     BODY.appendChild(constrainedFlex);
 
 
-    await matchViewportSnapshot();
+    await snapshot();
   })
   xit("width-flex-items-003", async () => {
     let p;
@@ -858,7 +858,7 @@ describe('flex-minimum', () => {
     BODY.appendChild(constrainedFlex);
 
 
-    await matchViewportSnapshot();
+    await snapshot();
   })
 
   xit("width-flex-items-004", async () => {
@@ -917,7 +917,7 @@ describe('flex-minimum', () => {
     BODY.appendChild(constrainedFlex);
 
 
-    await matchViewportSnapshot();
+    await snapshot();
   })
   xit("width-flex-items-005", async () => {
     let p;
@@ -978,7 +978,7 @@ describe('flex-minimum', () => {
     BODY.appendChild(constrainedFlex);
 
 
-    await matchViewportSnapshot();
+    await snapshot();
   })
   xit("width-flex-items-006", async () => {
     let p;
@@ -1040,7 +1040,7 @@ describe('flex-minimum', () => {
     BODY.appendChild(constrainedFlex);
 
 
-    await matchViewportSnapshot();
+    await snapshot();
   })
   xit("width-flex-items-007", async () => {
     let p;
@@ -1101,7 +1101,7 @@ describe('flex-minimum', () => {
     BODY.appendChild(constrainedFlex);
 
 
-    await matchViewportSnapshot();
+    await snapshot();
   })
   xit("width-flex-items-008", async () => {
     let p;
@@ -1163,7 +1163,7 @@ describe('flex-minimum', () => {
     BODY.appendChild(constrainedFlex);
 
 
-    await matchViewportSnapshot();
+    await snapshot();
   })
   xit("width-flex-items-009", async () => {
     let p;
@@ -1228,7 +1228,7 @@ describe('flex-minimum', () => {
     BODY.appendChild(constrainedFlex);
 
 
-    await matchViewportSnapshot();
+    await snapshot();
   })
   xit("width-flex-items-010", async () => {
     let p;
@@ -1294,7 +1294,7 @@ describe('flex-minimum', () => {
     BODY.appendChild(constrainedFlex);
 
 
-    await matchViewportSnapshot();
+    await snapshot();
   })
   it("width-flex-items-011", async () => {
     let p;
@@ -1342,7 +1342,7 @@ describe('flex-minimum', () => {
     BODY.appendChild(div_1);
 
 
-    await matchViewportSnapshot(0.1);
+    await snapshot(0.1);
   })
   it("width-flex-items-012", async () => {
     let p;
@@ -1391,7 +1391,7 @@ describe('flex-minimum', () => {
     BODY.appendChild(div_1);
 
 
-    await matchViewportSnapshot(0.1);
+    await snapshot(0.1);
   })
   xit("width-flex-items-013", async () => {
     let p;
@@ -1465,6 +1465,6 @@ describe('flex-minimum', () => {
     BODY.appendChild(div_1);
 
 
-    await matchViewportSnapshot();
+    await snapshot();
   })
 });

--- a/integration_tests/specs/css/css-flexbox/flex-shrink.ts
+++ b/integration_tests/specs/css/css-flexbox/flex-shrink.ts
@@ -76,7 +76,7 @@ describe('flex-shrink', () => {
     BODY.appendChild(container);
     BODY.appendChild(cover);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('002', async () => {
     let p;
@@ -154,7 +154,7 @@ describe('flex-shrink', () => {
     BODY.appendChild(container);
     BODY.appendChild(cover);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('003', async () => {
     let p;
@@ -231,7 +231,7 @@ describe('flex-shrink', () => {
     BODY.appendChild(container);
     BODY.appendChild(cover);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('004', async () => {
     let p;
@@ -311,7 +311,7 @@ describe('flex-shrink', () => {
     BODY.appendChild(container);
     BODY.appendChild(cover);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('005', async () => {
     let p;
@@ -389,7 +389,7 @@ describe('flex-shrink', () => {
     BODY.appendChild(container);
     BODY.appendChild(cover);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('006', async () => {
     let p;
@@ -475,7 +475,7 @@ describe('flex-shrink', () => {
     BODY.appendChild(p);
     BODY.appendChild(container);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('007', async () => {
     let p;
@@ -552,7 +552,7 @@ describe('flex-shrink', () => {
     BODY.appendChild(container);
     BODY.appendChild(cover);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('008', async () => {
     let p;
@@ -666,6 +666,6 @@ describe('flex-shrink', () => {
     BODY.appendChild(container);
     BODY.appendChild(container_1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-flexbox/flex-wrap.ts
+++ b/integration_tests/specs/css/css-flexbox/flex-wrap.ts
@@ -148,7 +148,7 @@ describe('flex-wrap', () => {
     BODY.appendChild(div);
     BODY.appendChild(div_1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('003', async () => {
     let p;
@@ -251,7 +251,7 @@ describe('flex-wrap', () => {
     BODY.appendChild(div);
     BODY.appendChild(div_1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('004', async () => {
     let p;
@@ -355,7 +355,7 @@ describe('flex-wrap', () => {
     BODY.appendChild(div);
     BODY.appendChild(div_1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('005', async () => {
     let p;
@@ -461,6 +461,6 @@ describe('flex-wrap', () => {
     BODY.appendChild(div);
     BODY.appendChild(div_1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-flexbox/flex.ts
+++ b/integration_tests/specs/css/css-flexbox/flex.ts
@@ -53,7 +53,7 @@ describe('flex', () => {
     BODY.appendChild(p);
     BODY.appendChild(flexbox);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('002', async () => {
     let p;
@@ -134,7 +134,7 @@ describe('flex', () => {
     BODY.appendChild(ref1);
     BODY.appendChild(ref2);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('003', async () => {
     let p;
@@ -216,7 +216,7 @@ describe('flex', () => {
     BODY.appendChild(ref1);
     BODY.appendChild(ref2);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('004', async () => {
     let p;
@@ -298,7 +298,7 @@ describe('flex', () => {
     BODY.appendChild(ref1);
     BODY.appendChild(ref2);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('direction', async () => {
     let flexItem;
@@ -574,7 +574,7 @@ describe('flex', () => {
     BODY.appendChild(flexContainer_2);
     BODY.appendChild(flexContainer_3);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('direction_column', async () => {
     let test01;
@@ -644,7 +644,7 @@ describe('flex', () => {
     );
     BODY.appendChild(test);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('direction_row', async () => {
     let test01;
@@ -714,7 +714,7 @@ describe('flex', () => {
     );
     BODY.appendChild(test);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('should work with initial', async () => {
@@ -759,7 +759,7 @@ describe('flex', () => {
     );
 
     document.body.appendChild(container);
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('should work with auto', async () => {
@@ -804,7 +804,7 @@ describe('flex', () => {
     );
 
     document.body.appendChild(container);
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('should work with none', async () => {
@@ -849,7 +849,7 @@ describe('flex', () => {
     );
 
     document.body.appendChild(container);
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('flex items with inner padding and no specify width', async () => {
@@ -879,7 +879,7 @@ describe('flex', () => {
       )
     ]);
     BODY.appendChild(container);
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it("column flex child with overflow scroll", async () => {
@@ -980,7 +980,7 @@ describe('flex', () => {
     BODY.appendChild(flexbox);
     BODY.appendChild(flexbox_1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('change from not none to none', async (done) => {
@@ -1009,11 +1009,11 @@ describe('flex', () => {
     );
     append(BODY, cont);
 
-    await matchViewportSnapshot();
+    await snapshot();
 
     requestAnimationFrame(async () => {
       item.style.flex = 'none';
-      await matchViewportSnapshot(0.1);
+      await snapshot(0.1);
       done();
     });
   });

--- a/integration_tests/specs/css/css-flexbox/flex_basis.ts
+++ b/integration_tests/specs/css/css-flexbox/flex_basis.ts
@@ -33,7 +33,7 @@ describe('flexbox flex-basis', () => {
     child3.appendChild(document.createTextNode('Item Three'));
     container1.appendChild(child3);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('should work with width', async () => {
@@ -71,6 +71,6 @@ describe('flexbox flex-basis', () => {
     child3.appendChild(document.createTextNode('Item Three'));
     container1.appendChild(child3);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-flexbox/flex_direction.ts
+++ b/integration_tests/specs/css/css-flexbox/flex_direction.ts
@@ -26,7 +26,7 @@ describe('flexbox flex-direction', () => {
       backgroundColor: 'red',
     });
     container.appendChild(child2);
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('should work with column', async () => {
@@ -56,6 +56,6 @@ describe('flexbox flex-direction', () => {
       backgroundColor: 'red',
     });
     container2.appendChild(child4);
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-flexbox/flex_grow.ts
+++ b/integration_tests/specs/css/css-flexbox/flex_grow.ts
@@ -48,7 +48,7 @@ describe('flexbox flex-grow', () => {
     );
     BODY.appendChild(container);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('002', async () => {
     let test1;
@@ -113,7 +113,7 @@ describe('flexbox flex-grow', () => {
     BODY.appendChild(container);
     BODY.appendChild(cover);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('003', async () => {
     let test1;
@@ -169,7 +169,7 @@ describe('flexbox flex-grow', () => {
     BODY.appendChild(container);
     BODY.appendChild(cover);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('004', async () => {
     let test1;
@@ -224,7 +224,7 @@ describe('flexbox flex-grow', () => {
     BODY.appendChild(container);
     BODY.appendChild(cover);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('005', async () => {
     let container;
@@ -275,7 +275,7 @@ describe('flexbox flex-grow', () => {
     BODY.appendChild(container);
     BODY.appendChild(cover);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('006', async () => {
     let test1;
@@ -335,7 +335,7 @@ describe('flexbox flex-grow', () => {
     BODY.appendChild(container);
     BODY.appendChild(container_1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('007', async () => {
     let test1;
@@ -426,7 +426,7 @@ describe('flexbox flex-grow', () => {
     BODY.appendChild(container);
     BODY.appendChild(container_1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('010', async () => {
     let test;
@@ -492,7 +492,7 @@ describe('flexbox flex-grow', () => {
       ]
     );
     BODY.appendChild(test);
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('should work when flex-direction is row', async () => {
     const container1 = document.createElement('div');
@@ -529,7 +529,7 @@ describe('flexbox flex-grow', () => {
     child3.appendChild(document.createTextNode('flex-grow: 1'));
     container1.appendChild(child3);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('should work when flex-direction is column', async () => {
@@ -567,7 +567,7 @@ describe('flexbox flex-grow', () => {
     child6.appendChild(document.createTextNode('flex-grow: 1'));
     container2.appendChild(child6);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('should work with multiple flex container', async () => {
     let container;
@@ -598,7 +598,7 @@ describe('flexbox flex-grow', () => {
     );
 
     BODY.appendChild(container);
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('should work with flex item of margin and not width when flex-direction is row', async () => {
@@ -632,7 +632,7 @@ describe('flexbox flex-grow', () => {
       ]
     );
     BODY.appendChild(containingBlock);
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('should work with flex item of margin and not width when flex-direction is row-reverse', async () => {
@@ -666,7 +666,7 @@ describe('flexbox flex-grow', () => {
       ]
     );
     BODY.appendChild(containingBlock);
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('should work with flex item of margin and not width when flex-direction is column', async () => {
@@ -699,7 +699,7 @@ describe('flexbox flex-grow', () => {
       ]
     );
     BODY.appendChild(containingBlock);
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('should work with flex item of margin and not width when flex-direction is column-reverse', async () => {
@@ -732,7 +732,7 @@ describe('flexbox flex-grow', () => {
       ]
     );
     BODY.appendChild(containingBlock);
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('works with max violation', async () => {
@@ -802,7 +802,7 @@ describe('flexbox flex-grow', () => {
     BODY.appendChild(container);
 
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('works with flex factor sum less than 1', async () => {
@@ -870,6 +870,6 @@ describe('flexbox flex-grow', () => {
     BODY.appendChild(container);
 
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-flexbox/flex_item_height.ts
+++ b/integration_tests/specs/css/css-flexbox/flex_item_height.ts
@@ -50,6 +50,6 @@ describe('flexbox flex-item', () => {
     flex1.appendChild(div3);
     flex1.appendChild(div4);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-flexbox/flex_item_width.ts
+++ b/integration_tests/specs/css/css-flexbox/flex_item_width.ts
@@ -30,6 +30,6 @@ describe('flexbox flex-item', () => {
     flex2.appendChild(div6);
 
     container.appendChild(flex2);
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-flexbox/flex_shrink.ts
+++ b/integration_tests/specs/css/css-flexbox/flex_shrink.ts
@@ -37,7 +37,7 @@ describe('flexbox flex-shrink', () => {
     child3.appendChild(document.createTextNode('flex-shrink: 1'));
     container1.appendChild(child3);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('should work when flex-direction is column', async () => {
@@ -78,7 +78,7 @@ describe('flexbox flex-shrink', () => {
     child6.appendChild(document.createTextNode('flex-shrink: 1'));
     container2.appendChild(child6);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('not shrink no defined size elements', async () => {
     let element = createElement('div', {
@@ -113,7 +113,7 @@ describe('flexbox flex-shrink', () => {
       })
     ]);
     BODY.appendChild(element);
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('scrollable height auto computed by flex container', async (done) => {
@@ -149,11 +149,11 @@ describe('flexbox flex-shrink', () => {
 
     BODY.appendChild(container);
 
-    await matchViewportSnapshot();
+    await snapshot();
 
     requestAnimationFrame(async () => {
       scroller.scrollTop = 400;
-      await matchViewportSnapshot();
+      await snapshot();
       done();
     });
   });
@@ -181,7 +181,7 @@ describe('flexbox flex-shrink', () => {
     );
     BODY.appendChild(constrainedFlex);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('should work with intrinsic element with min-height', async () => {
@@ -210,7 +210,7 @@ describe('flexbox flex-shrink', () => {
     );
     BODY.appendChild(constrainedFlex);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('should work with intrinsic element with width and no height', async () => {
@@ -239,7 +239,7 @@ describe('flexbox flex-shrink', () => {
     );
     BODY.appendChild(constrainedFlex);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('should work with flex layout in the column direction with children and height is not larger than children height', async () => {
@@ -284,7 +284,7 @@ describe('flexbox flex-shrink', () => {
     );
     BODY.appendChild(constrainedFlex);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('should work with flex layout in the column direction with children and height is larger than children height', async () => {
@@ -329,7 +329,7 @@ describe('flexbox flex-shrink', () => {
     );
     BODY.appendChild(constrainedFlex);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('should work with flex layout in the column direction with children and min-height', async () => {
@@ -375,7 +375,7 @@ describe('flexbox flex-shrink', () => {
     );
     BODY.appendChild(constrainedFlex);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('should work with flex layout in the row direction with children and height is not larger than children height', async () => {
@@ -426,7 +426,7 @@ describe('flexbox flex-shrink', () => {
     );
     BODY.appendChild(constrainedFlex);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('should work with flex layout in the row direction with children and height is larger than children height', async () => {
@@ -477,7 +477,7 @@ describe('flexbox flex-shrink', () => {
     );
     BODY.appendChild(constrainedFlex);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('should work with flex layout in the row direction with children and min-height', async () => {
@@ -529,7 +529,7 @@ describe('flexbox flex-shrink', () => {
     );
     BODY.appendChild(constrainedFlex);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('should work with flow layout with children and height is not larger than children height', async () => {
@@ -572,7 +572,7 @@ describe('flexbox flex-shrink', () => {
     );
     BODY.appendChild(constrainedFlex);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('should work with flow layout with children and height is larger than children height', async () => {
@@ -615,7 +615,7 @@ describe('flexbox flex-shrink', () => {
     );
     BODY.appendChild(constrainedFlex);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('should work with flow layout with children and min-height', async () => {
@@ -659,7 +659,7 @@ describe('flexbox flex-shrink', () => {
     );
     BODY.appendChild(constrainedFlex);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('works with min violation', async () => {
@@ -726,7 +726,7 @@ describe('flexbox flex-shrink', () => {
     BODY.appendChild(container);
 
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('works with flex factor sum less than 1', async () => {
@@ -794,6 +794,6 @@ describe('flexbox flex-shrink', () => {
     BODY.appendChild(container);
 
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-flexbox/flex_wrap.ts
+++ b/integration_tests/specs/css/css-flexbox/flex_wrap.ts
@@ -46,7 +46,7 @@ describe('flexbox flex-wrap', () => {
     );
 
     document.body.appendChild(container);
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('should work with nowrap', async () => {
@@ -96,7 +96,7 @@ describe('flexbox flex-wrap', () => {
     );
 
     document.body.appendChild(container);
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('should work with wrap-reverse', async () => {
@@ -146,7 +146,7 @@ describe('flexbox flex-wrap', () => {
     );
 
     document.body.appendChild(container);
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it("should work with wrap when flex-direction is column and height not exists", async () => {
@@ -187,7 +187,7 @@ describe('flexbox flex-wrap', () => {
     );
     BODY.appendChild(flexbox_1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it("should work with wrap when flex-direction is column and height is smaller than children's height", async () => {
@@ -229,6 +229,6 @@ describe('flexbox flex-wrap', () => {
     );
     BODY.appendChild(flexbox_1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-flexbox/flexbox-flex.ts
+++ b/integration_tests/specs/css/css-flexbox/flexbox-flex.ts
@@ -48,7 +48,7 @@ describe('flexbox-flex', () => {
     BODY.appendChild(p);
     BODY.appendChild(flexWrapper);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('wrap-flexing-ref', async () => {
     let p;
@@ -74,7 +74,7 @@ describe('flexbox-flex', () => {
     BODY.appendChild(p);
     BODY.appendChild(container);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('wrap-flexing', async () => {
     let p;
@@ -131,7 +131,7 @@ describe('flexbox-flex', () => {
     BODY.appendChild(p);
     BODY.appendChild(container);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('wrap-nowrap', async () => {
     let p;
@@ -182,6 +182,6 @@ describe('flexbox-flex', () => {
     BODY.appendChild(p);
     BODY.appendChild(flexWrapper);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-flexbox/flexbox_align-content.ts
+++ b/integration_tests/specs/css/css-flexbox/flexbox_align-content.ts
@@ -68,7 +68,7 @@ describe('flexbox_align-content', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('center', async () => {
     let div;
@@ -137,7 +137,7 @@ describe('flexbox_align-content', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('flexend-ref', async () => {
     let div;
@@ -207,7 +207,7 @@ describe('flexbox_align-content', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('flexend', async () => {
     let div;
@@ -276,7 +276,7 @@ describe('flexbox_align-content', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('flexstart-ref', async () => {
     let div;
@@ -346,7 +346,7 @@ describe('flexbox_align-content', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('flexstart', async () => {
     let div;
@@ -415,7 +415,7 @@ describe('flexbox_align-content', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('spacearound-ref', async () => {
     let div;
@@ -485,7 +485,7 @@ describe('flexbox_align-content', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('spacearound', async () => {
     let div;
@@ -554,7 +554,7 @@ describe('flexbox_align-content', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('spacebetween-ref', async () => {
     let div;
@@ -624,7 +624,7 @@ describe('flexbox_align-content', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('spacebetween', async () => {
     let div;
@@ -693,7 +693,7 @@ describe('flexbox_align-content', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('stretch-2-ref', async () => {
     let div;
@@ -763,7 +763,7 @@ describe('flexbox_align-content', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('stretch-2', async () => {
     let div;
@@ -829,7 +829,7 @@ describe('flexbox_align-content', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('stretch-ref', async () => {
     let div;
@@ -899,7 +899,7 @@ describe('flexbox_align-content', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('stretch', async () => {
     let div;
@@ -968,6 +968,6 @@ describe('flexbox_align-content', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-flexbox/flexbox_align-items.ts
+++ b/integration_tests/specs/css/css-flexbox/flexbox_align-items.ts
@@ -68,7 +68,7 @@ describe('flexbox_align-items', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('baseline', async () => {
     let div;
@@ -137,7 +137,7 @@ describe('flexbox_align-items', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('center-2-ref', async () => {
     let div;
@@ -207,7 +207,7 @@ describe('flexbox_align-items', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('center-2', async () => {
     let div;
@@ -275,7 +275,7 @@ describe('flexbox_align-items', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('center-ref', async () => {
     let div;
@@ -345,7 +345,7 @@ describe('flexbox_align-items', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('center', async () => {
     let div;
@@ -413,7 +413,7 @@ describe('flexbox_align-items', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('flexend-2-ref', async () => {
     let div;
@@ -482,7 +482,7 @@ describe('flexbox_align-items', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('flexend-2', async () => {
     let div;
@@ -549,7 +549,7 @@ describe('flexbox_align-items', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('flexend-ref', async () => {
     let div;
@@ -616,7 +616,7 @@ describe('flexbox_align-items', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('flexend', async () => {
     let div;
@@ -681,7 +681,7 @@ describe('flexbox_align-items', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('flexstart-2-ref', async () => {
     let div;
@@ -750,7 +750,7 @@ describe('flexbox_align-items', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('flexstart-2', async () => {
     let div;
@@ -817,7 +817,7 @@ describe('flexbox_align-items', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('flexstart-ref', async () => {
     let div;
@@ -884,7 +884,7 @@ describe('flexbox_align-items', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('flexstart', async () => {
     let div;
@@ -949,7 +949,7 @@ describe('flexbox_align-items', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('stretch-2-ref', async () => {
     let div;
@@ -976,7 +976,7 @@ describe('flexbox_align-items', () => {
     BODY.appendChild(div);
     BODY.appendChild(span);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('stretch-2', async () => {
     let div;
@@ -1031,7 +1031,7 @@ describe('flexbox_align-items', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('stretch-ref', async () => {
     let div;
@@ -1104,7 +1104,7 @@ describe('flexbox_align-items', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('stretch', async () => {
     let div;
@@ -1170,6 +1170,6 @@ describe('flexbox_align-items', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-flexbox/flexbox_align-self.ts
+++ b/integration_tests/specs/css/css-flexbox/flexbox_align-self.ts
@@ -65,7 +65,7 @@ describe('flexbox_align-self', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('auto', async () => {
     let div;
@@ -131,7 +131,7 @@ describe('flexbox_align-self', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('baseline-ref', async () => {
     let div;
@@ -201,7 +201,7 @@ describe('flexbox_align-self', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('baseline', async () => {
     let div;
@@ -270,7 +270,7 @@ describe('flexbox_align-self', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('center-ref', async () => {
     let div;
@@ -338,7 +338,7 @@ describe('flexbox_align-self', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('center', async () => {
     let div;
@@ -405,7 +405,7 @@ describe('flexbox_align-self', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('flexend-ref', async () => {
     let div;
@@ -473,7 +473,7 @@ describe('flexbox_align-self', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('flexend', async () => {
     let div;
@@ -539,7 +539,7 @@ describe('flexbox_align-self', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('flexstart-ref', async () => {
     let div;
@@ -607,7 +607,7 @@ describe('flexbox_align-self', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('flexstart', async () => {
     let div;
@@ -673,7 +673,7 @@ describe('flexbox_align-self', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('stretch-ref', async () => {
     let div;
@@ -743,7 +743,7 @@ describe('flexbox_align-self', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('stretch', async () => {
     let div;
@@ -812,6 +812,6 @@ describe('flexbox_align-self', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-flexbox/flexbox_box-clear.ts
+++ b/integration_tests/specs/css/css-flexbox/flexbox_box-clear.ts
@@ -45,6 +45,6 @@ describe('flexbox_box-clear', () => {
     BODY.appendChild(float);
     BODY.appendChild(flex);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-flexbox/flexbox_direction-column.ts
+++ b/integration_tests/specs/css/css-flexbox/flexbox_direction-column.ts
@@ -72,7 +72,7 @@ describe('flexbox_direction-column', () => {
     BODY.appendChild(div);
 
 
-    await matchViewportSnapshot();
+    await snapshot();
   })
   it('ref', async () => {
     let div;
@@ -143,7 +143,7 @@ describe('flexbox_direction-column', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('reverse-ref', async () => {
     let test;
@@ -216,7 +216,7 @@ describe('flexbox_direction-column', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('reverse', async () => {
     let test;
@@ -291,6 +291,6 @@ describe('flexbox_direction-column', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-flexbox/flexbox_flex-0.ts
+++ b/integration_tests/specs/css/css-flexbox/flexbox_flex-0.ts
@@ -71,7 +71,7 @@ describe('flexbox_flex-0', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('0-0-unitless', async () => {
     let div;
@@ -149,7 +149,7 @@ describe('flexbox_flex-0', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('0-0', async () => {
     let div;
@@ -227,7 +227,7 @@ describe('flexbox_flex-0', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('0-1-unitless-basis', async () => {
     let div;
@@ -305,7 +305,7 @@ describe('flexbox_flex-0', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('0-N-ref', async () => {
     let div;
@@ -382,7 +382,7 @@ describe('flexbox_flex-0', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('0-N-shrink-ref', async () => {
     let div;
@@ -460,7 +460,7 @@ describe('flexbox_flex-0', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('0-N-shrink', async () => {
     let div;
@@ -538,7 +538,7 @@ describe('flexbox_flex-0', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('0-N-unitless-basis', async () => {
     let div;
@@ -616,7 +616,7 @@ describe('flexbox_flex-0', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('0-N', async () => {
     let div;
@@ -694,7 +694,7 @@ describe('flexbox_flex-0', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('0-Npercent-ref', async () => {
     let div;
@@ -771,7 +771,7 @@ describe('flexbox_flex-0', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('0-Npercent-shrink-ref', async () => {
     let div;
@@ -849,7 +849,7 @@ describe('flexbox_flex-0', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('0-auto-ref', async () => {
     let div;
@@ -926,7 +926,7 @@ describe('flexbox_flex-0', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('0-auto-shrink-ref', async () => {
     let div;
@@ -1004,7 +1004,7 @@ describe('flexbox_flex-0', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('0-auto-shrink', async () => {
     let div;
@@ -1082,7 +1082,7 @@ describe('flexbox_flex-0', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('0-auto', async () => {
     let div;
@@ -1160,7 +1160,7 @@ describe('flexbox_flex-0', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('0', async () => {
     let div;
@@ -1238,7 +1238,7 @@ describe('flexbox_flex-0', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('1-0-ref', async () => {
     let div;
@@ -1311,7 +1311,7 @@ describe('flexbox_flex-0', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('1-0-unitless', async () => {
     let div;
@@ -1389,7 +1389,7 @@ describe('flexbox_flex-0', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('1-0', async () => {
     let div;
@@ -1467,7 +1467,7 @@ describe('flexbox_flex-0', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('1-1-unitless-basis', async () => {
     let div;
@@ -1545,7 +1545,7 @@ describe('flexbox_flex-0', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('1-N-ref', async () => {
     let div;
@@ -1622,7 +1622,7 @@ describe('flexbox_flex-0', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('1-N-shrink-ref', async () => {
     let div;
@@ -1699,7 +1699,7 @@ describe('flexbox_flex-0', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('1-N-shrink', async () => {
     let div;
@@ -1777,7 +1777,7 @@ describe('flexbox_flex-0', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('1-N-unitless-basis', async () => {
     let div;
@@ -1855,7 +1855,7 @@ describe('flexbox_flex-0', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('1-N', async () => {
     let div;
@@ -1933,7 +1933,7 @@ describe('flexbox_flex-0', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('1-Npercent-ref', async () => {
     let div;
@@ -2010,7 +2010,7 @@ describe('flexbox_flex-0', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('1-Npercent-shrink-ref', async () => {
     let div;
@@ -2087,7 +2087,7 @@ describe('flexbox_flex-0', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('1-Npercent-shrink', async () => {
     let div;
@@ -2165,7 +2165,7 @@ describe('flexbox_flex-0', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('1-Npercent', async () => {
     let div;
@@ -2243,7 +2243,7 @@ describe('flexbox_flex-0', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('1-auto-ref', async () => {
     let div;
@@ -2320,7 +2320,7 @@ describe('flexbox_flex-0', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('1-auto-shrink-ref', async () => {
     let div;
@@ -2397,7 +2397,7 @@ describe('flexbox_flex-0', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('1-auto-shrink', async () => {
     let div;
@@ -2475,7 +2475,7 @@ describe('flexbox_flex-0', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('1-auto', async () => {
     let div;
@@ -2553,7 +2553,7 @@ describe('flexbox_flex-0', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('1', async () => {
     let div;
@@ -2631,7 +2631,7 @@ describe('flexbox_flex-0', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('N-0-ref', async () => {
     let div;
@@ -2704,7 +2704,7 @@ describe('flexbox_flex-0', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('N-0-unitless', async () => {
     let div;
@@ -2782,7 +2782,7 @@ describe('flexbox_flex-0', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('N-0', async () => {
     let div;
@@ -2860,7 +2860,7 @@ describe('flexbox_flex-0', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('N-N-ref', async () => {
     let div;
@@ -2937,7 +2937,7 @@ describe('flexbox_flex-0', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('N-N-shrink-ref', async () => {
     let div;
@@ -3014,7 +3014,7 @@ describe('flexbox_flex-0', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('N-N-shrink', async () => {
     let div;
@@ -3092,7 +3092,7 @@ describe('flexbox_flex-0', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('N-N', async () => {
     let div;
@@ -3170,7 +3170,7 @@ describe('flexbox_flex-0', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('N-Npercent-ref', async () => {
     let div;
@@ -3247,7 +3247,7 @@ describe('flexbox_flex-0', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('N-Npercent-shrink-ref', async () => {
     let div;
@@ -3324,7 +3324,7 @@ describe('flexbox_flex-0', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('N-Npercent-shrink', async () => {
     let div;
@@ -3402,7 +3402,7 @@ describe('flexbox_flex-0', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('N-Npercent', async () => {
     let div;
@@ -3480,7 +3480,7 @@ describe('flexbox_flex-0', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('N-auto-ref', async () => {
     let div;
@@ -3557,7 +3557,7 @@ describe('flexbox_flex-0', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('N-auto-shrink-ref', async () => {
     let div;
@@ -3633,7 +3633,7 @@ describe('flexbox_flex-0', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('N-auto-shrink', async () => {
     let div;
@@ -3711,7 +3711,7 @@ describe('flexbox_flex-0', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('N-auto', async () => {
     let div;
@@ -3789,7 +3789,7 @@ describe('flexbox_flex-0', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('N', async () => {
     let div;
@@ -3867,7 +3867,7 @@ describe('flexbox_flex-0', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('auto', async () => {
     let div;
@@ -4020,6 +4020,6 @@ describe('flexbox_flex-0', () => {
     BODY.appendChild(div);
     BODY.appendChild(flex);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-flexbox/flexbox_flex-1.ts
+++ b/integration_tests/specs/css/css-flexbox/flexbox_flex-1.ts
@@ -75,7 +75,7 @@ describe('flexbox_flex-1', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('0-0-unitless', async () => {
     let div;
@@ -153,7 +153,7 @@ describe('flexbox_flex-1', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('0-0', async () => {
     let div;
@@ -231,7 +231,7 @@ describe('flexbox_flex-1', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('0-N-ref', async () => {
     let div;
@@ -308,7 +308,7 @@ describe('flexbox_flex-1', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('0-N-shrink-ref', async () => {
     let div;
@@ -386,7 +386,7 @@ describe('flexbox_flex-1', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('0-N-shrink', async () => {
     let div;
@@ -464,7 +464,7 @@ describe('flexbox_flex-1', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('0-N', async () => {
     let div;
@@ -542,7 +542,7 @@ describe('flexbox_flex-1', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('0-Npercent-ref', async () => {
     let div;
@@ -619,7 +619,7 @@ describe('flexbox_flex-1', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('0-Npercent-shrink-ref', async () => {
     let div;
@@ -697,7 +697,7 @@ describe('flexbox_flex-1', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('0-Npercent-shrink', async () => {
     let div;
@@ -775,7 +775,7 @@ describe('flexbox_flex-1', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('0-Npercent', async () => {
     let div;
@@ -853,7 +853,7 @@ describe('flexbox_flex-1', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('0-auto-ref', async () => {
     let div;
@@ -930,7 +930,7 @@ describe('flexbox_flex-1', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('0-auto-shrink-ref', async () => {
     let div;
@@ -1008,7 +1008,7 @@ describe('flexbox_flex-1', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('0-auto-shrink', async () => {
     let div;
@@ -1086,7 +1086,7 @@ describe('flexbox_flex-1', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('0-auto', async () => {
     let div;
@@ -1164,7 +1164,7 @@ describe('flexbox_flex-1', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('0', async () => {
     let div;
@@ -1242,7 +1242,7 @@ describe('flexbox_flex-1', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('1-0-ref', async () => {
     let div;
@@ -1319,7 +1319,7 @@ describe('flexbox_flex-1', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('1-0-unitless', async () => {
     let div;
@@ -1397,7 +1397,7 @@ describe('flexbox_flex-1', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('1-0', async () => {
     let div;
@@ -1475,7 +1475,7 @@ describe('flexbox_flex-1', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('1-N-ref', async () => {
     let div;
@@ -1552,7 +1552,7 @@ describe('flexbox_flex-1', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('1-N-shrink-ref', async () => {
     let div;
@@ -1629,7 +1629,7 @@ describe('flexbox_flex-1', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('1-N-shrink', async () => {
     let div;
@@ -1707,7 +1707,7 @@ describe('flexbox_flex-1', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('1-N', async () => {
     let div;
@@ -1785,7 +1785,7 @@ describe('flexbox_flex-1', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('1-Npercent-ref', async () => {
     let div;
@@ -1862,7 +1862,7 @@ describe('flexbox_flex-1', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('1-Npercent-shrink-ref', async () => {
     let div;
@@ -1939,7 +1939,7 @@ describe('flexbox_flex-1', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('1-Npercent-shrink', async () => {
     let div;
@@ -2017,7 +2017,7 @@ describe('flexbox_flex-1', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('1-Npercent', async () => {
     let div;
@@ -2095,7 +2095,7 @@ describe('flexbox_flex-1', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('1-auto-ref', async () => {
     let div;
@@ -2172,7 +2172,7 @@ describe('flexbox_flex-1', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('1-auto-shrink-ref', async () => {
     let div;
@@ -2249,7 +2249,7 @@ describe('flexbox_flex-1', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('1-auto-shrink', async () => {
     let div;
@@ -2327,7 +2327,7 @@ describe('flexbox_flex-1', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('1-auto', async () => {
     let div;
@@ -2405,7 +2405,7 @@ describe('flexbox_flex-1', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('1', async () => {
     let div;
@@ -2483,7 +2483,7 @@ describe('flexbox_flex-1', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('N-0-ref', async () => {
     let div;
@@ -2560,7 +2560,7 @@ describe('flexbox_flex-1', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('N-0-unitless', async () => {
     let div;
@@ -2638,7 +2638,7 @@ describe('flexbox_flex-1', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('N-0', async () => {
     let div;
@@ -2716,7 +2716,7 @@ describe('flexbox_flex-1', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('N-N-ref', async () => {
     let div;
@@ -2793,7 +2793,7 @@ describe('flexbox_flex-1', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('N-N-shrink-ref', async () => {
     let div;
@@ -2870,7 +2870,7 @@ describe('flexbox_flex-1', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('N-N-shrink', async () => {
     let div;
@@ -2948,7 +2948,7 @@ describe('flexbox_flex-1', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('N-N', async () => {
     let div;
@@ -3026,7 +3026,7 @@ describe('flexbox_flex-1', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('N-Npercent-ref', async () => {
     let div;
@@ -3103,7 +3103,7 @@ describe('flexbox_flex-1', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('N-Npercent-shrink-ref', async () => {
     let div;
@@ -3180,7 +3180,7 @@ describe('flexbox_flex-1', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('N-Npercent-shrink', async () => {
     let div;
@@ -3258,7 +3258,7 @@ describe('flexbox_flex-1', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('N-Npercent', async () => {
     let div;
@@ -3336,7 +3336,7 @@ describe('flexbox_flex-1', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('N-auto-ref', async () => {
     let div;
@@ -3413,7 +3413,7 @@ describe('flexbox_flex-1', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('N-auto-shrink-ref', async () => {
     let div;
@@ -3490,7 +3490,7 @@ describe('flexbox_flex-1', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('N-auto-shrink', async () => {
     let div;
@@ -3568,7 +3568,7 @@ describe('flexbox_flex-1', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('N-auto', async () => {
     let div;
@@ -3646,7 +3646,7 @@ describe('flexbox_flex-1', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('N', async () => {
     let div;
@@ -3724,6 +3724,6 @@ describe('flexbox_flex-1', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-flexbox/flexbox_flex-auto.ts
+++ b/integration_tests/specs/css/css-flexbox/flexbox_flex-auto.ts
@@ -148,6 +148,6 @@ describe('flexbox_flex-auto', () => {
     BODY.appendChild(div);
     BODY.appendChild(div_1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-flexbox/flexbox_flex-basis.ts
+++ b/integration_tests/specs/css/css-flexbox/flexbox_flex-basis.ts
@@ -76,7 +76,7 @@ describe('flexbox_flex-basis', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('shrink-ref', async () => {
     let div;
@@ -153,7 +153,7 @@ describe('flexbox_flex-basis', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('shrink', async () => {
     let div;
@@ -231,6 +231,6 @@ describe('flexbox_flex-basis', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-flexbox/flexbox_flex-initial.ts
+++ b/integration_tests/specs/css/css-flexbox/flexbox_flex-initial.ts
@@ -148,7 +148,7 @@ describe('flexbox_flex-initial', () => {
     BODY.appendChild(div);
     BODY.appendChild(div_1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('2', async () => {
     let div;
@@ -301,7 +301,7 @@ describe('flexbox_flex-initial', () => {
     BODY.appendChild(div);
     BODY.appendChild(flex);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('ref', async () => {
     let div;
@@ -451,6 +451,6 @@ describe('flexbox_flex-initial', () => {
     BODY.appendChild(div);
     BODY.appendChild(div_1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-flexbox/flexbox_flex-n.ts
+++ b/integration_tests/specs/css/css-flexbox/flexbox_flex-n.ts
@@ -75,7 +75,7 @@ describe('flexbox_flex-N', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('0-0-unitless', async () => {
     let div;
@@ -153,7 +153,7 @@ describe('flexbox_flex-N', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('0-0', async () => {
     let div;
@@ -231,7 +231,7 @@ describe('flexbox_flex-N', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('0-N-ref', async () => {
     let div;
@@ -308,7 +308,7 @@ describe('flexbox_flex-N', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('0-N-shrink-ref', async () => {
     let div;
@@ -386,7 +386,7 @@ describe('flexbox_flex-N', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('0-N-shrink', async () => {
     let div;
@@ -464,7 +464,7 @@ describe('flexbox_flex-N', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('0-N', async () => {
     let div;
@@ -542,7 +542,7 @@ describe('flexbox_flex-N', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('0-Npercent-ref', async () => {
     let div;
@@ -619,7 +619,7 @@ describe('flexbox_flex-N', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('0-Npercent-shrink-ref', async () => {
     let div;
@@ -697,7 +697,7 @@ describe('flexbox_flex-N', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('0-Npercent-shrink', async () => {
     let div;
@@ -775,7 +775,7 @@ describe('flexbox_flex-N', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('0-Npercent', async () => {
     let div;
@@ -853,7 +853,7 @@ describe('flexbox_flex-N', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('0-auto-ref', async () => {
     let div;
@@ -930,7 +930,7 @@ describe('flexbox_flex-N', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('0-auto-shrink-ref', async () => {
     let div;
@@ -1008,7 +1008,7 @@ describe('flexbox_flex-N', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('0-auto-shrink', async () => {
     let div;
@@ -1086,7 +1086,7 @@ describe('flexbox_flex-N', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('0-auto', async () => {
     let div;
@@ -1164,7 +1164,7 @@ describe('flexbox_flex-N', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('0', async () => {
     let div;
@@ -1242,7 +1242,7 @@ describe('flexbox_flex-N', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('1-0-ref', async () => {
     let div;
@@ -1319,7 +1319,7 @@ describe('flexbox_flex-N', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('1-0-unitless', async () => {
     let div;
@@ -1397,7 +1397,7 @@ describe('flexbox_flex-N', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('1-0', async () => {
     let div;
@@ -1475,7 +1475,7 @@ describe('flexbox_flex-N', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('1-N-ref', async () => {
     let div;
@@ -1552,7 +1552,7 @@ describe('flexbox_flex-N', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('1-N-shrink-ref', async () => {
     let div;
@@ -1629,7 +1629,7 @@ describe('flexbox_flex-N', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('1-N-shrink', async () => {
     let div;
@@ -1707,7 +1707,7 @@ describe('flexbox_flex-N', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('1-N', async () => {
     let div;
@@ -1785,7 +1785,7 @@ describe('flexbox_flex-N', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('1-Npercent-ref', async () => {
     let div;
@@ -1862,7 +1862,7 @@ describe('flexbox_flex-N', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('1-Npercent-shrink-ref', async () => {
     let div;
@@ -1939,7 +1939,7 @@ describe('flexbox_flex-N', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('1-Npercent-shrink', async () => {
     let div;
@@ -2017,7 +2017,7 @@ describe('flexbox_flex-N', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('1-Npercent', async () => {
     let div;
@@ -2095,7 +2095,7 @@ describe('flexbox_flex-N', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('1-auto-ref', async () => {
     let div;
@@ -2172,7 +2172,7 @@ describe('flexbox_flex-N', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('1-auto-shrink-ref', async () => {
     let div;
@@ -2249,7 +2249,7 @@ describe('flexbox_flex-N', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('1-auto-shrink', async () => {
     let div;
@@ -2327,7 +2327,7 @@ describe('flexbox_flex-N', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('1-auto', async () => {
     let div;
@@ -2405,7 +2405,7 @@ describe('flexbox_flex-N', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('1', async () => {
     let div;
@@ -2483,7 +2483,7 @@ describe('flexbox_flex-N', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('N-0-ref', async () => {
     let div;
@@ -2560,7 +2560,7 @@ describe('flexbox_flex-N', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('N-0-unitless', async () => {
     let div;
@@ -2638,7 +2638,7 @@ describe('flexbox_flex-N', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('N-0', async () => {
     let div;
@@ -2716,7 +2716,7 @@ describe('flexbox_flex-N', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('N-N-ref', async () => {
     let div;
@@ -2793,7 +2793,7 @@ describe('flexbox_flex-N', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('N-N-shrink-ref', async () => {
     let div;
@@ -2870,7 +2870,7 @@ describe('flexbox_flex-N', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('N-N-shrink', async () => {
     let div;
@@ -2948,7 +2948,7 @@ describe('flexbox_flex-N', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('N-N', async () => {
     let div;
@@ -3026,7 +3026,7 @@ describe('flexbox_flex-N', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('N-Npercent-ref', async () => {
     let div;
@@ -3103,7 +3103,7 @@ describe('flexbox_flex-N', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('N-Npercent-shrink-ref', async () => {
     let div;
@@ -3180,7 +3180,7 @@ describe('flexbox_flex-N', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('N-Npercent-shrink', async () => {
     let div;
@@ -3258,7 +3258,7 @@ describe('flexbox_flex-N', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('N-Npercent', async () => {
     let div;
@@ -3336,7 +3336,7 @@ describe('flexbox_flex-N', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('N-auto-ref', async () => {
     let div;
@@ -3413,7 +3413,7 @@ describe('flexbox_flex-N', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('N-auto-shrink-ref', async () => {
     let div;
@@ -3490,7 +3490,7 @@ describe('flexbox_flex-N', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('N-auto-shrink', async () => {
     let div;
@@ -3568,7 +3568,7 @@ describe('flexbox_flex-N', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('N-auto', async () => {
     let div;
@@ -3646,7 +3646,7 @@ describe('flexbox_flex-N', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('N', async () => {
     let div;
@@ -3724,6 +3724,6 @@ describe('flexbox_flex-N', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-flexbox/flexbox_flex-natural.ts
+++ b/integration_tests/specs/css/css-flexbox/flexbox_flex-natural.ts
@@ -74,7 +74,7 @@ describe('flexbox_flex-natural', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('mixed-basis-auto', async () => {
     let div;
@@ -143,7 +143,7 @@ describe('flexbox_flex-natural', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('mixed-basis-ref', async () => {
     let div;
@@ -214,7 +214,7 @@ describe('flexbox_flex-natural', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('mixed-basis', async () => {
     let div;
@@ -282,7 +282,7 @@ describe('flexbox_flex-natural', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('ref', async () => {
     let div;
@@ -432,7 +432,7 @@ describe('flexbox_flex-natural', () => {
     BODY.appendChild(div);
     BODY.appendChild(div_1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('variable-auto-basis', async () => {
     let div;
@@ -504,7 +504,7 @@ describe('flexbox_flex-natural', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('variable-zero-basis', async () => {
     let div;
@@ -576,6 +576,6 @@ describe('flexbox_flex-natural', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-flexbox/flexbox_flex-none.ts
+++ b/integration_tests/specs/css/css-flexbox/flexbox_flex-none.ts
@@ -148,7 +148,7 @@ describe('flexbox_flex-none', () => {
     BODY.appendChild(div);
     BODY.appendChild(div_1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('wrappable-content-ref', async () => {
     let div;
@@ -191,7 +191,7 @@ describe('flexbox_flex-none', () => {
     BODY.appendChild(div);
     BODY.appendChild(div_1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('wrappable-content', async () => {
     let div;
@@ -247,6 +247,6 @@ describe('flexbox_flex-none', () => {
     BODY.appendChild(div);
     BODY.appendChild(div_1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-flexbox/flexbox_flex.ts
+++ b/integration_tests/specs/css/css-flexbox/flexbox_flex.ts
@@ -151,7 +151,7 @@ describe('flexbox_flex', () => {
     BODY.appendChild(div);
     BODY.appendChild(flex);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('basis', async () => {
     let div;
@@ -237,7 +237,7 @@ describe('flexbox_flex', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('initial', async () => {
     let div;
@@ -390,7 +390,7 @@ describe('flexbox_flex', () => {
     BODY.appendChild(div);
     BODY.appendChild(flex);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('natural', async () => {
     let div;
@@ -543,7 +543,7 @@ describe('flexbox_flex', () => {
     BODY.appendChild(div);
     BODY.appendChild(flex);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('none', async () => {
     let div;
@@ -696,6 +696,6 @@ describe('flexbox_flex', () => {
     BODY.appendChild(div);
     BODY.appendChild(flex);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-flexbox/flexbox_flow-column.ts
+++ b/integration_tests/specs/css/css-flexbox/flexbox_flow-column.ts
@@ -77,7 +77,7 @@ describe('flexbox_flow-column', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('reverse-wrap', async () => {
     let div;
@@ -156,7 +156,7 @@ describe('flexbox_flow-column', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('wrap-reverse', async () => {
     let div;
@@ -231,7 +231,7 @@ describe('flexbox_flow-column', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('wrap', async () => {
     let div;
@@ -306,6 +306,6 @@ describe('flexbox_flow-column', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-flexbox/flexbox_flow-row.ts
+++ b/integration_tests/specs/css/css-flexbox/flexbox_flow-row.ts
@@ -72,7 +72,7 @@ describe('flexbox_flow-row', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('wrap', async () => {
     let div;
@@ -146,6 +146,6 @@ describe('flexbox_flow-row', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-flexbox/flexbox_item-vertical.ts
+++ b/integration_tests/specs/css/css-flexbox/flexbox_item-vertical.ts
@@ -78,6 +78,6 @@ describe('flexbox_item-vertical', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-flexbox/flexbox_justifycontent-center.ts
+++ b/integration_tests/specs/css/css-flexbox/flexbox_justifycontent-center.ts
@@ -71,6 +71,6 @@ describe('flexbox_justifycontent-center', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-flexbox/flexbox_justifycontent-flex.ts
+++ b/integration_tests/specs/css/css-flexbox/flexbox_justifycontent-flex.ts
@@ -71,7 +71,7 @@ describe('flexbox_justifycontent-flex', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('end', async () => {
     let div;
@@ -139,7 +139,7 @@ describe('flexbox_justifycontent-flex', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('start-ref', async () => {
     let div;
@@ -212,7 +212,7 @@ describe('flexbox_justifycontent-flex', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('start', async () => {
     let div;
@@ -280,6 +280,6 @@ describe('flexbox_justifycontent-flex', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-flexbox/flexbox_justifycontent-spacearound.ts
+++ b/integration_tests/specs/css/css-flexbox/flexbox_justifycontent-spacearound.ts
@@ -68,7 +68,7 @@ describe('flexbox_justifycontent-spacearound', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('negative', async () => {
     let div;
@@ -133,7 +133,7 @@ describe('flexbox_justifycontent-spacearound', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('only-ref', async () => {
     let div;
@@ -169,7 +169,7 @@ describe('flexbox_justifycontent-spacearound', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('only', async () => {
     let div;
@@ -207,7 +207,7 @@ describe('flexbox_justifycontent-spacearound', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('ref', async () => {
     let div;
@@ -280,6 +280,6 @@ describe('flexbox_justifycontent-spacearound', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-flexbox/flexbox_justifycontent-spacebetween.ts
+++ b/integration_tests/specs/css/css-flexbox/flexbox_justifycontent-spacebetween.ts
@@ -68,7 +68,7 @@ describe('flexbox_justifycontent-spacebetween', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('negative', async () => {
     let div;
@@ -133,7 +133,7 @@ describe('flexbox_justifycontent-spacebetween', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('only-ref', async () => {
     let div;
@@ -172,7 +172,7 @@ describe('flexbox_justifycontent-spacebetween', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('only', async () => {
     let div;
@@ -210,7 +210,7 @@ describe('flexbox_justifycontent-spacebetween', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('ref', async () => {
     let div;
@@ -283,6 +283,6 @@ describe('flexbox_justifycontent-spacebetween', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-flexbox/flexbox_justifycontent.ts
+++ b/integration_tests/specs/css/css-flexbox/flexbox_justifycontent.ts
@@ -66,7 +66,7 @@ describe('flexbox_justifycontent', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('spacearound', async () => {
     let div;
@@ -134,7 +134,7 @@ describe('flexbox_justifycontent', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('spacebetween', async () => {
     let div;
@@ -202,6 +202,6 @@ describe('flexbox_justifycontent', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-flexbox/flexbox_margin-auto.ts
+++ b/integration_tests/specs/css/css-flexbox/flexbox_margin-auto.ts
@@ -54,7 +54,7 @@ describe('flexbox_margin-auto', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('overflow', async () => {
     let div;
@@ -105,7 +105,7 @@ describe('flexbox_margin-auto', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('ref', async () => {
     let div;
@@ -161,6 +161,6 @@ describe('flexbox_margin-auto', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-flexbox/flexbox_margin-collapse.ts
+++ b/integration_tests/specs/css/css-flexbox/flexbox_margin-collapse.ts
@@ -36,6 +36,6 @@ describe('flexbox_margin-collapse', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-flexbox/flexbox_margin-left.ts
+++ b/integration_tests/specs/css/css-flexbox/flexbox_margin-left.ts
@@ -75,7 +75,7 @@ describe('flexbox_margin-left', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('ex', async () => {
     let div;
@@ -147,6 +147,6 @@ describe('flexbox_margin-left', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-flexbox/flexbox_margin.ts
+++ b/integration_tests/specs/css/css-flexbox/flexbox_margin.ts
@@ -47,7 +47,7 @@ describe('flexbox_margin', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('ref', async () => {
     let div;
@@ -61,7 +61,7 @@ describe('flexbox_margin', () => {
     });
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('', async () => {
     let div;
@@ -77,6 +77,6 @@ describe('flexbox_margin', () => {
     });
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-flexbox/flexbox_nested.ts
+++ b/integration_tests/specs/css/css-flexbox/flexbox_nested.ts
@@ -31,6 +31,6 @@ describe('flexbox_nested', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-flexbox/flexbox_object.ts
+++ b/integration_tests/specs/css/css-flexbox/flexbox_object.ts
@@ -39,6 +39,6 @@ describe('flexbox_object', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-flexbox/flexbox_order-abspos.ts
+++ b/integration_tests/specs/css/css-flexbox/flexbox_order-abspos.ts
@@ -67,6 +67,6 @@ describe('flexbox_order-abspos', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-flexbox/flexbox_order-box.ts
+++ b/integration_tests/specs/css/css-flexbox/flexbox_order-box.ts
@@ -101,6 +101,6 @@ describe('flexbox_order-box', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-flexbox/flexbox_stf-inline.ts
+++ b/integration_tests/specs/css/css-flexbox/flexbox_stf-inline.ts
@@ -91,6 +91,6 @@ describe('flexbox_stf-inline', () => {
     );
     BODY.appendChild(test);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-flexbox/flexbox_stf.ts
+++ b/integration_tests/specs/css/css-flexbox/flexbox_stf.ts
@@ -91,7 +91,7 @@ describe('flexbox_stf', () => {
     );
     BODY.appendChild(test);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('fixpos', async () => {
     let test;
@@ -184,6 +184,6 @@ describe('flexbox_stf', () => {
     );
     BODY.appendChild(test);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-flexbox/flexbox_width-change.ts
+++ b/integration_tests/specs/css/css-flexbox/flexbox_width-change.ts
@@ -66,10 +66,10 @@ describe('flexbox_width-change', () => {
 
     requestAnimationFrame(async () => {
       container.style.width = '200px';
-      await matchViewportSnapshot();
+      await snapshot();
       done();
     });
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-flexbox/flexbox_width-wrapping.ts
+++ b/integration_tests/specs/css/css-flexbox/flexbox_width-wrapping.ts
@@ -87,6 +87,6 @@ describe('flexbox_width-wrapping', () => {
     BODY.appendChild(p);
     BODY.appendChild(test);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-flexbox/flexbox_width.ts
+++ b/integration_tests/specs/css/css-flexbox/flexbox_width.ts
@@ -70,6 +70,6 @@ describe('flexbox_width', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-flexbox/flexbox_wrap.ts
+++ b/integration_tests/specs/css/css-flexbox/flexbox_wrap.ts
@@ -72,7 +72,7 @@ describe('flexbox_wrap', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('reverse', async () => {
     let div;
@@ -146,7 +146,7 @@ describe('flexbox_wrap', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('001', async () => {
     let div;
@@ -220,6 +220,6 @@ describe('flexbox_wrap', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-flexbox/flexible.ts
+++ b/integration_tests/specs/css/css-flexbox/flexible.ts
@@ -63,6 +63,6 @@ describe('Flexible', () => {
     );
     BODY.appendChild(box);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-flexbox/flexitem-no.ts
+++ b/integration_tests/specs/css/css-flexbox/flexitem-no.ts
@@ -53,6 +53,6 @@ describe('flexitem-no', () => {
     BODY.appendChild(log);
     BODY.appendChild(flexbox);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-flexbox/image-items.ts
+++ b/integration_tests/specs/css/css-flexbox/image-items.ts
@@ -61,6 +61,6 @@ describe('image-items', () => {
     BODY.appendChild(referenceOverlappedRed);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-flexbox/inline.ts
+++ b/integration_tests/specs/css/css-flexbox/inline.ts
@@ -100,6 +100,6 @@ describe('inline', () => {
     BODY.appendChild(p);
     BODY.appendChild(testcase);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-flexbox/justify-content.ts
+++ b/integration_tests/specs/css/css-flexbox/justify-content.ts
@@ -52,7 +52,7 @@ describe('justify-content', () => {
     BODY.appendChild(p);
     BODY.appendChild(flexbox);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('002', async () => {
     let p;
@@ -104,7 +104,7 @@ describe('justify-content', () => {
     BODY.appendChild(p);
     BODY.appendChild(flexbox);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('003', async () => {
     let p;
@@ -156,7 +156,7 @@ describe('justify-content', () => {
     BODY.appendChild(p);
     BODY.appendChild(flexbox);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('004', async () => {
     let p;
@@ -210,7 +210,7 @@ describe('justify-content', () => {
     BODY.appendChild(p);
     BODY.appendChild(flexbox);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('005', async () => {
     let p;
@@ -264,6 +264,6 @@ describe('justify-content', () => {
     BODY.appendChild(p);
     BODY.appendChild(flexbox);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-flexbox/justify-content_flex.ts
+++ b/integration_tests/specs/css/css-flexbox/justify-content_flex.ts
@@ -87,7 +87,7 @@ describe('justify-content_flex', () => {
     BODY.appendChild(p);
     BODY.appendChild(test);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('start', async () => {
     let p;
@@ -176,6 +176,6 @@ describe('justify-content_flex', () => {
     BODY.appendChild(p);
     BODY.appendChild(test);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-flexbox/justify-content_space.ts
+++ b/integration_tests/specs/css/css-flexbox/justify-content_space.ts
@@ -87,7 +87,7 @@ describe('justify-content_space', () => {
     BODY.appendChild(p);
     BODY.appendChild(test);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('between-001', async () => {
     let p;
@@ -176,7 +176,7 @@ describe('justify-content_space', () => {
     BODY.appendChild(p);
     BODY.appendChild(test);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('between-002', async () => {
     let flexbox;
@@ -216,6 +216,6 @@ describe('justify-content_space', () => {
     );
     BODY.appendChild(flexbox);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-flexbox/justify.ts
+++ b/integration_tests/specs/css/css-flexbox/justify.ts
@@ -90,6 +90,6 @@ describe('justify', () => {
     BODY.appendChild(p);
     BODY.appendChild(test);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-flexbox/justify_content.ts
+++ b/integration_tests/specs/css/css-flexbox/justify_content.ts
@@ -36,7 +36,7 @@ describe('flexbox justify-content', () => {
     });
     container.appendChild(child3);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('should work with flex-end when flex-direction is row', async () => {
@@ -76,7 +76,7 @@ describe('flexbox justify-content', () => {
     });
     container.appendChild(child3);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('should work with center when flex-direction is row', async () => {
@@ -116,7 +116,7 @@ describe('flexbox justify-content', () => {
     });
     container.appendChild(child3);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('should work with space-around when flex-direction is row', async () => {
@@ -156,7 +156,7 @@ describe('flexbox justify-content', () => {
     });
     container.appendChild(child3);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('should work with space-between when flex-direction is row', async () => {
@@ -196,7 +196,7 @@ describe('flexbox justify-content', () => {
     });
     container.appendChild(child3);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('should work with flex-start when flex-direction is column', async () => {
@@ -236,7 +236,7 @@ describe('flexbox justify-content', () => {
     });
     container.appendChild(child3);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('should work with flex-end when flex-direction is column', async () => {
@@ -276,7 +276,7 @@ describe('flexbox justify-content', () => {
     });
     container.appendChild(child3);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('should work with center when flex-direction is column', async () => {
@@ -316,7 +316,7 @@ describe('flexbox justify-content', () => {
     });
     container.appendChild(child3);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('should work with space-around when flex-direction is column', async () => {
@@ -356,7 +356,7 @@ describe('flexbox justify-content', () => {
     });
     container.appendChild(child3);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('should work with space-between when flex-direction is column', async () => {
@@ -396,7 +396,7 @@ describe('flexbox justify-content', () => {
     });
     container.appendChild(child3);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('should work with center when flex-grow exists', async () => {
@@ -465,7 +465,7 @@ describe('flexbox justify-content', () => {
     );
     BODY.appendChild(container);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('should work with center when flex-shrink exists', async () => {
@@ -531,7 +531,7 @@ describe('flexbox justify-content', () => {
     );
     BODY.appendChild(container);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('should work with flex-start when children width is larger than container', async () => {
@@ -600,7 +600,7 @@ describe('flexbox justify-content', () => {
     );
     BODY.appendChild(container);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('should work with flex-end when children width is larger than container', async () => {
@@ -669,7 +669,7 @@ describe('flexbox justify-content', () => {
     );
     BODY.appendChild(container);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('should work with center when children width is larger than container', async () => {
     let failFlag;
@@ -737,7 +737,7 @@ describe('flexbox justify-content', () => {
     );
     BODY.appendChild(container);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('should work with space-between when children width is larger than container', async () => {
@@ -806,7 +806,7 @@ describe('flexbox justify-content', () => {
     );
     BODY.appendChild(container);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('should work with space-around when children width is larger than container', async () => {
@@ -875,7 +875,7 @@ describe('flexbox justify-content', () => {
     );
     BODY.appendChild(container);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('should work with space-evenly when children width is larger than container', async () => {
@@ -944,6 +944,6 @@ describe('flexbox justify-content', () => {
     );
     BODY.appendChild(container);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-flexbox/layout-algorithm_algo.ts
+++ b/integration_tests/specs/css/css-flexbox/layout-algorithm_algo.ts
@@ -61,7 +61,7 @@ describe('layout-algorithm_algo', () => {
     BODY.appendChild(p);
     BODY.appendChild(flex);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('cross-line-002', async () => {
     let p;
@@ -126,6 +126,6 @@ describe('layout-algorithm_algo', () => {
     BODY.appendChild(p);
     BODY.appendChild(flex);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-flexbox/max-width.ts
+++ b/integration_tests/specs/css/css-flexbox/max-width.ts
@@ -151,7 +151,7 @@ describe('max-width', () => {
     BODY.appendChild(p_1);
     BODY.appendChild(columns_1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('should work with flex-shrink 0', async () => {
@@ -202,7 +202,7 @@ describe('max-width', () => {
     div_1.appendChild(div);
     BODY.appendChild(div_1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('should work with flex-shrink 1 and parent has width set', async () => {
@@ -252,7 +252,7 @@ describe('max-width', () => {
     div_1.appendChild(div);
     BODY.appendChild(div_1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('should work with flex-shrink 1 and parent has max-width set', async () => {
@@ -303,6 +303,6 @@ describe('max-width', () => {
     div_1.appendChild(div);
     BODY.appendChild(div_1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-flexbox/multi-line.ts
+++ b/integration_tests/specs/css/css-flexbox/multi-line.ts
@@ -136,7 +136,7 @@ describe('multi-line', () => {
     );
     BODY.appendChild(test);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('wrap-reverse-row-reverse', async () => {
     let row3Col1;
@@ -268,7 +268,7 @@ describe('multi-line', () => {
     );
     BODY.appendChild(test);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('wrap-with-column-reverse', async () => {
     let col1Row3;
@@ -400,7 +400,7 @@ describe('multi-line', () => {
     );
     BODY.appendChild(test);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('wrap-with-row-reverse', async () => {
     let row1Col3;
@@ -517,6 +517,6 @@ describe('multi-line', () => {
     );
     BODY.appendChild(test);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-flexbox/multiline-column.ts
+++ b/integration_tests/specs/css/css-flexbox/multiline-column.ts
@@ -227,6 +227,6 @@ describe('multiline-column', () => {
     );
     BODY.appendChild(flex);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-flexbox/multiline-min.ts
+++ b/integration_tests/specs/css/css-flexbox/multiline-min.ts
@@ -1135,6 +1135,6 @@ describe('multiline-min', () => {
     BODY.appendChild(flexbox_12);
     BODY.appendChild(flexbox_13);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-flexbox/multiline-reverse.ts
+++ b/integration_tests/specs/css/css-flexbox/multiline-reverse.ts
@@ -96,7 +96,7 @@ describe('multiline-reverse', () => {
     );
     BODY.appendChild(flexbox);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('wrap-baseline with margin-bottom', async () => {
@@ -195,7 +195,7 @@ describe('multiline-reverse', () => {
     );
     BODY.appendChild(flexbox_1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   xit('wrap-baseline with more than 2 flex-item', async () => {
@@ -267,7 +267,7 @@ describe('multiline-reverse', () => {
     );
     // BODY.appendChild(flexbox_2);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('should work with align-items flex-start', async () => {
@@ -366,7 +366,7 @@ describe('multiline-reverse', () => {
     );
     BODY.appendChild(flexbox);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('should work with align-items flex-end', async () => {
@@ -465,7 +465,7 @@ describe('multiline-reverse', () => {
     );
     BODY.appendChild(flexbox);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('should work with align-items center', async () => {
@@ -564,7 +564,7 @@ describe('multiline-reverse', () => {
     );
     BODY.appendChild(flexbox);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('should work with align-items baseline', async () => {
@@ -663,7 +663,7 @@ describe('multiline-reverse', () => {
     );
     BODY.appendChild(flexbox);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('should work with align-items stretch', async () => {
@@ -762,6 +762,6 @@ describe('multiline-reverse', () => {
     );
     BODY.appendChild(flexbox);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-flexbox/nested-orthogonal.ts
+++ b/integration_tests/specs/css/css-flexbox/nested-orthogonal.ts
@@ -46,7 +46,7 @@ describe('nested-orthogonal', () => {
     );
     BODY.appendChild(column);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('flexbox-relayout', async () => {
     let item;
@@ -94,6 +94,6 @@ describe('nested-orthogonal', () => {
     );
     BODY.appendChild(column);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-flexbox/position-absolute.ts
+++ b/integration_tests/specs/css/css-flexbox/position-absolute.ts
@@ -34,7 +34,7 @@ describe('flexbox-position-absolute', () => {
     );
     BODY.appendChild(flex);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('007', async () => {
     let p;
@@ -87,7 +87,7 @@ describe('flexbox-position-absolute', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('010', async () => {
     let p;
@@ -154,7 +154,7 @@ describe('flexbox-position-absolute', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('015', async () => {
     let abspos;
@@ -189,6 +189,6 @@ describe('flexbox-position-absolute', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-flexbox/relayout-align.ts
+++ b/integration_tests/specs/css/css-flexbox/relayout-align.ts
@@ -219,12 +219,12 @@ describe('relayout-align', () => {
     BODY.appendChild(fromStretch);
     BODY.appendChild(toStretch);
 
-    await matchViewportSnapshot();
+    await snapshot();
 
     requestAnimationFrame(async () => {
       fromStretch.style.alignItems = 'flex-end';
       toStretch.style.alignItems = 'stretch';
-      await matchViewportSnapshot(0.1);
+      await snapshot(0.1);
       done();
     }); 
   });

--- a/integration_tests/specs/css/css-flexbox/relayout-image.ts
+++ b/integration_tests/specs/css/css-flexbox/relayout-image.ts
@@ -59,10 +59,10 @@ describe('relayout-image', () => {
 
     requestAnimationFrame(async () => {
       image.src = 'assets/100x100-green.png';
-      await matchViewportSnapshot(0.1);
+      await snapshot(0.1);
       done();
     });
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-flexbox/zIndex.ts
+++ b/integration_tests/specs/css/css-flexbox/zIndex.ts
@@ -74,6 +74,6 @@ describe('flex-box', () => {
     BODY.appendChild(p);
     BODY.appendChild(flexBox);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-flow/block-formatting.ts
+++ b/integration_tests/specs/css/css-flow/block-formatting.ts
@@ -43,7 +43,7 @@ describe('block-formatting', () => {
     BODY.appendChild(p);
     BODY.appendChild(container);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('context-height-003-ref', async () => {
     let p;
@@ -71,7 +71,7 @@ describe('block-formatting', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('context-height-003', async () => {
     let p;
@@ -143,7 +143,7 @@ describe('block-formatting', () => {
     BODY.appendChild(p);
     BODY.appendChild(container);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('contexts-001', async () => {
     let p;
@@ -201,7 +201,7 @@ describe('block-formatting', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('contexts-004-ref', async () => {
     let p;
@@ -236,7 +236,7 @@ describe('block-formatting', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('contexts-005-ref', async () => {
     let p;
@@ -271,7 +271,7 @@ describe('block-formatting', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('contexts-005', async () => {
     let div1;
@@ -298,7 +298,7 @@ describe('block-formatting', () => {
     );
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('contexts-006-ref', async () => {
     let p;
@@ -334,7 +334,7 @@ describe('block-formatting', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('contexts-006', async () => {
     let child;
@@ -364,7 +364,7 @@ describe('block-formatting', () => {
     );
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('contexts-008-ref', async () => {
     let p;
@@ -400,7 +400,7 @@ describe('block-formatting', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot(0.2);
+    await snapshot(0.2);
   });
   xit('contexts-009', async () => {
     let p;
@@ -446,7 +446,7 @@ describe('block-formatting', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('contexts-010', async () => {
     let p;
@@ -506,7 +506,7 @@ describe('block-formatting', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('contexts-015-ref', async () => {
     let p;
@@ -557,6 +557,6 @@ describe('block-formatting', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-flow/block-in.ts
+++ b/integration_tests/specs/css/css-flow/block-in.ts
@@ -14,7 +14,7 @@ describe('block-in', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('inline-003', async () => {
     let block;
@@ -67,7 +67,7 @@ describe('block-in', () => {
     BODY.appendChild(block);
     BODY.appendChild(block_1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('inline-004', async () => {
     let block;
@@ -123,7 +123,7 @@ describe('block-in', () => {
     BODY.appendChild(block);
     BODY.appendChild(block_1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('inline-005', async () => {
     let test;
@@ -177,7 +177,7 @@ describe('block-in', () => {
       ]
     );
     BODY.appendChild(block);
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('inline-008-ref', async () => {
     let p;
@@ -201,7 +201,7 @@ describe('block-in', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('inline-008', async () => {
     let p;
@@ -268,7 +268,7 @@ describe('block-in', () => {
     BODY.appendChild(control);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('inline-relpos-001-ref', async () => {
     let p;
@@ -412,7 +412,7 @@ describe('block-in', () => {
     BODY.appendChild(container);
     BODY.appendChild(container_1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('inline-relpos-001', async () => {
     let p;
@@ -556,7 +556,7 @@ describe('block-in', () => {
     BODY.appendChild(container);
     BODY.appendChild(container_1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('inline-empty-001-ref', async () => {
     let span;
@@ -585,7 +585,7 @@ describe('block-in', () => {
     BODY.appendChild(span);
     BODY.appendChild(span_1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('inline-empty-003-ref', async () => {
     let span;
@@ -614,7 +614,7 @@ describe('block-in', () => {
     BODY.appendChild(span);
     BODY.appendChild(span_1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('inline-empty-003', async () => {
     let span;
@@ -645,7 +645,7 @@ describe('block-in', () => {
     );
     BODY.appendChild(span);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('inline-empty-004', async () => {
     let span;
@@ -676,6 +676,6 @@ describe('block-in', () => {
     );
     BODY.appendChild(span);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-flow/block-non.ts
+++ b/integration_tests/specs/css/css-flow/block-non.ts
@@ -37,7 +37,7 @@ describe('block-non', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('replaced-height-001', async () => {
     let p;
@@ -97,7 +97,7 @@ describe('block-non', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('replaced-height-002', async () => {
     let p;
@@ -149,7 +149,7 @@ describe('block-non', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('replaced-height-003', async () => {
     let p;
@@ -220,7 +220,7 @@ describe('block-non', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('replaced-height-004', async () => {
     let p;
@@ -291,7 +291,7 @@ describe('block-non', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('replaced-height-005-ref', async () => {
     let p;
@@ -352,7 +352,7 @@ describe('block-non', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('replaced-height-005', async () => {
     let p;
@@ -436,7 +436,7 @@ describe('block-non', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('replaced-height-006', async () => {
     let p;
@@ -520,11 +520,11 @@ describe('block-non', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
 
-    await matchViewportSnapshot();
+    await snapshot();
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('replaced-height-007', async () => {
     let p;
@@ -592,7 +592,7 @@ describe('block-non', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('replaced-height-008', async () => {
     let p;
@@ -660,7 +660,7 @@ describe('block-non', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('replaced-height-009-ref', async () => {
     let p;
@@ -684,7 +684,7 @@ describe('block-non', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('replaced-height-009', async () => {
     let p;
@@ -768,7 +768,7 @@ describe('block-non', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('replaced-height-010', async () => {
     let p;
@@ -852,7 +852,7 @@ describe('block-non', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('replaced-height-013', async () => {
     let p;
@@ -907,7 +907,7 @@ describe('block-non', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('replaced-height-014', async () => {
     let p;
@@ -962,7 +962,7 @@ describe('block-non', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('replaced-height-015', async () => {
     let p;
@@ -1034,7 +1034,7 @@ describe('block-non', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('replaced-height-016', async () => {
     let p;
@@ -1106,7 +1106,7 @@ describe('block-non', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('replaced-width-001-ref', async () => {
     let p;
@@ -1154,7 +1154,7 @@ describe('block-non', () => {
     BODY.appendChild(orange);
     BODY.appendChild(blue);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('replaced-width-001', async () => {
     let p;
@@ -1241,7 +1241,7 @@ describe('block-non', () => {
     BODY.appendChild(div1);
     BODY.appendChild(d3);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('replaced-width-002', async () => {
     let p;
@@ -1324,7 +1324,7 @@ describe('block-non', () => {
     BODY.appendChild(div1);
     BODY.appendChild(div2);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('replaced-width-003', async () => {
     let p;
@@ -1413,7 +1413,7 @@ describe('block-non', () => {
     BODY.appendChild(div1);
     BODY.appendChild(div2);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('replaced-width-004-ref', async () => {
     let p;
@@ -1462,7 +1462,7 @@ describe('block-non', () => {
     BODY.appendChild(orange);
     BODY.appendChild(blue);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('replaced-width-004', async () => {
     let p;
@@ -1545,7 +1545,7 @@ describe('block-non', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('replaced-width-005-ref', async () => {
     let p;
@@ -1581,7 +1581,7 @@ describe('block-non', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('replaced-width-006', async () => {
     let p;
@@ -1643,7 +1643,7 @@ describe('block-non', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('replaced-width-007-ref', async () => {
     let p;
@@ -1701,7 +1701,7 @@ describe('block-non', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('replaced-width-007', async () => {
     let p;
@@ -1767,7 +1767,7 @@ describe('block-non', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('replaced-width-008', async () => {
     let p;
@@ -1817,6 +1817,6 @@ describe('block-non', () => {
     BODY.appendChild(p);
     BODY.appendChild(containingBlock);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-flow/block-replaced.ts
+++ b/integration_tests/specs/css/css-flow/block-replaced.ts
@@ -39,7 +39,7 @@ describe('block-replaced', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot(0.5);
+    await snapshot(0.5);
   });
   it('height-001', async () => {
     let p;
@@ -85,7 +85,7 @@ describe('block-replaced', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('height-002-ref', async () => {
     let p;
@@ -140,7 +140,7 @@ describe('block-replaced', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot(0.5);
+    await snapshot(0.5);
   });
   xit('height-003', async () => {
     let p;
@@ -202,7 +202,7 @@ describe('block-replaced', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('height-004-ref', async () => {
     let p;
@@ -236,7 +236,7 @@ describe('block-replaced', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('height-004', async () => {
     let p;
@@ -290,7 +290,7 @@ describe('block-replaced', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('height-005', async () => {
     let p;
@@ -347,7 +347,7 @@ describe('block-replaced', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('height-006-ref', async () => {
     let p;
@@ -398,7 +398,7 @@ describe('block-replaced', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('width-001', async () => {
     let p;
@@ -460,7 +460,7 @@ describe('block-replaced', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('width-002-ref', async () => {
     let p;
@@ -525,7 +525,7 @@ describe('block-replaced', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('width-002', async () => {
     let p;
@@ -605,7 +605,7 @@ describe('block-replaced', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('width-003', async () => {
     let p;
@@ -675,7 +675,7 @@ describe('block-replaced', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('width-004', async () => {
     let p;
@@ -759,7 +759,7 @@ describe('block-replaced', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('width-006-ref', async () => {
     let p;
@@ -834,7 +834,7 @@ describe('block-replaced', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('width-006', async () => {
     let p;
@@ -914,6 +914,6 @@ describe('block-replaced', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-flow/blocks-011.ts
+++ b/integration_tests/specs/css/css-flow/blocks-011.ts
@@ -22,6 +22,6 @@ describe('blocks-011', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-flow/blocks-013.ts
+++ b/integration_tests/specs/css/css-flow/blocks-013.ts
@@ -50,6 +50,6 @@ describe('blocks-013', () => {
     BODY.appendChild(control);
     BODY.appendChild(control_1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-flow/blocks-014.ts
+++ b/integration_tests/specs/css/css-flow/blocks-014.ts
@@ -22,6 +22,6 @@ describe('blocks-014', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-flow/blocks-018.ts
+++ b/integration_tests/specs/css/css-flow/blocks-018.ts
@@ -25,6 +25,6 @@ describe('blocks-018', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-flow/blocks-019.ts
+++ b/integration_tests/specs/css/css-flow/blocks-019.ts
@@ -26,6 +26,6 @@ describe('blocks-019', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-flow/blocks-020.ts
+++ b/integration_tests/specs/css/css-flow/blocks-020.ts
@@ -32,6 +32,6 @@ describe('blocks-020', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-flow/blocks.ts
+++ b/integration_tests/specs/css/css-flow/blocks.ts
@@ -59,7 +59,7 @@ describe('blocks', () => {
     BODY.appendChild(container);
     BODY.appendChild(control);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('012', async () => {
     let p;
@@ -126,7 +126,7 @@ describe('blocks', () => {
     BODY.appendChild(container);
     BODY.appendChild(control);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('014', async () => {
     let p;
@@ -187,7 +187,7 @@ describe('blocks', () => {
     BODY.appendChild(container);
     BODY.appendChild(control);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('015', async () => {
     let p;
@@ -254,7 +254,7 @@ describe('blocks', () => {
     BODY.appendChild(container);
     BODY.appendChild(control);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('018', async () => {
     let control;
@@ -316,7 +316,7 @@ describe('blocks', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('019', async () => {
     let control;
@@ -378,7 +378,7 @@ describe('blocks', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('020', async () => {
     let p;
@@ -439,7 +439,7 @@ describe('blocks', () => {
     BODY.appendChild(p);
     BODY.appendChild(outer);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('021', async () => {
     let p;
@@ -500,7 +500,7 @@ describe('blocks', () => {
     BODY.appendChild(p);
     BODY.appendChild(outer);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('022', async () => {
     let p;
@@ -561,7 +561,7 @@ describe('blocks', () => {
     BODY.appendChild(p);
     BODY.appendChild(outer);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('026', async () => {
     let p;
@@ -652,7 +652,7 @@ describe('blocks', () => {
     BODY.appendChild(div);
     BODY.appendChild(div_1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('027', async () => {
     let p;
@@ -697,7 +697,7 @@ describe('blocks', () => {
     BODY.appendChild(test);
     BODY.appendChild(control);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('028', async () => {
     let p;
@@ -742,6 +742,6 @@ describe('blocks', () => {
     BODY.appendChild(test);
     BODY.appendChild(control);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-flow/child-bottom.ts
+++ b/integration_tests/specs/css/css-flow/child-bottom.ts
@@ -72,6 +72,6 @@ describe('child-bottom', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-flow/containing-block.ts
+++ b/integration_tests/specs/css/css-flow/containing-block.ts
@@ -54,7 +54,7 @@ describe('containing-block', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('003', async () => {
     let div1;
@@ -91,7 +91,7 @@ describe('containing-block', () => {
     );
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('004', async () => {
     let p;
@@ -147,7 +147,7 @@ describe('containing-block', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('006', async () => {
     let p;
@@ -203,7 +203,7 @@ describe('containing-block', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('007-ref', async () => {
     let p;
@@ -231,7 +231,7 @@ describe('containing-block', () => {
     );
     BODY.appendChild(p);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('007', async () => {
     let p;
@@ -277,7 +277,7 @@ describe('containing-block', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('008-ref', async () => {
     let p;
@@ -329,7 +329,7 @@ describe('containing-block', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('008', async () => {
     let p;
@@ -405,7 +405,7 @@ describe('containing-block', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('009-ref', async () => {
     let div;
@@ -432,7 +432,7 @@ describe('containing-block', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('009', async () => {
     let p;
@@ -506,7 +506,7 @@ describe('containing-block', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('010', async () => {
     let p;
@@ -580,7 +580,7 @@ describe('containing-block', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('011', async () => {
     let p;
@@ -647,7 +647,7 @@ describe('containing-block', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('013', async () => {
     let p;
@@ -714,7 +714,7 @@ describe('containing-block', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('015', async () => {
     let p;
@@ -781,7 +781,7 @@ describe('containing-block', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('017', async () => {
     let p;
@@ -914,10 +914,10 @@ describe('containing-block', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('018', async () => {
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('019-ref', async () => {
     let div;
@@ -945,7 +945,7 @@ describe('containing-block', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('019', async () => {
     let p;
@@ -1016,7 +1016,7 @@ describe('containing-block', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('020-ref', async () => {
     let p;
@@ -1063,7 +1063,7 @@ describe('containing-block', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('020', async () => {
     let p;
@@ -1134,7 +1134,7 @@ describe('containing-block', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('021', async () => {
     let p;
@@ -1205,7 +1205,7 @@ describe('containing-block', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('022', async () => {
     let p;
@@ -1276,7 +1276,7 @@ describe('containing-block', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('023', async () => {
     let p;
@@ -1345,7 +1345,7 @@ describe('containing-block', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('026', async () => {
     let p;
@@ -1397,7 +1397,7 @@ describe('containing-block', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('027', async () => {
     let p;
@@ -1445,7 +1445,7 @@ describe('containing-block', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('028', async () => {
     let p;
@@ -1495,7 +1495,7 @@ describe('containing-block', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('030', async () => {
     let p;
@@ -1539,7 +1539,7 @@ describe('containing-block', () => {
     BODY.appendChild(p);
     BODY.appendChild(containingBlock);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('percent-margin-bottom', async () => {
     let p;
@@ -1579,7 +1579,7 @@ describe('containing-block', () => {
     BODY.appendChild(p);
     BODY.appendChild(container);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('percent-margin-left', async () => {
     let p;
@@ -1618,7 +1618,7 @@ describe('containing-block', () => {
     BODY.appendChild(p);
     BODY.appendChild(container);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('percent-margin-right', async () => {
     let p;
@@ -1657,7 +1657,7 @@ describe('containing-block', () => {
     BODY.appendChild(p);
     BODY.appendChild(container);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('percent-margin-top', async () => {
     let p;
@@ -1697,7 +1697,7 @@ describe('containing-block', () => {
     BODY.appendChild(p);
     BODY.appendChild(container);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('percent-padding-bottom', async () => {
     let p;
@@ -1737,7 +1737,7 @@ describe('containing-block', () => {
     BODY.appendChild(p);
     BODY.appendChild(container);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('percent-padding-left', async () => {
     let p;
@@ -1777,7 +1777,7 @@ describe('containing-block', () => {
     BODY.appendChild(p);
     BODY.appendChild(container);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('percent-padding-right', async () => {
     let p;
@@ -1817,7 +1817,7 @@ describe('containing-block', () => {
     BODY.appendChild(p);
     BODY.appendChild(container);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('percent-padding-top', async () => {
     let p;
@@ -1857,6 +1857,6 @@ describe('containing-block', () => {
     BODY.appendChild(p);
     BODY.appendChild(container);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-flow/dynamic-percentage.ts
+++ b/integration_tests/specs/css/css-flow/dynamic-percentage.ts
@@ -56,6 +56,6 @@ describe('dynamic-percentage', () => {
     container = document.getElementById('container');
     container.style.height = '100px';
     document.body.offsetTop;
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-flow/height-001.ts
+++ b/integration_tests/specs/css/css-flow/height-001.ts
@@ -38,6 +38,6 @@ describe('height-001', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-flow/height.ts
+++ b/integration_tests/specs/css/css-flow/height.ts
@@ -40,7 +40,7 @@ describe('height', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('002', async () => {
     let p;
@@ -82,7 +82,7 @@ describe('height', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('003', async () => {
     let p;
@@ -108,7 +108,7 @@ describe('height', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('004', async () => {
     let p;
@@ -150,7 +150,7 @@ describe('height', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('005', async () => {
     let p;
@@ -192,7 +192,7 @@ describe('height', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('006', async () => {
     let p;
@@ -246,7 +246,7 @@ describe('height', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('007', async () => {
     let p;
@@ -300,7 +300,7 @@ describe('height', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('should auto compute height when remove height property', async () => {
@@ -319,10 +319,10 @@ describe('height', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
 
     div.style.height = null;
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-fonts/font-family.ts
+++ b/integration_tests/specs/css/css-fonts/font-family.ts
@@ -19,7 +19,7 @@ describe('FontFamily', () => {
     append(BODY, p1);
     append(BODY, p2);
 
-    return matchViewportSnapshot();
+    return snapshot();
   });
 
   it('should works in chinese', () => {
@@ -42,6 +42,6 @@ describe('FontFamily', () => {
     append(BODY, p1);
     append(BODY, p2);
 
-    return matchViewportSnapshot();
+    return snapshot();
   });
 });

--- a/integration_tests/specs/css/css-fonts/font-size.ts
+++ b/integration_tests/specs/css/css-fonts/font-size.ts
@@ -9,7 +9,7 @@ describe('FontSize', () => {
     );
     append(BODY, p1);
 
-    return matchViewportSnapshot();
+    return snapshot();
   });
 
   it('should work with chinese', () => {
@@ -22,7 +22,7 @@ describe('FontSize', () => {
     );
     append(BODY, p1);
 
-    return matchViewportSnapshot();
+    return snapshot();
   });
 
   it('should work with less than 12px', () => {
@@ -44,7 +44,7 @@ describe('FontSize', () => {
     append(BODY, p1);
     append(BODY, p2);
 
-    return matchViewportSnapshot();
+    return snapshot();
   });
 
   it('should work with percentage', async () => {
@@ -75,6 +75,6 @@ describe('FontSize', () => {
     );
 
     BODY.appendChild(div);
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-fonts/font-style.ts
+++ b/integration_tests/specs/css/css-fonts/font-style.ts
@@ -19,7 +19,7 @@ describe('FontStyle', () => {
     append(BODY, p1);
     append(BODY, p2);
 
-    return matchViewportSnapshot();
+    return snapshot();
   });
 
   it('should works with italic', () => {
@@ -42,7 +42,7 @@ describe('FontStyle', () => {
     append(BODY, p1);
     append(BODY, p2);
 
-    return matchViewportSnapshot();
+    return snapshot();
   });
 
   it('should works with oblique', () => {
@@ -65,6 +65,6 @@ describe('FontStyle', () => {
     append(BODY, p1);
     append(BODY, p2);
 
-    return matchViewportSnapshot();
+    return snapshot();
   });
 });

--- a/integration_tests/specs/css/css-fonts/font-weight.ts
+++ b/integration_tests/specs/css/css-fonts/font-weight.ts
@@ -45,7 +45,7 @@ describe('FontWeight', () => {
       append(BODY, p1);
       append(BODY, p2);
 
-      return matchViewportSnapshot();
+      return snapshot();
     });
   });
 });

--- a/integration_tests/specs/css/css-fonts/font.ts
+++ b/integration_tests/specs/css/css-fonts/font.ts
@@ -47,6 +47,6 @@ describe('Font', () => {
     append(BODY, p4);
     append(BODY, p5);
 
-    return matchViewportSnapshot();
+    return snapshot();
   });
 });

--- a/integration_tests/specs/css/css-images/conic-gradient.ts
+++ b/integration_tests/specs/css/css-images/conic-gradient.ts
@@ -14,7 +14,7 @@ describe('conic-gradient', () => {
     });
     BODY.appendChild(gradient);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('angle', async () => {
     let gradient;
@@ -30,7 +30,7 @@ describe('conic-gradient', () => {
     });
     BODY.appendChild(gradient);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('center-ref', async () => {
     let top;
@@ -69,7 +69,7 @@ describe('conic-gradient', () => {
     );
     BODY.appendChild(box);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('center', async () => {
     let gradient;
@@ -85,6 +85,6 @@ describe('conic-gradient', () => {
     });
     BODY.appendChild(gradient);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-images/css-image.ts
+++ b/integration_tests/specs/css/css-images/css-image.ts
@@ -24,7 +24,7 @@ describe('css-image', () => {
     BODY.appendChild(p);
     BODY.appendChild(square);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('fallbacks-and-annotations', async () => {
     let p;
@@ -51,7 +51,7 @@ describe('css-image', () => {
     BODY.appendChild(p);
     BODY.appendChild(square);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('fallbacks-and-annotations002', async () => {
     let p;
@@ -79,7 +79,7 @@ describe('css-image', () => {
     BODY.appendChild(p);
     BODY.appendChild(square);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('fallbacks-and-annotations003', async () => {
     let p;
@@ -107,7 +107,7 @@ describe('css-image', () => {
     BODY.appendChild(p);
     BODY.appendChild(square);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('fallbacks-and-annotations004', async () => {
     let p;
@@ -135,7 +135,7 @@ describe('css-image', () => {
     BODY.appendChild(p);
     BODY.appendChild(square);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('fallbacks-and-annotations005', async () => {
     let p;
@@ -167,7 +167,7 @@ describe('css-image', () => {
     BODY.appendChild(p);
     BODY.appendChild(square);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
  it('size works width position absolute' , async (done) => {
@@ -201,7 +201,7 @@ describe('css-image', () => {
     n2.src = 'https://img.alicdn.com/tfs/TB14bXLHFT7gK0jSZFpXXaTkpXa-100-100.png';
 
     n2.onload = async () => {
-      await matchViewportSnapshot();
+      await snapshot();
       done();
     };
   });
@@ -229,7 +229,7 @@ describe('css-image', () => {
     image.src = 'https://gw.alicdn.com/tfs/TB1Fejan7cx_u4jSZFlXXXnUFXa-200-200.png';
 
     image.onload = async () => {
-      await matchViewportSnapshot();
+      await snapshot();
       done();
     };
   });
@@ -269,7 +269,7 @@ describe('css-image', () => {
         }
       });
       div.appendChild(image2);
-      await matchViewportSnapshot(0.1);
+      await snapshot(0.1);
       done();
     }, 1000);
   });

--- a/integration_tests/specs/css/css-images/gradient-border.ts
+++ b/integration_tests/specs/css/css-images/gradient-border.ts
@@ -14,7 +14,7 @@ describe('gradient-border', () => {
     });
     BODY.appendChild(x);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('box', async () => {
     let x;
@@ -34,6 +34,6 @@ describe('gradient-border', () => {
     });
     BODY.appendChild(x);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-images/gradient-button.ts
+++ b/integration_tests/specs/css/css-images/gradient-button.ts
@@ -17,6 +17,6 @@ describe('gradient-button', () => {
     });
     BODY.appendChild(button);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-images/gradient-content.ts
+++ b/integration_tests/specs/css/css-images/gradient-content.ts
@@ -17,7 +17,7 @@ describe('gradient-content', () => {
     });
     BODY.appendChild(x);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('box', async () => {
     let x;
@@ -35,6 +35,6 @@ describe('gradient-content', () => {
     });
     BODY.appendChild(x);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-images/gradient-move.ts
+++ b/integration_tests/specs/css/css-images/gradient-move.ts
@@ -14,7 +14,7 @@ describe('gradient-move', () => {
     });
     BODY.appendChild(gradient);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('stops', async () => {
     let gradient;
@@ -30,6 +30,6 @@ describe('gradient-move', () => {
     });
     BODY.appendChild(gradient);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-images/gradient.ts
+++ b/integration_tests/specs/css/css-images/gradient.ts
@@ -18,7 +18,7 @@ describe('gradient', () => {
     });
     BODY.appendChild(button);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('refcrash', async () => {
     let div;
@@ -30,6 +30,6 @@ describe('gradient', () => {
     });
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-images/gradients-with.ts
+++ b/integration_tests/specs/css/css-images/gradients-with.ts
@@ -47,7 +47,7 @@ describe('gradients-with', () => {
     BODY.appendChild(gradient2);
     BODY.appendChild(gradient3);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('transparent-ref', async () => {
     let p;
@@ -76,7 +76,7 @@ describe('gradients-with', () => {
     BODY.appendChild(p);
     BODY.appendChild(gradient1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('transparent', async () => {
     let p;
@@ -130,6 +130,6 @@ describe('gradients-with', () => {
     BODY.appendChild(gradient1);
     BODY.appendChild(gradient2);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-images/image-fit.ts
+++ b/integration_tests/specs/css/css-images/image-fit.ts
@@ -36,7 +36,7 @@ describe('image-fit', () => {
     BODY.appendChild(div);
     BODY.appendChild(div_1);
 
-    await matchViewportSnapshot(0.5);
+    await snapshot(0.5);
   });
   it('006', async () => {
     let div;
@@ -74,6 +74,6 @@ describe('image-fit', () => {
     BODY.appendChild(div);
     BODY.appendChild(div_1);
 
-    await matchViewportSnapshot(0.5);
+    await snapshot(0.5);
   });
 });

--- a/integration_tests/specs/css/css-images/infinite-radial.ts
+++ b/integration_tests/specs/css/css-images/infinite-radial.ts
@@ -27,7 +27,7 @@ describe('infinite-radial', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('gradient-refcrash', async () => {
     let p;
@@ -58,6 +58,6 @@ describe('infinite-radial', () => {
     BODY.appendChild(p);
     BODY.appendChild(crash);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-images/linear-gradient.ts
+++ b/integration_tests/specs/css/css-images/linear-gradient.ts
@@ -13,7 +13,7 @@ describe('linear-gradient', () => {
     });
     BODY.appendChild(gradient);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('2', async () => {
     let gradient;
@@ -28,7 +28,7 @@ describe('linear-gradient', () => {
     });
     BODY.appendChild(gradient);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('ref', async () => {
     let gradient;
@@ -44,6 +44,6 @@ describe('linear-gradient', () => {
     });
     BODY.appendChild(gradient);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-images/multiple-position.ts
+++ b/integration_tests/specs/css/css-images/multiple-position.ts
@@ -13,9 +13,9 @@ describe('multiple-position', () => {
     });
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('color-stop-conic-2', async () => {
     let div;
@@ -31,7 +31,7 @@ describe('multiple-position', () => {
     });
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('color-stop-conic', async () => {
     let target;
@@ -47,7 +47,7 @@ describe('multiple-position', () => {
     });
     BODY.appendChild(target);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('color-stop-linear-2-ref', async () => {
     let div;
@@ -62,7 +62,7 @@ describe('multiple-position', () => {
     });
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('color-stop-linear-2', async () => {
     let div;
@@ -77,7 +77,7 @@ describe('multiple-position', () => {
     });
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('color-stop-linear', async () => {
     let target;
@@ -93,7 +93,7 @@ describe('multiple-position', () => {
     });
     BODY.appendChild(target);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('color-stop-radial-2-ref', async () => {
     let div;
@@ -108,7 +108,7 @@ describe('multiple-position', () => {
     });
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('color-stop-radial-2', async () => {
     let div;
@@ -124,7 +124,7 @@ describe('multiple-position', () => {
     });
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('color-stop-radial', async () => {
     let target;
@@ -141,6 +141,6 @@ describe('multiple-position', () => {
     });
     BODY.appendChild(target);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-images/normalization-conic.ts
+++ b/integration_tests/specs/css/css-images/normalization-conic.ts
@@ -13,7 +13,7 @@ describe('normalization-conic', () => {
     });
     BODY.appendChild(gradient);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('degenerate', async () => {
     let gradient;
@@ -28,6 +28,6 @@ describe('normalization-conic', () => {
     });
     BODY.appendChild(gradient);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-images/normalization-linear.ts
+++ b/integration_tests/specs/css/css-images/normalization-linear.ts
@@ -13,7 +13,7 @@ describe('normalization-linear', () => {
     });
     BODY.appendChild(gradient);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('degenerate', async () => {
     let gradient;
@@ -28,6 +28,6 @@ describe('normalization-linear', () => {
     });
     BODY.appendChild(gradient);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-images/normalization-radial.ts
+++ b/integration_tests/specs/css/css-images/normalization-radial.ts
@@ -13,7 +13,7 @@ describe('normalization-radial', () => {
     });
     BODY.appendChild(gradient);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('degenerate', async () => {
     let gradient;
@@ -28,6 +28,6 @@ describe('normalization-radial', () => {
     });
     BODY.appendChild(gradient);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-images/normalization.ts
+++ b/integration_tests/specs/css/css-images/normalization.ts
@@ -13,7 +13,7 @@ describe('normalization', () => {
     });
     BODY.appendChild(gradient);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('linear', async () => {
     let gradient;
@@ -28,7 +28,7 @@ describe('normalization', () => {
     });
     BODY.appendChild(gradient);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('radial', async () => {
     let gradient;
@@ -43,6 +43,6 @@ describe('normalization', () => {
     });
     BODY.appendChild(gradient);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-images/out-of.ts
+++ b/integration_tests/specs/css/css-images/out-of.ts
@@ -14,6 +14,6 @@ describe('out-of', () => {
     });
     BODY.appendChild(gradient);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-images/repeating-conic.ts
+++ b/integration_tests/specs/css/css-images/repeating-conic.ts
@@ -14,7 +14,7 @@ describe('repeating-conic', () => {
     });
     BODY.appendChild(gradient);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('gradient', async () => {
     let gradient;
@@ -31,6 +31,6 @@ describe('repeating-conic', () => {
     });
     BODY.appendChild(gradient);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-images/tiled-conic.ts
+++ b/integration_tests/specs/css/css-images/tiled-conic.ts
@@ -377,7 +377,7 @@ describe('tiled-conic', () => {
     BODY.appendChild(bar_3);
     BODY.appendChild(bar_4);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('gradients', async () => {
     let gradient;
@@ -395,6 +395,6 @@ describe('tiled-conic', () => {
     });
     BODY.appendChild(gradient);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-images/tiled-gradients.ts
+++ b/integration_tests/specs/css/css-images/tiled-gradients.ts
@@ -136,6 +136,6 @@ describe('tiled-gradients', () => {
     BODY.appendChild(bar);
     BODY.appendChild(bar_1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-images/tiled-radial.ts
+++ b/integration_tests/specs/css/css-images/tiled-radial.ts
@@ -45,7 +45,7 @@ describe('tiled-radial', () => {
     );
     BODY.appendChild(outer);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('gradients', async () => {
     let gradient;
@@ -67,6 +67,6 @@ describe('tiled-radial', () => {
     });
     BODY.appendChild(gradient);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-images/tiled.ts
+++ b/integration_tests/specs/css/css-images/tiled.ts
@@ -15,6 +15,6 @@ describe('tiled', () => {
     });
     BODY.appendChild(gradient);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-inline/line-height.ts
+++ b/integration_tests/specs/css/css-inline/line-height.ts
@@ -18,7 +18,7 @@ describe('line-height', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('with unit of number', async () => {
@@ -40,7 +40,7 @@ describe('line-height', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('with block element', async () => {
@@ -75,7 +75,7 @@ describe('line-height', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('with inline element', async () => {
@@ -110,7 +110,7 @@ describe('line-height', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('with flex item', async () => {
@@ -161,7 +161,7 @@ describe('line-height', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('with multiple lines', async () => {
@@ -210,7 +210,7 @@ describe('line-height', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('works with text of multiple lines', async () => {
@@ -231,7 +231,7 @@ describe('line-height', () => {
       ]
     );
     BODY.appendChild(div);
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('should work with percentage', async () => {
@@ -261,7 +261,7 @@ describe('line-height', () => {
       ]
     );
     BODY.appendChild(div);
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
 });

--- a/integration_tests/specs/css/css-inline/vertical-align.ts
+++ b/integration_tests/specs/css/css-inline/vertical-align.ts
@@ -43,7 +43,7 @@ describe('vertical-align', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('with top', async () => {
@@ -89,7 +89,7 @@ describe('vertical-align', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('with bottom', async () => {
@@ -135,7 +135,7 @@ describe('vertical-align', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it("works with baseline in nested inline elements", async () => {
@@ -180,7 +180,7 @@ describe('vertical-align', () => {
       ]
     );
     BODY.appendChild(container);
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it("work with baseline in nested block elements", async () => {
@@ -224,7 +224,7 @@ describe('vertical-align', () => {
       ]
     );
     BODY.appendChild(container);
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it("work with baseline in nested block elements and contain text", async () => {
@@ -272,6 +272,6 @@ describe('vertical-align', () => {
       ]
     );
     BODY.appendChild(container);
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-overflow/clip-001.ts
+++ b/integration_tests/specs/css/css-overflow/clip-001.ts
@@ -42,6 +42,6 @@ describe('clip-001', () => {
     );
     BODY.appendChild(container);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-overflow/clip-002.ts
+++ b/integration_tests/specs/css/css-overflow/clip-002.ts
@@ -94,6 +94,6 @@ describe('clip-002', () => {
     BODY.appendChild(outer_1);
     BODY.appendChild(outer_2);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-overflow/clip-003.ts
+++ b/integration_tests/specs/css/css-overflow/clip-003.ts
@@ -238,6 +238,6 @@ describe('clip-003', () => {
     BODY.appendChild(wrapper_3);
     BODY.appendChild(wrapper_4);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-overflow/clip-004.ts
+++ b/integration_tests/specs/css/css-overflow/clip-004.ts
@@ -94,6 +94,6 @@ describe('clip-004', () => {
     BODY.appendChild(outer_1);
     BODY.appendChild(outer_2);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-overflow/clip-005.ts
+++ b/integration_tests/specs/css/css-overflow/clip-005.ts
@@ -97,6 +97,6 @@ describe('clip-005', () => {
     BODY.appendChild(outer_1);
     BODY.appendChild(outer_2);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-overflow/clip.ts
+++ b/integration_tests/specs/css/css-overflow/clip.ts
@@ -101,7 +101,7 @@ describe('clip', () => {
     BODY.appendChild(outer_1);
     BODY.appendChild(outer_2);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('003', async () => {
     let inner;
@@ -347,7 +347,7 @@ describe('clip', () => {
     BODY.appendChild(wrapper_3);
     BODY.appendChild(wrapper_4);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('004', async () => {
     let inner;
@@ -453,7 +453,7 @@ describe('clip', () => {
     BODY.appendChild(outer_1);
     BODY.appendChild(outer_2);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('005', async () => {
     let inner;
@@ -562,6 +562,6 @@ describe('clip', () => {
     BODY.appendChild(outer_1);
     BODY.appendChild(outer_2);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-overflow/orthogonal-flow.ts
+++ b/integration_tests/specs/css/css-overflow/orthogonal-flow.ts
@@ -29,6 +29,6 @@ describe('orthogonal-flow', () => {
     );
     BODY.appendChild(container);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-overflow/overflow-abpos.ts
+++ b/integration_tests/specs/css/css-overflow/overflow-abpos.ts
@@ -32,6 +32,6 @@ describe('overflow-abpos', () => {
     );
     BODY.appendChild(container);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-overflow/overflow-change.ts
+++ b/integration_tests/specs/css/css-overflow/overflow-change.ts
@@ -17,11 +17,11 @@ describe('overflow-change', () => {
 
     setTimeout(async() => {
       cont.style.overflow = 'hidden';
-      await matchViewportSnapshot(0.1);
+      await snapshot(0.1);
       done();
     }, 100);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('should work with overflow change from hidden to visible', async (done) => {
@@ -42,11 +42,11 @@ describe('overflow-change', () => {
 
     setTimeout(async() => {
       cont.style.overflow = 'visible';
-      await matchViewportSnapshot(0.1);
+      await snapshot(0.1);
       done();
     }, 100);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('change from scroll to visible and no transform exists', async (done) => {
@@ -68,11 +68,11 @@ describe('overflow-change', () => {
     );
     append(BODY, cont);
 
-    await matchViewportSnapshot();
+    await snapshot();
 
     requestAnimationFrame(async() => {
       cont.style.overflow = 'visible';
-      await matchViewportSnapshot(0.1);
+      await snapshot(0.1);
       done();
     });
   });
@@ -97,11 +97,11 @@ describe('overflow-change', () => {
     );
     append(BODY, cont);
 
-    await matchViewportSnapshot();
+    await snapshot();
 
     requestAnimationFrame(async() => {
       cont.style.overflow = 'visible';
-      await matchViewportSnapshot(0.1);
+      await snapshot(0.1);
       done();
     });
   });
@@ -125,11 +125,11 @@ describe('overflow-change', () => {
     );
     append(BODY, cont);
 
-    await matchViewportSnapshot();
+    await snapshot();
 
     requestAnimationFrame(async() => {
       cont.style.overflow = 'scroll';
-      await matchViewportSnapshot(0.1);
+      await snapshot(0.1);
       done();
     });
   });
@@ -157,14 +157,14 @@ describe('overflow-change', () => {
     ]);
     BODY.appendChild(inner3);
 
-    await matchViewportSnapshot();
+    await snapshot();
 
     requestAnimationFrame(async() => {
       inner3.style.position = 'static';
       inner3.style.position = 'relative';
       inner3.style.overflowY = 'visible';
       inner3.style.overflowY = 'scroll';
-      await matchViewportSnapshot(0.1);
+      await snapshot(0.1);
       done();
     });
   });

--- a/integration_tests/specs/css/css-overflow/overflow-ellipsis.ts
+++ b/integration_tests/specs/css/css-overflow/overflow-ellipsis.ts
@@ -18,6 +18,6 @@ describe('overflow-ellipsis', () => {
     );
     BODY.appendChild(p);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-overflow/overflow-inline.ts
+++ b/integration_tests/specs/css/css-overflow/overflow-inline.ts
@@ -48,6 +48,6 @@ describe('overflow-inline', () => {
     );
     BODY.appendChild(container);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-overflow/overflow-recalc.ts
+++ b/integration_tests/specs/css/css-overflow/overflow-recalc.ts
@@ -98,6 +98,6 @@ describe('overflow-recalc', () => {
     BODY.appendChild(p);
     BODY.appendChild(scroller);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-overflow/overfow-outside.ts
+++ b/integration_tests/specs/css/css-overflow/overfow-outside.ts
@@ -221,6 +221,6 @@ describe('overfow-outside', () => {
     BODY.appendChild(container_4);
     BODY.appendChild(container_5);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-overflow/text-overflow.ts
+++ b/integration_tests/specs/css/css-overflow/text-overflow.ts
@@ -61,7 +61,7 @@ describe('text-overflow', () => {
     BODY.appendChild(div_1);
     BODY.appendChild(div_2);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('ellipsis-002', async () => {
     let element;
@@ -96,7 +96,7 @@ describe('text-overflow', () => {
     );
     BODY.appendChild(parent);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('ellipsis-editing-input-ref', async () => {
     let p;
@@ -122,7 +122,7 @@ describe('text-overflow', () => {
     BODY.appendChild(inputElement);
     inputElement.setAttribute('value', 'xxxxxxxxxxxxxxxx');
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   
   it('ellipsis-editing-input', async () => {
@@ -149,6 +149,6 @@ describe('text-overflow', () => {
     BODY.appendChild(inputElement);
     inputElement.setAttribute('value', 'xxxxxxxxxxxxxxxx');
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-position/absolute-non.ts
+++ b/integration_tests/specs/css/css-position/absolute-non.ts
@@ -48,7 +48,7 @@ describe('absolute-non', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('replaced-height-002-ref', async () => {
     let p;
@@ -102,7 +102,7 @@ describe('absolute-non', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('replaced-height-002', async () => {
     let p;
@@ -176,7 +176,7 @@ describe('absolute-non', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('replaced-height-003-ref', async () => {
     let p;
@@ -233,7 +233,7 @@ describe('absolute-non', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('replaced-height-003', async () => {
     let p;
@@ -292,7 +292,7 @@ describe('absolute-non', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('replaced-height-004', async () => {
     let p;
@@ -351,7 +351,7 @@ describe('absolute-non', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('replaced-height-005', async () => {
     let p;
@@ -410,7 +410,7 @@ describe('absolute-non', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('replaced-height-006-ref', async () => {
     let p;
@@ -461,7 +461,7 @@ describe('absolute-non', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('replaced-height-006', async () => {
     let p;
@@ -531,7 +531,7 @@ describe('absolute-non', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('replaced-height-007-ref', async () => {
     let p;
@@ -582,9 +582,9 @@ describe('absolute-non', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('replaced-height-007', async () => {
     let p;
@@ -648,7 +648,7 @@ describe('absolute-non', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('replaced-height-008-ref', async () => {
     let p;
@@ -696,7 +696,7 @@ describe('absolute-non', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('replaced-height-008', async () => {
     let p;
@@ -743,7 +743,7 @@ describe('absolute-non', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('replaced-height-009-ref', async () => {
     let p;
@@ -796,7 +796,7 @@ describe('absolute-non', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('replaced-height-009', async () => {
     let p;
@@ -858,7 +858,7 @@ describe('absolute-non', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('replaced-height-010', async () => {
     let p;
@@ -917,7 +917,7 @@ describe('absolute-non', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('replaced-height-011', async () => {
     let p;
@@ -976,7 +976,7 @@ describe('absolute-non', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('replaced-height-012', async () => {
     let p;
@@ -1035,7 +1035,7 @@ describe('absolute-non', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('replaced-height-013', async () => {
     let p;
@@ -1090,7 +1090,7 @@ describe('absolute-non', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('replaced-max-height-001', async () => {
     let p;
@@ -1140,7 +1140,7 @@ describe('absolute-non', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('replaced-max-height-002-ref', async () => {
     let p;
@@ -1188,7 +1188,7 @@ describe('absolute-non', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('replaced-max-height-002', async () => {
     let p;
@@ -1249,7 +1249,7 @@ describe('absolute-non', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('replaced-max-height-003-ref', async () => {
     let p;
@@ -1297,7 +1297,7 @@ describe('absolute-non', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('replaced-max-height-003', async () => {
     let p;
@@ -1357,7 +1357,7 @@ describe('absolute-non', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('replaced-max-height-004', async () => {
     let p;
@@ -1417,7 +1417,7 @@ describe('absolute-non', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('replaced-max-height-005', async () => {
     let p;
@@ -1477,7 +1477,7 @@ describe('absolute-non', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('replaced-max-height-006', async () => {
     let p;
@@ -1537,7 +1537,7 @@ describe('absolute-non', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('replaced-max-height-007-ref', async () => {
     let p;
@@ -1592,7 +1592,7 @@ describe('absolute-non', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('replaced-max-height-007', async () => {
     let p;
@@ -1666,7 +1666,7 @@ describe('absolute-non', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('replaced-max-height-008-ref', async () => {
     let p;
@@ -1716,7 +1716,7 @@ describe('absolute-non', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('replaced-max-height-008', async () => {
     let p;
@@ -1768,7 +1768,7 @@ describe('absolute-non', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('replaced-max-height-009-ref', async () => {
     let p;
@@ -1823,7 +1823,7 @@ describe('absolute-non', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('replaced-max-height-009', async () => {
     let p;
@@ -1896,7 +1896,7 @@ describe('absolute-non', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('replaced-max-height-010', async () => {
     let p;
@@ -1956,7 +1956,7 @@ describe('absolute-non', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('replaced-max-height-011', async () => {
     let p;
@@ -2016,7 +2016,7 @@ describe('absolute-non', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('replaced-max-height-012', async () => {
     let p;
@@ -2076,7 +2076,7 @@ describe('absolute-non', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('replaced-width-001', async () => {
     let p;
@@ -2149,7 +2149,7 @@ describe('absolute-non', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('replaced-width-002-ref', async () => {
     let p;
@@ -2204,7 +2204,7 @@ describe('absolute-non', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('replaced-width-002', async () => {
     let p;
@@ -2277,7 +2277,7 @@ describe('absolute-non', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('replaced-width-003-ref', async () => {
     let p;
@@ -2332,7 +2332,7 @@ describe('absolute-non', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('replaced-width-003', async () => {
     let p;
@@ -2406,7 +2406,7 @@ describe('absolute-non', () => {
     BODY.appendChild(p);
     BODY.appendChild(containingblock);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('replaced-width-004', async () => {
     let p;
@@ -2481,7 +2481,7 @@ describe('absolute-non', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('replaced-width-005', async () => {
     let p;
@@ -2556,7 +2556,7 @@ describe('absolute-non', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('replaced-width-006', async () => {
     let p;
@@ -2631,7 +2631,7 @@ describe('absolute-non', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('replaced-width-007', async () => {
     let p;
@@ -2706,7 +2706,7 @@ describe('absolute-non', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('replaced-width-008-ref', async () => {
     let p;
@@ -2760,7 +2760,7 @@ describe('absolute-non', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('replaced-width-008', async () => {
     let p;
@@ -2835,7 +2835,7 @@ describe('absolute-non', () => {
     BODY.appendChild(p);
     BODY.appendChild(containingblock);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('replaced-width-009', async () => {
     let p;
@@ -2910,7 +2910,7 @@ describe('absolute-non', () => {
     BODY.appendChild(p);
     BODY.appendChild(containingblock);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('replaced-width-010', async () => {
     let p;
@@ -2984,7 +2984,7 @@ describe('absolute-non', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('replaced-width-011', async () => {
     let p;
@@ -3059,7 +3059,7 @@ describe('absolute-non', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('replaced-width-012', async () => {
     let p;
@@ -3134,7 +3134,7 @@ describe('absolute-non', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('replaced-width-013', async () => {
     let p;
@@ -3208,7 +3208,7 @@ describe('absolute-non', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('replaced-width-014', async () => {
     let p;
@@ -3282,7 +3282,7 @@ describe('absolute-non', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('replaced-width-015-ref', async () => {
     let p;
@@ -3337,7 +3337,7 @@ describe('absolute-non', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('replaced-width-015', async () => {
     let p;
@@ -3406,7 +3406,7 @@ describe('absolute-non', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('replaced-width-016', async () => {
     let p;
@@ -3480,7 +3480,7 @@ describe('absolute-non', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('replaced-width-017-ref', async () => {
     let p;
@@ -3531,7 +3531,7 @@ describe('absolute-non', () => {
     BODY.appendChild(green45X120_1);
     BODY.appendChild(blackStripe);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('replaced-width-017', async () => {
     let p;
@@ -3578,7 +3578,7 @@ describe('absolute-non', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('replaced-width-018', async () => {
     let p;
@@ -3628,7 +3628,7 @@ describe('absolute-non', () => {
     BODY.appendChild(p);
     BODY.appendChild(outerAbsPos);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('replaced-width-019', async () => {
     let p;
@@ -3678,7 +3678,7 @@ describe('absolute-non', () => {
     BODY.appendChild(p);
     BODY.appendChild(outerAbsPos);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('replaced-width-020', async () => {
     let p;
@@ -3725,7 +3725,7 @@ describe('absolute-non', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('replaced-width-021-ref', async () => {
     let p;
@@ -3779,7 +3779,7 @@ describe('absolute-non', () => {
     BODY.appendChild(green45X120_1);
     BODY.appendChild(blackStripe);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('replaced-width-021', async () => {
     let p;
@@ -3828,7 +3828,7 @@ describe('absolute-non', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('replaced-width-022', async () => {
     let p;
@@ -3880,7 +3880,7 @@ describe('absolute-non', () => {
     BODY.appendChild(p);
     BODY.appendChild(outerAbsPos);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('replaced-width-023', async () => {
     let p;
@@ -3932,7 +3932,7 @@ describe('absolute-non', () => {
     BODY.appendChild(p);
     BODY.appendChild(outerAbsPos);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('replaced-width-024', async () => {
     let p;
@@ -3981,7 +3981,7 @@ describe('absolute-non', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('replaced-width-025-ref', async () => {
     let p;
@@ -4024,7 +4024,7 @@ describe('absolute-non', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('replaced-width-025', async () => {
     let p;
@@ -4092,7 +4092,7 @@ describe('absolute-non', () => {
     BODY.appendChild(absPosOverlappingGreen);
     BODY.appendChild(overlappedRed);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('replaced-width-026-ref', async () => {
     let p;
@@ -4136,7 +4136,7 @@ describe('absolute-non', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('replaced-width-026', async () => {
     let p;
@@ -4204,7 +4204,7 @@ describe('absolute-non', () => {
     BODY.appendChild(absPosOverlappingGreen);
     BODY.appendChild(overlappedRed);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('replaced-width-027', async () => {
     let p;
@@ -4274,7 +4274,7 @@ describe('absolute-non', () => {
     BODY.appendChild(p);
     BODY.appendChild(relPosContainer);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('replaced-width-028', async () => {
     let p;
@@ -4338,6 +4338,6 @@ describe('absolute-non', () => {
     BODY.appendChild(p_1);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-position/absolute-replaced.ts
+++ b/integration_tests/specs/css/css-position/absolute-replaced.ts
@@ -43,7 +43,7 @@ describe('absolute-replaced', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot(0.1);
+    await snapshot(0.1);
   });
   xit('height-001', async () => {
     let p;
@@ -98,7 +98,7 @@ describe('absolute-replaced', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('height-002-ref', async () => {
     let p;
@@ -153,7 +153,7 @@ describe('absolute-replaced', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot(0.1);
+    await snapshot(0.1);
   });
   xit('height-002', async () => {
     let p;
@@ -216,7 +216,7 @@ describe('absolute-replaced', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot(0.1);
+    await snapshot(0.1);
   });
   xit('height-003', async () => {
     let p;
@@ -279,7 +279,7 @@ describe('absolute-replaced', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('height-004-ref', async () => {
     let p;
@@ -313,7 +313,7 @@ describe('absolute-replaced', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('height-004', async () => {
     let p;
@@ -374,7 +374,7 @@ describe('absolute-replaced', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('height-005-ref', async () => {
     let p;
@@ -408,7 +408,7 @@ describe('absolute-replaced', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('height-005', async () => {
     let p;
@@ -471,7 +471,7 @@ describe('absolute-replaced', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('height-006-ref', async () => {
     let p;
@@ -522,7 +522,7 @@ describe('absolute-replaced', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('height-007-ref', async () => {
     let p;
@@ -555,7 +555,7 @@ describe('absolute-replaced', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('height-007', async () => {
     let p;
@@ -615,7 +615,7 @@ describe('absolute-replaced', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('height-008-ref', async () => {
     let p;
@@ -654,7 +654,7 @@ describe('absolute-replaced', () => {
     BODY.appendChild(div);
     BODY.appendChild(div_1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('height-008', async () => {
     let p;
@@ -715,7 +715,7 @@ describe('absolute-replaced', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('height-009', async () => {
     let p;
@@ -774,7 +774,7 @@ describe('absolute-replaced', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('height-010-ref', async () => {
     let p;
@@ -813,7 +813,7 @@ describe('absolute-replaced', () => {
     BODY.appendChild(div);
     BODY.appendChild(div_1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('height-010', async () => {
     let p;
@@ -872,7 +872,7 @@ describe('absolute-replaced', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('height-011-ref', async () => {
     let p;
@@ -907,7 +907,7 @@ describe('absolute-replaced', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('height-011', async () => {
     let p;
@@ -970,7 +970,7 @@ describe('absolute-replaced', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('height-012-ref', async () => {
     let p;
@@ -1005,7 +1005,7 @@ describe('absolute-replaced', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('height-012', async () => {
     let p;
@@ -1070,7 +1070,7 @@ describe('absolute-replaced', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('height-013-ref', async () => {
     let p;
@@ -1128,7 +1128,7 @@ describe('absolute-replaced', () => {
     BODY.appendChild(div);
     BODY.appendChild(div_1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('height-014-ref', async () => {
     let p;
@@ -1162,7 +1162,7 @@ describe('absolute-replaced', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('height-014', async () => {
     let p;
@@ -1225,7 +1225,7 @@ describe('absolute-replaced', () => {
     BODY.appendChild(p);
     BODY.appendChild(containingBlock);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('height-016', async () => {
     let p;
@@ -1284,7 +1284,7 @@ describe('absolute-replaced', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('height-017', async () => {
     let p;
@@ -1343,7 +1343,7 @@ describe('absolute-replaced', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('height-018', async () => {
     let p;
@@ -1406,7 +1406,7 @@ describe('absolute-replaced', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('height-019', async () => {
     let p;
@@ -1471,7 +1471,7 @@ describe('absolute-replaced', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('height-021', async () => {
     let p;
@@ -1534,7 +1534,7 @@ describe('absolute-replaced', () => {
     BODY.appendChild(p);
     BODY.appendChild(containingBlock);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('height-022', async () => {
     let p;
@@ -1593,7 +1593,7 @@ describe('absolute-replaced', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('height-023', async () => {
     let p;
@@ -1654,7 +1654,7 @@ describe('absolute-replaced', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('height-024', async () => {
     let p;
@@ -1715,7 +1715,7 @@ describe('absolute-replaced', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('height-025', async () => {
     let p;
@@ -1780,7 +1780,7 @@ describe('absolute-replaced', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('height-026', async () => {
     let p;
@@ -1847,7 +1847,7 @@ describe('absolute-replaced', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('height-028', async () => {
     let p;
@@ -1912,7 +1912,7 @@ describe('absolute-replaced', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('height-029', async () => {
     let p;
@@ -1971,7 +1971,7 @@ describe('absolute-replaced', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('height-030', async () => {
     let p;
@@ -2032,7 +2032,7 @@ describe('absolute-replaced', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('height-031', async () => {
     let p;
@@ -2093,7 +2093,7 @@ describe('absolute-replaced', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('height-032', async () => {
     let p;
@@ -2158,7 +2158,7 @@ describe('absolute-replaced', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('height-033', async () => {
     let p;
@@ -2225,7 +2225,7 @@ describe('absolute-replaced', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('height-035', async () => {
     let p;
@@ -2290,7 +2290,7 @@ describe('absolute-replaced', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('height-036', async () => {
     let p;
@@ -2408,7 +2408,7 @@ describe('absolute-replaced', () => {
     BODY.appendChild(p);
     BODY.appendChild(container);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('width-001-ref', async () => {
     let p;
@@ -2455,7 +2455,7 @@ describe('absolute-replaced', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('width-001', async () => {
     let p;
@@ -2511,7 +2511,7 @@ describe('absolute-replaced', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('width-002-ref', async () => {
     let p;
@@ -2562,7 +2562,7 @@ describe('absolute-replaced', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('width-003-ref', async () => {
     let p;
@@ -2613,7 +2613,7 @@ describe('absolute-replaced', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('width-003a-ref', async () => {
     let p;
@@ -2647,7 +2647,7 @@ describe('absolute-replaced', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('width-003b-ref', async () => {
     let p;
@@ -2681,7 +2681,7 @@ describe('absolute-replaced', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('width-003c-ref', async () => {
     let p;
@@ -2715,7 +2715,7 @@ describe('absolute-replaced', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('width-004-ref', async () => {
     let p;
@@ -2768,7 +2768,7 @@ describe('absolute-replaced', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('width-006-ref', async () => {
     let p;
@@ -2819,7 +2819,7 @@ describe('absolute-replaced', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('width-006', async () => {
     let p;
@@ -2877,7 +2877,7 @@ describe('absolute-replaced', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('width-008', async () => {
     let p;
@@ -2936,7 +2936,7 @@ describe('absolute-replaced', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('width-013', async () => {
     let p;
@@ -2997,7 +2997,7 @@ describe('absolute-replaced', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('width-015-ref', async () => {
     let p;
@@ -3048,7 +3048,7 @@ describe('absolute-replaced', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('width-015', async () => {
     let p;
@@ -3108,7 +3108,7 @@ describe('absolute-replaced', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('width-020-ref', async () => {
     let p;
@@ -3163,7 +3163,7 @@ describe('absolute-replaced', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('width-020', async () => {
     let p;
@@ -3224,7 +3224,7 @@ describe('absolute-replaced', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('width-022-ref', async () => {
     let p;
@@ -3279,7 +3279,7 @@ describe('absolute-replaced', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('width-022', async () => {
     let p;
@@ -3340,7 +3340,7 @@ describe('absolute-replaced', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('width-023-ref', async () => {
     let p;
@@ -3393,7 +3393,7 @@ describe('absolute-replaced', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('width-024-ref', async () => {
     let p;
@@ -3446,7 +3446,7 @@ describe('absolute-replaced', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('width-025-ref', async () => {
     let p;
@@ -3501,7 +3501,7 @@ describe('absolute-replaced', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('width-027-ref', async () => {
     let p;
@@ -3554,7 +3554,7 @@ describe('absolute-replaced', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('width-027', async () => {
     let p;
@@ -3616,7 +3616,7 @@ describe('absolute-replaced', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('width-029', async () => {
     let p;
@@ -3677,7 +3677,7 @@ describe('absolute-replaced', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('width-034', async () => {
     let p;
@@ -3738,7 +3738,7 @@ describe('absolute-replaced', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('width-036-ref', async () => {
     let p;
@@ -3799,7 +3799,7 @@ describe('absolute-replaced', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('width-036', async () => {
     let p;
@@ -3871,7 +3871,7 @@ describe('absolute-replaced', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('width-037-ref', async () => {
     let p;
@@ -3932,7 +3932,7 @@ describe('absolute-replaced', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('width-039-ref', async () => {
     let p;
@@ -3995,7 +3995,7 @@ describe('absolute-replaced', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('width-041-ref', async () => {
     let p;
@@ -4056,7 +4056,7 @@ describe('absolute-replaced', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('width-041', async () => {
     let p;
@@ -4129,7 +4129,7 @@ describe('absolute-replaced', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('width-043', async () => {
     let p;
@@ -4201,7 +4201,7 @@ describe('absolute-replaced', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('width-048', async () => {
     let p;
@@ -4274,7 +4274,7 @@ describe('absolute-replaced', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('width-050', async () => {
     let p;
@@ -4346,7 +4346,7 @@ describe('absolute-replaced', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('width-055', async () => {
     let p;
@@ -4419,7 +4419,7 @@ describe('absolute-replaced', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('width-057', async () => {
     let p;
@@ -4491,7 +4491,7 @@ describe('absolute-replaced', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('width-062', async () => {
     let p;
@@ -4564,7 +4564,7 @@ describe('absolute-replaced', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('width-064', async () => {
     let p;
@@ -4636,7 +4636,7 @@ describe('absolute-replaced', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('width-069', async () => {
     let p;
@@ -4709,7 +4709,7 @@ describe('absolute-replaced', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('width-071', async () => {
     let p;
@@ -4781,7 +4781,7 @@ describe('absolute-replaced', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('width-076', async () => {
     let p;
@@ -4854,6 +4854,6 @@ describe('absolute-replaced', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-position/absolute.ts
+++ b/integration_tests/specs/css/css-position/absolute.ts
@@ -27,7 +27,7 @@ describe('Position absolute', () => {
     container.appendChild(div2);
     document.body.appendChild(container);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('should be a green square below', async done => {
@@ -44,11 +44,11 @@ describe('Position absolute', () => {
     });
     append(parent, child);
     append(BODY, parent);
-    await matchElementImageSnapshot(parent);
+    await snapshot(parent);
 
     requestAnimationFrame(async () => {
       child.style.left = '150px';
-      await matchElementImageSnapshot(parent);
+      await snapshot(parent);
       done();
     });
   });
@@ -76,7 +76,7 @@ describe('Position absolute', () => {
     append(div2, span);
     append(BODY, div1);
     append(div1, div2);
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('with no top following inline element', async () => {
@@ -102,7 +102,7 @@ describe('Position absolute', () => {
     append(div2, span);
     append(BODY, div1);
     append(div1, div2);
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('with no left following block element', async () => {
@@ -130,7 +130,7 @@ describe('Position absolute', () => {
     append(div2, span);
     append(BODY, div1);
     append(div1, div2);
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('with no top following block element', async () => {
@@ -158,7 +158,7 @@ describe('Position absolute', () => {
     append(div2, span);
     append(BODY, div1);
     append(div1, div2);
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('with no left in flex layout', async () => {
@@ -203,7 +203,7 @@ describe('Position absolute', () => {
     ]);
 
     append(BODY, div);
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('with no top in flex layout', async () => {
@@ -248,7 +248,7 @@ describe('Position absolute', () => {
     ]);
 
     append(BODY, div);
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('with no left and top in flex layout', async () => {
@@ -291,7 +291,7 @@ describe('Position absolute', () => {
     ]);
 
     append(BODY, div);
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('works with dynamic change bottom property', async (done) => {
@@ -303,17 +303,17 @@ describe('Position absolute', () => {
 
     setTimeout(async () => {
       div.style.bottom = '100px';
-      await matchViewportSnapshot();
+      await snapshot();
     }, 100);
 
     setTimeout(async () => {
       div.style.bottom = '-200px';
-      await matchViewportSnapshot();
+      await snapshot();
       done();
     }, 300);
 
     document.body.appendChild(div);
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('works with dynamic change width property', async (done) => {
@@ -325,17 +325,17 @@ describe('Position absolute', () => {
 
     setTimeout(async () => {
       div.style.width = '100px';
-      await matchViewportSnapshot();
+      await snapshot();
     }, 100);
 
     setTimeout(async () => {
       div.style.width = '400px';
-      await matchViewportSnapshot();
+      await snapshot();
       done();
     }, 300);
 
     document.body.appendChild(div);
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('works with dynamic change height property', async (done) => {
@@ -347,17 +347,17 @@ describe('Position absolute', () => {
 
     setTimeout(async () => {
       div.style.height = '100px';
-      await matchViewportSnapshot();
+      await snapshot();
     }, 100);
 
     setTimeout(async () => {
       div.style.height = '400px';
-      await matchViewportSnapshot();
+      await snapshot();
       done();
     }, 300);
 
     document.body.appendChild(div);
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('works with dynamic change top property', async (done) => {
@@ -369,17 +369,17 @@ describe('Position absolute', () => {
 
     setTimeout(async () => {
       div.style.top = '100px';
-      await matchViewportSnapshot();
+      await snapshot();
     }, 100);
 
     setTimeout(async () => {
       div.style.top = '-50px';
-      await matchViewportSnapshot();
+      await snapshot();
       done();
     }, 300);
 
     document.body.appendChild(div);
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('works with dynamic change left property', async (done) => {
@@ -391,17 +391,17 @@ describe('Position absolute', () => {
 
     setTimeout(async () => {
       div.style.left = '100px';
-      await matchViewportSnapshot();
+      await snapshot();
     }, 100);
 
     setTimeout(async () => {
       div.style.left = '-50px';
-      await matchViewportSnapshot();
+      await snapshot();
       done();
     }, 300);
 
     document.body.appendChild(div);
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('works with dynamic change right property', async (done) => {
@@ -413,17 +413,17 @@ describe('Position absolute', () => {
 
     setTimeout(async () => {
       div.style.right = '100px';
-      await matchViewportSnapshot();
+      await snapshot();
     }, 100);
 
     setTimeout(async () => {
       div.style.right = '-50px';
-      await matchViewportSnapshot();
+      await snapshot();
       done();
     }, 300);
 
     document.body.appendChild(div);
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('with no width and height', async () => {
@@ -450,7 +450,7 @@ describe('Position absolute', () => {
     ]);
 
     append(BODY, div);
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('works with nested children' , async () => {
@@ -491,7 +491,7 @@ describe('Position absolute', () => {
     );
     BODY.appendChild(n1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('with no left and width in flex layout', async () => {
@@ -529,7 +529,7 @@ describe('Position absolute', () => {
     ]);
 
     append(BODY, div);
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('with no top and height in flex layout', async () => {
@@ -567,7 +567,7 @@ describe('Position absolute', () => {
     ]);
 
     append(BODY, div);
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('with no top left width and height in flex layout', async () => {
@@ -603,7 +603,7 @@ describe('Position absolute', () => {
     ]);
 
     append(BODY, div);
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('should work with percentage size in flow layout', async () => {
@@ -639,7 +639,7 @@ describe('Position absolute', () => {
     );
 
     BODY.appendChild(div);
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('should work with percentage size in flex layout', async () => {
@@ -676,7 +676,7 @@ describe('Position absolute', () => {
     );
 
     BODY.appendChild(div);
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('should work with percentage offset', async () => {
@@ -723,6 +723,6 @@ describe('Position absolute', () => {
     );
 
     BODY.appendChild(div);
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-position/abspos-001.ts
+++ b/integration_tests/specs/css/css-position/abspos-001.ts
@@ -32,6 +32,6 @@ describe('abspos-001', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-position/abspos-002.ts
+++ b/integration_tests/specs/css/css-position/abspos-002.ts
@@ -22,6 +22,6 @@ describe('abspos-002', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-position/abspos-007.ts
+++ b/integration_tests/specs/css/css-position/abspos-007.ts
@@ -34,6 +34,6 @@ describe('abspos-007', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-position/abspos-008.ts
+++ b/integration_tests/specs/css/css-position/abspos-008.ts
@@ -38,6 +38,6 @@ describe('abspos-008', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-position/abspos-009.ts
+++ b/integration_tests/specs/css/css-position/abspos-009.ts
@@ -33,6 +33,6 @@ describe('abspos-009', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-position/abspos-013.ts
+++ b/integration_tests/specs/css/css-position/abspos-013.ts
@@ -17,6 +17,6 @@ describe('abspos-013', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-position/abspos-024.ts
+++ b/integration_tests/specs/css/css-position/abspos-024.ts
@@ -43,6 +43,6 @@ describe('abspos-024', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot(0.1);
+    await snapshot(0.1);
   });
 });

--- a/integration_tests/specs/css/css-position/abspos-025.ts
+++ b/integration_tests/specs/css/css-position/abspos-025.ts
@@ -45,6 +45,6 @@ describe('abspos-025', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-position/abspos-028.ts
+++ b/integration_tests/specs/css/css-position/abspos-028.ts
@@ -32,6 +32,6 @@ describe('abspos-028', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-position/abspos-block.ts
+++ b/integration_tests/specs/css/css-position/abspos-block.ts
@@ -128,7 +128,7 @@ describe('abspos-block', () => {
     BODY.appendChild(rtl);
     BODY.appendChild(rtl_1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('level-001', async () => {
     let absolute;
@@ -278,6 +278,6 @@ describe('abspos-block', () => {
     BODY.appendChild(rtl);
     BODY.appendChild(rtl_1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-position/abspos-containing.ts
+++ b/integration_tests/specs/css/css-position/abspos-containing.ts
@@ -24,7 +24,7 @@ describe('abspos-containing', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('block-001', async () => {
     let div;
@@ -61,7 +61,7 @@ describe('abspos-containing', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('block-002', async () => {
     let div;
@@ -98,7 +98,7 @@ describe('abspos-containing', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('block-003', async () => {
     let div;
@@ -135,7 +135,7 @@ describe('abspos-containing', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('block-004', async () => {
     let div;
@@ -172,7 +172,7 @@ describe('abspos-containing', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('block-005', async () => {
     let div;
@@ -209,7 +209,7 @@ describe('abspos-containing', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('block-006', async () => {
     let div;
@@ -246,7 +246,7 @@ describe('abspos-containing', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('block-007', async () => {
     let div;
@@ -283,7 +283,7 @@ describe('abspos-containing', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('block-008', async () => {
     let div;
@@ -320,7 +320,7 @@ describe('abspos-containing', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('block-009', async () => {
     let div;
@@ -357,7 +357,7 @@ describe('abspos-containing', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('block-010', async () => {
     let p;
@@ -420,6 +420,6 @@ describe('abspos-containing', () => {
     BODY.appendChild(p_1);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-position/abspos-float.ts
+++ b/integration_tests/specs/css/css-position/abspos-float.ts
@@ -23,6 +23,6 @@ describe('abspos-float', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-position/abspos-inline.ts
+++ b/integration_tests/specs/css/css-position/abspos-inline.ts
@@ -106,7 +106,7 @@ describe('abspos-inline', () => {
     BODY.appendChild(p);
     BODY.appendChild(p_1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('002', async () => {
     let filler;
@@ -215,7 +215,7 @@ describe('abspos-inline', () => {
     BODY.appendChild(p);
     BODY.appendChild(p_1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('003', async () => {
     let filler;
@@ -324,7 +324,7 @@ describe('abspos-inline', () => {
     BODY.appendChild(p);
     BODY.appendChild(p_1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('004', async () => {
     let filler;
@@ -433,7 +433,7 @@ describe('abspos-inline', () => {
     BODY.appendChild(p);
     BODY.appendChild(p_1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('005', async () => {
     let filler;
@@ -542,7 +542,7 @@ describe('abspos-inline', () => {
     BODY.appendChild(p);
     BODY.appendChild(p_1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('006', async () => {
     let filler;
@@ -651,7 +651,7 @@ describe('abspos-inline', () => {
     BODY.appendChild(p);
     BODY.appendChild(p_1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('007-ref', async () => {
     let abspos;
@@ -852,7 +852,7 @@ block, and 2) is not a child of the inline containing block, but a descendant.`)
     BODY.appendChild(blockContainer);
     BODY.appendChild(p);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('007', async () => {
     let abspos;
@@ -1059,7 +1059,7 @@ block, and 2) is not a child of the inline containing block, but a descendant.`)
     BODY.appendChild(blockContainer);
     BODY.appendChild(p);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('008', async () => {
     let p;
@@ -1113,6 +1113,6 @@ block, and 2) is not a child of the inline containing block, but a descendant.`)
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-position/abspos-negative.ts
+++ b/integration_tests/specs/css/css-position/abspos-negative.ts
@@ -61,7 +61,7 @@ describe('abspos-negative', () => {
     BODY.appendChild(div);
     BODY.appendChild(div_1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('margin-001', async () => {
     let abspos;
@@ -157,6 +157,6 @@ describe('abspos-negative', () => {
     BODY.appendChild(div);
     BODY.appendChild(div_1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-position/abspos-overflow.ts
+++ b/integration_tests/specs/css/css-position/abspos-overflow.ts
@@ -43,7 +43,7 @@ describe('abspos-overflow', () => {
     BODY.appendChild(p);
     BODY.appendChild(overflow);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('001', async () => {
     let control;
@@ -109,7 +109,7 @@ describe('abspos-overflow', () => {
     BODY.appendChild(p);
     BODY.appendChild(overflow);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('002-ref', async () => {
     let positioned;
@@ -154,7 +154,7 @@ describe('abspos-overflow', () => {
     BODY.appendChild(p);
     BODY.appendChild(overflow);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('002', async () => {
     let control;
@@ -221,7 +221,7 @@ describe('abspos-overflow', () => {
     BODY.appendChild(p);
     BODY.appendChild(overflow);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('003-ref', async () => {
     let positioned;
@@ -267,7 +267,7 @@ describe('abspos-overflow', () => {
     BODY.appendChild(p);
     BODY.appendChild(overflow);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('003', async () => {
     let control;
@@ -336,7 +336,7 @@ describe('abspos-overflow', () => {
     BODY.appendChild(p);
     BODY.appendChild(overflow);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('004-ref', async () => {
     let positioned;
@@ -358,7 +358,7 @@ describe('abspos-overflow', () => {
     );
     BODY.appendChild(positioned);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('004', async () => {
     let control;
@@ -412,7 +412,7 @@ describe('abspos-overflow', () => {
     BODY.appendChild(control);
     BODY.appendChild(overflow);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('005-ref', async () => {
     let positioned;
@@ -434,7 +434,7 @@ describe('abspos-overflow', () => {
     );
     BODY.appendChild(positioned);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('005', async () => {
     let control;
@@ -489,7 +489,7 @@ describe('abspos-overflow', () => {
     BODY.appendChild(control);
     BODY.appendChild(overflow);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('006-ref', async () => {
     let positioned;
@@ -512,7 +512,7 @@ describe('abspos-overflow', () => {
     );
     BODY.appendChild(positioned);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('006', async () => {
     let control;
@@ -569,7 +569,7 @@ describe('abspos-overflow', () => {
     BODY.appendChild(control);
     BODY.appendChild(overflow);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('007', async () => {
     let control;
@@ -623,7 +623,7 @@ describe('abspos-overflow', () => {
     BODY.appendChild(control);
     BODY.appendChild(overflow);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('008', async () => {
     let control;
@@ -678,7 +678,7 @@ describe('abspos-overflow', () => {
     BODY.appendChild(control);
     BODY.appendChild(overflow);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('009', async () => {
     let control;
@@ -735,7 +735,7 @@ describe('abspos-overflow', () => {
     BODY.appendChild(control);
     BODY.appendChild(overflow);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('010-ref', async () => {
     let p;
@@ -761,7 +761,7 @@ describe('abspos-overflow', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('010', async () => {
     let p;
@@ -805,7 +805,7 @@ describe('abspos-overflow', () => {
     BODY.appendChild(p);
     BODY.appendChild(outer);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('011-ref', async () => {
     let p;
@@ -841,7 +841,7 @@ describe('abspos-overflow', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('011', async () => {
     let p;
@@ -915,7 +915,7 @@ describe('abspos-overflow', () => {
     BODY.appendChild(p);
     BODY.appendChild(outer);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('012', async () => {
     let p;
@@ -990,6 +990,6 @@ describe('abspos-overflow', () => {
     BODY.appendChild(p);
     BODY.appendChild(outer);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-position/abspos-paged.ts
+++ b/integration_tests/specs/css/css-position/abspos-paged.ts
@@ -128,7 +128,7 @@ describe('abspos-paged', () => {
     BODY.appendChild(div_2);
     BODY.appendChild(div_3);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('002', async () => {
     let div;
@@ -301,6 +301,6 @@ describe('abspos-paged', () => {
     BODY.appendChild(div_3);
     BODY.appendChild(div_4);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-position/abspos-width.ts
+++ b/integration_tests/specs/css/css-position/abspos-width.ts
@@ -78,7 +78,7 @@ describe('abspos-width', () => {
     BODY.appendChild(a);
     BODY.appendChild(b);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('003', async () => {
     let p;
@@ -158,7 +158,7 @@ describe('abspos-width', () => {
     BODY.appendChild(a);
     BODY.appendChild(b);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('004', async () => {
     let p;
@@ -217,7 +217,7 @@ describe('abspos-width', () => {
     BODY.appendChild(p);
     BODY.appendChild(test);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('005-ref', async () => {
     let p;
@@ -265,7 +265,7 @@ describe('abspos-width', () => {
     BODY.appendChild(p);
     BODY.appendChild(parent);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('005', async () => {
     let p;
@@ -319,7 +319,7 @@ describe('abspos-width', () => {
     BODY.appendChild(p);
     BODY.appendChild(relative);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('change-inline-container-001-ref', async () => {
     let abspos;
@@ -367,7 +367,7 @@ describe('abspos-width', () => {
     );
     BODY.appendChild(container);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('change-inline-container-001', async () => {
     let abspos;
@@ -421,6 +421,6 @@ describe('abspos-width', () => {
       container.style.width = '100px';
     }
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-position/abspos.ts
+++ b/integration_tests/specs/css/css-position/abspos.ts
@@ -71,7 +71,7 @@ describe('abspos', () => {
     BODY.appendChild(abs);
     BODY.appendChild(flow);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('002', async () => {
     let p;
@@ -139,7 +139,7 @@ describe('abspos', () => {
     BODY.appendChild(p);
     BODY.appendChild(container);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('003', async () => {
     let absolute;
@@ -187,7 +187,7 @@ describe('abspos', () => {
     BODY.appendChild(absolute);
     BODY.appendChild(control);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('004', async () => {
     let absolute;
@@ -235,9 +235,9 @@ describe('abspos', () => {
     BODY.appendChild(absolute);
     BODY.appendChild(control);
 
-    await matchViewportSnapshot();
+    await snapshot();
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('006', async () => {
     let description;
@@ -281,7 +281,7 @@ describe('abspos', () => {
     BODY.appendChild(description);
     BODY.appendChild(control);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('007', async () => {
     let test;
@@ -349,7 +349,7 @@ describe('abspos', () => {
     );
     BODY.appendChild(container);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('008', async () => {
     let p;
@@ -442,7 +442,7 @@ describe('abspos', () => {
     BODY.appendChild(p);
     BODY.appendChild(container);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('009', async () => {
     let p;
@@ -497,7 +497,7 @@ describe('abspos', () => {
     BODY.appendChild(test);
     BODY.appendChild(control);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('010', async () => {
     let p;
@@ -513,7 +513,7 @@ describe('abspos', () => {
     );
     BODY.appendChild(p);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('011', async () => {
     let p;
@@ -573,7 +573,7 @@ describe('abspos', () => {
     BODY.appendChild(p_2);
     BODY.appendChild(p_3);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('013', async () => {
     let a;
@@ -617,7 +617,7 @@ describe('abspos', () => {
     BODY.appendChild(a);
     BODY.appendChild(b);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('014', async () => {
     let b;
@@ -661,7 +661,7 @@ describe('abspos', () => {
     BODY.appendChild(b);
     BODY.appendChild(a);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('015', async () => {
     let a;
@@ -705,7 +705,7 @@ describe('abspos', () => {
     BODY.appendChild(a);
     BODY.appendChild(b);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('016', async () => {
     let b;
@@ -749,7 +749,7 @@ describe('abspos', () => {
     BODY.appendChild(b);
     BODY.appendChild(a);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('017', async () => {
     let a;
@@ -793,7 +793,7 @@ describe('abspos', () => {
     BODY.appendChild(a);
     BODY.appendChild(b);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('018', async () => {
     let b;
@@ -837,7 +837,7 @@ describe('abspos', () => {
     BODY.appendChild(b);
     BODY.appendChild(a);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('019', async () => {
     let a;
@@ -881,7 +881,7 @@ describe('abspos', () => {
     BODY.appendChild(a);
     BODY.appendChild(b);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('020', async () => {
     let b;
@@ -925,7 +925,7 @@ describe('abspos', () => {
     BODY.appendChild(b);
     BODY.appendChild(a);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('022', async () => {
     let c3;
@@ -1015,7 +1015,7 @@ describe('abspos', () => {
     BODY.appendChild(a);
     BODY.appendChild(c4);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('023', async () => {
     let p;
@@ -1076,7 +1076,7 @@ describe('abspos', () => {
     BODY.appendChild(container);
     BODY.appendChild(control);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('024', async () => {
     let p;
@@ -1129,7 +1129,7 @@ describe('abspos', () => {
     BODY.appendChild(test);
     BODY.appendChild(control);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('025', async () => {
     let p;
@@ -1170,7 +1170,7 @@ describe('abspos', () => {
     );
     BODY.appendChild(p);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('026', async () => {
     let p;
@@ -1225,6 +1225,6 @@ describe('abspos', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-position/auto-position.ts
+++ b/integration_tests/specs/css/css-position/auto-position.ts
@@ -35,7 +35,7 @@ describe('auto-position', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('rtl-child-viewport-scrollbar', async () => {
     let p;
@@ -88,6 +88,6 @@ describe('auto-position', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-position/bottom-007.ts
+++ b/integration_tests/specs/css/css-position/bottom-007.ts
@@ -31,6 +31,6 @@ describe('bottom-007', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-position/bottom-019.ts
+++ b/integration_tests/specs/css/css-position/bottom-019.ts
@@ -31,6 +31,6 @@ describe('bottom-019', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-position/bottom-079.ts
+++ b/integration_tests/specs/css/css-position/bottom-079.ts
@@ -31,6 +31,6 @@ describe('bottom-079', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-position/bottom-113.ts
+++ b/integration_tests/specs/css/css-position/bottom-113.ts
@@ -32,6 +32,6 @@ describe('bottom-113', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-position/bottom-applies.ts
+++ b/integration_tests/specs/css/css-position/bottom-applies.ts
@@ -30,7 +30,7 @@ describe('bottom-applies', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('to-009', async () => {
     let p;
@@ -74,7 +74,7 @@ describe('bottom-applies', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('to-008', async () => {
     let p;
@@ -110,7 +110,7 @@ describe('bottom-applies', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('to-012', async () => {
     let p;
@@ -179,6 +179,6 @@ describe('bottom-applies', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-position/bottom-offset.ts
+++ b/integration_tests/specs/css/css-position/bottom-offset.ts
@@ -82,7 +82,7 @@ describe('bottom-offset', () => {
     BODY.appendChild(p);
     BODY.appendChild(inlineBlock);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('001', async () => {
     let p;
@@ -141,7 +141,7 @@ describe('bottom-offset', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('002', async () => {
     let p;
@@ -189,7 +189,7 @@ describe('bottom-offset', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('003', async () => {
     let p;
@@ -247,7 +247,7 @@ describe('bottom-offset', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('percentage-001-ref', async () => {
     let p;
@@ -296,7 +296,7 @@ describe('bottom-offset', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot(0.5);
+    await snapshot(0.5);
   });
   xit('percentage-001', async () => {
     let p;
@@ -368,6 +368,6 @@ describe('bottom-offset', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-position/bottom.ts
+++ b/integration_tests/specs/css/css-position/bottom.ts
@@ -52,7 +52,7 @@ describe('bottom', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('005', async () => {
     let p;
@@ -106,7 +106,7 @@ describe('bottom', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('006', async () => {
     let p;
@@ -160,7 +160,7 @@ describe('bottom', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('007', async () => {
     let p;
@@ -215,7 +215,7 @@ describe('bottom', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('008', async () => {
     let p;
@@ -270,7 +270,7 @@ describe('bottom', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('016', async () => {
     let p;
@@ -324,7 +324,7 @@ describe('bottom', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('018', async () => {
@@ -379,7 +379,7 @@ describe('bottom', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('019', async () => {
     let p;
@@ -433,7 +433,7 @@ describe('bottom', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('020', async () => {
     let p;
@@ -487,7 +487,7 @@ describe('bottom', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('028', async () => {
     let p;
@@ -541,7 +541,7 @@ describe('bottom', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('029', async () => {
     let p;
@@ -595,7 +595,7 @@ describe('bottom', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('030', async () => {
     let p;
@@ -649,7 +649,7 @@ describe('bottom', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('031', async () => {
     let p;
@@ -703,7 +703,7 @@ describe('bottom', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('032', async () => {
     let p;
@@ -757,7 +757,7 @@ describe('bottom', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('040', async () => {
     let p;
@@ -811,9 +811,9 @@ describe('bottom', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('041', async () => {
     let p;
@@ -867,7 +867,7 @@ describe('bottom', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('042', async () => {
     let p;
@@ -921,7 +921,7 @@ describe('bottom', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('043', async () => {
     let p;
@@ -975,7 +975,7 @@ describe('bottom', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('044', async () => {
     let p;
@@ -1029,7 +1029,7 @@ describe('bottom', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('052', async () => {
     let p;
@@ -1083,7 +1083,7 @@ describe('bottom', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('053', async () => {
     let p;
@@ -1137,7 +1137,7 @@ describe('bottom', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('113', async () => {
     let p;
@@ -1208,6 +1208,6 @@ describe('bottom', () => {
     BODY.appendChild(p);
     BODY.appendChild(parent);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-position/dynamic-top.ts
+++ b/integration_tests/specs/css/css-position/dynamic-top.ts
@@ -38,7 +38,7 @@ describe('dynamic-top', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('change-002-ref', async () => {
     let p;
@@ -78,7 +78,7 @@ describe('dynamic-top', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('change-004', async () => {
     let p;
@@ -144,7 +144,7 @@ describe('dynamic-top', () => {
       parent.style.top = '2em';
     };
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('change-005', async () => {
     let p;
@@ -218,7 +218,7 @@ describe('dynamic-top', () => {
       parent.style.top = '50px';
     };
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('change-005a', async () => {
     let p;
@@ -292,9 +292,9 @@ describe('dynamic-top', () => {
       parent.style.top = '50px';
     };
 
-    await matchViewportSnapshot();
+    await snapshot();
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('change-005b', async () => {
     let p;
@@ -363,6 +363,6 @@ describe('dynamic-top', () => {
     BODY.appendChild(grandparent);
     BODY.appendChild(green);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-position/fixed-z-index.ts
+++ b/integration_tests/specs/css/css-position/fixed-z-index.ts
@@ -31,6 +31,6 @@ describe('fixed-z-index', () => {
       ])
     ]);
     BODY.appendChild(container);
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-position/fixed-z.ts
+++ b/integration_tests/specs/css/css-position/fixed-z.ts
@@ -44,7 +44,7 @@ describe('fixed-z', () => {
       });
     });
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('index-blend-ref', async () => {
     let div;
@@ -67,6 +67,6 @@ describe('fixed-z', () => {
       });
     });
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-position/fixed.ts
+++ b/integration_tests/specs/css/css-position/fixed.ts
@@ -23,7 +23,7 @@ describe('Position fixed', () => {
     div1.appendChild(document.createTextNode('fixed element'));
     container1.appendChild(div1);
 
-    await expectAsync(container1.toBlob(1)).toMatchImageSnapshot();
+    await expectAsync(container1.toBlob(1)).toMatchSnapshot();
   });
 
   it('works with scroller container', async (done) => {
@@ -59,12 +59,12 @@ describe('Position fixed', () => {
     );
 
     BODY.appendChild(container);
-    await matchViewportSnapshot();
+    await snapshot();
 
     requestAnimationFrame( () => {
       container.scroll(0, 200);
       setTimeout(async () => {
-        await matchViewportSnapshot();
+        await snapshot();
         done();
       }, 100);
     });
@@ -101,12 +101,12 @@ describe('Position fixed', () => {
     );
 
     BODY.appendChild(container);
-    await matchViewportSnapshot();
+    await snapshot();
 
     requestAnimationFrame( () => {
       BODY.scroll(0, 200);
       setTimeout(async () => {
-        await matchViewportSnapshot();
+        await snapshot();
         done();
       }, 100);
     });
@@ -145,12 +145,12 @@ describe('Position fixed', () => {
     );
 
     BODY.appendChild(container);
-    await matchViewportSnapshot();
+    await snapshot();
 
     requestAnimationFrame( () => {
       BODY.scroll(100, 200);
       setTimeout(async () => {
-        await matchViewportSnapshot();
+        await snapshot();
         done();
       }, 100);
     });
@@ -248,7 +248,7 @@ describe('Position fixed', () => {
 
     BODY.appendChild(test01);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('change from fixed to static and transform exists', async (done) => {
@@ -271,11 +271,11 @@ describe('Position fixed', () => {
     );
     append(BODY, cont);
 
-    await matchViewportSnapshot();
+    await snapshot();
 
     requestAnimationFrame(async() => {
       cont.style.position = 'static';
-      await matchViewportSnapshot(0.1);
+      await snapshot(0.1);
       done();
     });
   });
@@ -299,11 +299,11 @@ describe('Position fixed', () => {
     );
     append(BODY, cont);
 
-    await matchViewportSnapshot();
+    await snapshot();
 
     requestAnimationFrame(async() => {
       cont.style.position = 'static';
-      await matchViewportSnapshot(0.1);
+      await snapshot(0.1);
       done();
     });
   });

--- a/integration_tests/specs/css/css-position/hypothetical-box.ts
+++ b/integration_tests/specs/css/css-position/hypothetical-box.ts
@@ -25,7 +25,7 @@ describe('hypothetical-box', () => {
 
     div.scrollLeft = 1000;
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('scroll-parent', async () => {
     let target;
@@ -60,7 +60,7 @@ describe('hypothetical-box', () => {
     // Now force relayout of the abs pos div.
     target.textContent = 'Modified text';
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('scroll-viewport', async () => {
     let div;
@@ -85,7 +85,7 @@ describe('hypothetical-box', () => {
     // Now force relayout of the abs pos div.
     div.textContent = 'Modified text';
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('scroll-viewport-ref', async () => {
     let div;
@@ -100,6 +100,6 @@ describe('hypothetical-box', () => {
 
     window.scrollTo(window.innerWidth * 2, 0);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-position/hypothetical-dynamic.ts
+++ b/integration_tests/specs/css/css-position/hypothetical-dynamic.ts
@@ -12,7 +12,7 @@ describe('hypothetical-dynamic', () => {
     });
     BODY.appendChild(ancestor);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('change-001', async () => {
     let child;
@@ -38,11 +38,11 @@ describe('hypothetical-dynamic', () => {
     );
     BODY.appendChild(ancestor);
 
-    await matchViewportSnapshot();
+    await snapshot();
 
     ancestor.style.left = '100px';
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('change-002', async () => {
     let child;
@@ -68,11 +68,11 @@ describe('hypothetical-dynamic', () => {
     );
     BODY.appendChild(ancestor);
 
-    await matchViewportSnapshot();
+    await snapshot();
 
     ancestor.style.left = '100px';
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('change-003', async () => {
     let child;
@@ -98,11 +98,11 @@ describe('hypothetical-dynamic', () => {
     );
     BODY.appendChild(ancestor);
 
-    await matchViewportSnapshot();
+    await snapshot();
     ancestor.style.left = '100px';
 
-    await matchViewportSnapshot();
+    await snapshot();
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-position/inline-static.ts
+++ b/integration_tests/specs/css/css-position/inline-static.ts
@@ -348,6 +348,6 @@ describe('inline-static', () => {
     //   checkLayout('.tests .abs');
     // });
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-position/left-004.ts
+++ b/integration_tests/specs/css/css-position/left-004.ts
@@ -57,6 +57,6 @@ describe('left-004', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot(0.1);
+    await snapshot(0.1);
   });
 });

--- a/integration_tests/specs/css/css-position/left-007.ts
+++ b/integration_tests/specs/css/css-position/left-007.ts
@@ -32,6 +32,6 @@ describe('left-007', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-position/left-031.ts
+++ b/integration_tests/specs/css/css-position/left-031.ts
@@ -32,6 +32,6 @@ describe('left-031', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-position/left-079.ts
+++ b/integration_tests/specs/css/css-position/left-079.ts
@@ -32,6 +32,6 @@ describe('left-079', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-position/left-113.ts
+++ b/integration_tests/specs/css/css-position/left-113.ts
@@ -33,6 +33,6 @@ describe('left-113', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-position/left-applies.ts
+++ b/integration_tests/specs/css/css-position/left-applies.ts
@@ -28,7 +28,7 @@ describe('left-applies', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('to-008', async () => {
     let p;
@@ -65,7 +65,7 @@ describe('left-applies', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('to-009', async () => {
     let p;
@@ -109,7 +109,7 @@ describe('left-applies', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('to-012', async () => {
     let p;
@@ -179,6 +179,6 @@ describe('left-applies', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-position/left-offset.ts
+++ b/integration_tests/specs/css/css-position/left-offset.ts
@@ -82,7 +82,7 @@ describe('left-offset', () => {
     BODY.appendChild(p);
     BODY.appendChild(inlineBlock);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('001', async () => {
     let p;
@@ -130,7 +130,7 @@ describe('left-offset', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('002', async () => {
     let p;
@@ -178,7 +178,7 @@ describe('left-offset', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('003-ref', async () => {
     let p;
@@ -219,7 +219,7 @@ describe('left-offset', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('003', async () => {
     let p;
@@ -279,7 +279,7 @@ describe('left-offset', () => {
     BODY.appendChild(p);
     BODY.appendChild(container);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('percentage-001-ref', async () => {
     let p;
@@ -320,7 +320,7 @@ describe('left-offset', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('percentage-001', async () => {
     let p;
@@ -370,7 +370,7 @@ describe('left-offset', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('percentage-002-ref', async () => {
     let p;
@@ -407,7 +407,7 @@ describe('left-offset', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('percentage-002', async () => {
     let p;
@@ -492,6 +492,6 @@ describe('left-offset', () => {
     BODY.appendChild(p);
     BODY.appendChild(grandParentAbsPos);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-position/left.ts
+++ b/integration_tests/specs/css/css-position/left.ts
@@ -52,7 +52,7 @@ describe('left', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('005', async () => {
     let p;
@@ -106,7 +106,7 @@ describe('left', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('006', async () => {
     let p;
@@ -160,7 +160,7 @@ describe('left', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('007', async () => {
     let p;
@@ -216,7 +216,7 @@ describe('left', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('008', async () => {
     let p;
@@ -272,7 +272,7 @@ describe('left', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('016', async () => {
     let p;
@@ -326,7 +326,7 @@ describe('left', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('017', async () => {
     let p;
@@ -380,7 +380,7 @@ describe('left', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('018', async () => {
     let p;
@@ -434,7 +434,7 @@ describe('left', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('019', async () => {
     let p;
@@ -491,7 +491,7 @@ describe('left', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('020', async () => {
     let p;
@@ -548,7 +548,7 @@ describe('left', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('028', async () => {
     let p;
@@ -602,7 +602,7 @@ describe('left', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('029', async () => {
     let p;
@@ -656,7 +656,7 @@ describe('left', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('030', async () => {
     let p;
@@ -710,7 +710,7 @@ describe('left', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('031', async () => {
     let p;
@@ -767,7 +767,7 @@ describe('left', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('032', async () => {
     let p;
@@ -824,7 +824,7 @@ describe('left', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('040', async () => {
     let p;
@@ -878,7 +878,7 @@ describe('left', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('041', async () => {
     let p;
@@ -932,7 +932,7 @@ describe('left', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('042', async () => {
     let p;
@@ -986,7 +986,7 @@ describe('left', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('043', async () => {
     let p;
@@ -1043,7 +1043,7 @@ describe('left', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('044', async () => {
     let p;
@@ -1100,7 +1100,7 @@ describe('left', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('052', async () => {
     let p;
@@ -1154,7 +1154,7 @@ describe('left', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('053', async () => {
     let p;
@@ -1208,7 +1208,7 @@ describe('left', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('054', async () => {
     let p;
@@ -1262,7 +1262,7 @@ describe('left', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('055', async () => {
     let p;
@@ -1319,7 +1319,7 @@ describe('left', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('056', async () => {
     let p;
@@ -1375,7 +1375,7 @@ describe('left', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('064', async () => {
     let p;
@@ -1429,7 +1429,7 @@ describe('left', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('065', async () => {
     let p;
@@ -1483,7 +1483,7 @@ describe('left', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('066', async () => {
     let p;
@@ -1537,7 +1537,7 @@ describe('left', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('067', async () => {
     let p;
@@ -1594,7 +1594,7 @@ describe('left', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('068', async () => {
     let p;
@@ -1651,7 +1651,7 @@ describe('left', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('076', async () => {
     let p;
@@ -1705,7 +1705,7 @@ describe('left', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('077', async () => {
     let p;
@@ -1759,7 +1759,7 @@ describe('left', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('078', async () => {
     let p;
@@ -1813,7 +1813,7 @@ describe('left', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('079', async () => {
     let p;
@@ -1872,7 +1872,7 @@ describe('left', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('080', async () => {
     let p;
@@ -1931,7 +1931,7 @@ describe('left', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('088', async () => {
     let p;
@@ -1987,7 +1987,7 @@ describe('left', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('089', async () => {
     let p;
@@ -2043,7 +2043,7 @@ describe('left', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('090', async () => {
     let p;
@@ -2099,7 +2099,7 @@ describe('left', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('091', async () => {
     let p;
@@ -2158,6 +2158,6 @@ describe('left', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-position/line-break.ts
+++ b/integration_tests/specs/css/css-position/line-break.ts
@@ -37,7 +37,7 @@ describe('line-break', () => {
     );
     BODY.appendChild(parent);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('after-leading-oof-001-ref', async () => {
     let div;
@@ -53,7 +53,7 @@ describe('line-break', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('after-leading-oof-001', async () => {
     let div;
@@ -78,6 +78,6 @@ describe('line-break', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-position/nonstatic-to-static.ts
+++ b/integration_tests/specs/css/css-position/nonstatic-to-static.ts
@@ -57,13 +57,13 @@ describe('Position non-static', () => {
     div4.appendChild(document.createTextNode('sticky to static'));
     container.appendChild(div4);
 
-    await matchViewportSnapshot();
+    await snapshot();
 
     div1.style.position = 'static';
     div2.style.position = 'static';
     div3.style.position = 'static';
     div4.style.position = 'static';
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-position/position-006.ts
+++ b/integration_tests/specs/css/css-position/position-006.ts
@@ -26,8 +26,8 @@ describe('position-006', () => {
     BODY.appendChild(p);
     BODY.appendChild(p_1);
 
-    await matchViewportSnapshot();
+    await snapshot();
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-position/position-absolute.ts
+++ b/integration_tests/specs/css/css-position/position-absolute.ts
@@ -62,7 +62,7 @@ describe('position-absolute', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('002-ref', async () => {
     let p;
@@ -110,7 +110,7 @@ describe('position-absolute', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('002', async () => {
     let p;
@@ -167,7 +167,7 @@ describe('position-absolute', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('003', async () => {
     let p;
@@ -235,7 +235,7 @@ describe('position-absolute', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('004-ref', async () => {
     let p;
@@ -276,7 +276,7 @@ describe('position-absolute', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('004', async () => {
     let p;
@@ -338,7 +338,7 @@ describe('position-absolute', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('005', async () => {
     let p;
@@ -404,7 +404,7 @@ describe('position-absolute', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('006', async () => {
     let p;
@@ -470,7 +470,7 @@ describe('position-absolute', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('007-ref', async () => {
     let p;
@@ -529,7 +529,7 @@ describe('position-absolute', () => {
     BODY.appendChild(blue_1);
     BODY.appendChild(orange);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('007', async () => {
     let p;
@@ -595,7 +595,7 @@ describe('position-absolute', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('008', async () => {
     let p;
@@ -661,7 +661,7 @@ describe('position-absolute', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('should work with nested parent', async () => {
@@ -708,6 +708,6 @@ describe('position-absolute', () => {
     BODY.appendChild(container);
     container.appendChild(flex);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-position/position-applies.ts
+++ b/integration_tests/specs/css/css-position/position-applies.ts
@@ -34,7 +34,7 @@ describe('position-applies', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('to-009', async () => {
     let p;
@@ -78,7 +78,7 @@ describe('position-applies', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('to-010', async () => {
     let p;
@@ -112,7 +112,7 @@ describe('position-applies', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('to-012', async () => {
     let p;
@@ -181,6 +181,6 @@ describe('position-applies', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-position/position-fixed.ts
+++ b/integration_tests/specs/css/css-position/position-fixed.ts
@@ -62,7 +62,7 @@ describe('position-fixed', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('003', async () => {
     let p;
@@ -106,7 +106,7 @@ describe('position-fixed', () => {
     BODY.appendChild(div1);
     BODY.appendChild(filler);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('005', async () => {
     let prerequisite;
@@ -183,7 +183,7 @@ describe('position-fixed', () => {
     BODY.appendChild(p);
     BODY.appendChild(fixed);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('006', async () => {
     let p;
@@ -202,7 +202,7 @@ describe('position-fixed', () => {
       ]
     );
     BODY.appendChild(p);
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('007-ref', async () => {
     let div;
@@ -243,7 +243,7 @@ describe('position-fixed', () => {
     BODY.appendChild(div);
     BODY.appendChild(p);
 
-    await matchViewportSnapshot(0.5);
+    await snapshot(0.5);
   });
   it('007', async () => {
     let p;
@@ -279,6 +279,6 @@ describe('position-fixed', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-position/position-legacy.ts
+++ b/integration_tests/specs/css/css-position/position-legacy.ts
@@ -40,7 +40,7 @@ describe('Position', () => {
 
     container2.appendChild(div2);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('should work with flex', async () => {
@@ -91,7 +91,7 @@ describe('Position', () => {
     container.appendChild(absoluteEl);
 
     document.body.appendChild(container);
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('property static', async () => {
@@ -108,7 +108,7 @@ describe('Position', () => {
 
     document.body.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('proeprty relative', async () => {
@@ -136,7 +136,7 @@ describe('Position', () => {
     div2.appendChild(document.createTextNode('relative bottom & right'));
     document.body.appendChild(div2);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('property fixed', async () => {
@@ -164,7 +164,7 @@ describe('Position', () => {
 
     container1.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   xit('peroperty sticky', async () => {
@@ -249,6 +249,6 @@ describe('Position', () => {
     document.body.appendChild(sticky4);
     document.body.appendChild(block4);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-position/position-relative.ts
+++ b/integration_tests/specs/css/css-position/position-relative.ts
@@ -30,7 +30,7 @@ describe('position-relative', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('001', async () => {
     let p;
@@ -105,7 +105,7 @@ describe('position-relative', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('002', async () => {
     let p;
@@ -173,7 +173,7 @@ describe('position-relative', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('003-ref', async () => {
     let p;
@@ -204,7 +204,7 @@ describe('position-relative', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('003', async () => {
     let p;
@@ -251,7 +251,7 @@ describe('position-relative', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('004-ref', async () => {
     let p;
@@ -327,7 +327,7 @@ describe('position-relative', () => {
     BODY.appendChild(div);
     BODY.appendChild(div_1);
 
-    await matchViewportSnapshot(0.5);
+    await snapshot(0.5);
   });
   it('004', async () => {
     let p;
@@ -388,7 +388,7 @@ describe('position-relative', () => {
     BODY.appendChild(div2);
     BODY.appendChild(div3);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('005-ref', async () => {
     let p;
@@ -439,7 +439,7 @@ describe('position-relative', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('005', async () => {
     let p;
@@ -486,7 +486,7 @@ describe('position-relative', () => {
     BODY.appendChild(div1);
     BODY.appendChild(div2);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('006', async () => {
     let p;
@@ -545,7 +545,7 @@ describe('position-relative', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('007', async () => {
     let p;
@@ -606,7 +606,7 @@ describe('position-relative', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('008', async () => {
     let p;
@@ -667,7 +667,7 @@ describe('position-relative', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('009', async () => {
     let p;
@@ -715,7 +715,7 @@ describe('position-relative', () => {
     BODY.appendChild(div1);
     BODY.appendChild(div2);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('010', async () => {
     let p;
@@ -763,7 +763,7 @@ describe('position-relative', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('013', async () => {
     let p;
@@ -834,7 +834,7 @@ describe('position-relative', () => {
     BODY.appendChild(div2);
     BODY.appendChild(div3);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('014-ref', async () => {
     let p;
@@ -892,7 +892,7 @@ describe('position-relative', () => {
     BODY.appendChild(div);
     BODY.appendChild(div_1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('014', async () => {
     let p;
@@ -939,7 +939,7 @@ describe('position-relative', () => {
     BODY.appendChild(div1);
     BODY.appendChild(div2);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('015', async () => {
     let p;
@@ -987,7 +987,7 @@ describe('position-relative', () => {
     BODY.appendChild(div1);
     BODY.appendChild(div2);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('016-ref', async () => {
     let p;
@@ -1031,7 +1031,7 @@ describe('position-relative', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('016', async () => {
     let p;
@@ -1116,7 +1116,7 @@ describe('position-relative', () => {
     BODY.appendChild(div1);
     BODY.appendChild(div2);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('017', async () => {
     let p;
@@ -1164,7 +1164,7 @@ describe('position-relative', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('018-ref', async () => {
     let p;
@@ -1189,7 +1189,7 @@ describe('position-relative', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('019', async () => {
     let p;
@@ -1237,7 +1237,7 @@ describe('position-relative', () => {
     BODY.appendChild(div1);
     BODY.appendChild(div2);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('020', async () => {
     let p;
@@ -1285,7 +1285,7 @@ describe('position-relative', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('021', async () => {
     let p;
@@ -1333,7 +1333,7 @@ describe('position-relative', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('022', async () => {
     let p;
@@ -1379,7 +1379,7 @@ describe('position-relative', () => {
     BODY.appendChild(p);
     BODY.appendChild(containingAncestor);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('027-ref', async () => {
     let p;
@@ -1407,7 +1407,7 @@ describe('position-relative', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('027', async () => {
     let p;
@@ -1455,7 +1455,7 @@ describe('position-relative', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('028-ref', async () => {
     let p;
@@ -1483,7 +1483,7 @@ describe('position-relative', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('028', async () => {
     let p;
@@ -1525,7 +1525,7 @@ describe('position-relative', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('029', async () => {
     let p;
@@ -1576,7 +1576,7 @@ describe('position-relative', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('030-ref', async () => {
     let p;
@@ -1604,7 +1604,7 @@ describe('position-relative', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('030', async () => {
     let p;
@@ -1658,7 +1658,7 @@ describe('position-relative', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('031-ref', async () => {
     let p;
@@ -1690,7 +1690,7 @@ describe('position-relative', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('031', async () => {
     let p;
@@ -1753,7 +1753,7 @@ describe('position-relative', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('032-ref', async () => {
     let p;
@@ -1828,7 +1828,7 @@ describe('position-relative', () => {
     BODY.appendChild(div);
     BODY.appendChild(div_1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('032', async () => {
     let p;
@@ -1887,7 +1887,7 @@ describe('position-relative', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('033-ref', async () => {
     let p;
@@ -1951,7 +1951,7 @@ describe('position-relative', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('033', async (done) => {
     let p;
@@ -2016,7 +2016,7 @@ describe('position-relative', () => {
     BODY.appendChild(div);
 
     requestAnimationFrame(async () => {
-      await matchViewportSnapshot();
+      await snapshot();
       done();
     });
   });
@@ -2065,7 +2065,7 @@ describe('position-relative', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   // @TODO Need to impl text anonymous box split
@@ -2117,7 +2117,7 @@ describe('position-relative', () => {
     BODY.appendChild(black);
     BODY.appendChild(orange);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('035', async () => {
     let p;
@@ -2179,7 +2179,7 @@ describe('position-relative', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('036', async () => {
     let p;
@@ -2226,7 +2226,7 @@ describe('position-relative', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('037-ref', async () => {
     let p;
@@ -2268,7 +2268,7 @@ describe('position-relative', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('037', async () => {
     let p;
@@ -2316,7 +2316,7 @@ describe('position-relative', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('038-ref', async () => {
     let p;
@@ -2357,7 +2357,7 @@ describe('position-relative', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('038', async () => {
     let p;
@@ -2405,7 +2405,7 @@ describe('position-relative', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('nested-001-ref', async () => {
     let p;
@@ -2439,7 +2439,7 @@ describe('position-relative', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('nested-001', async () => {
     let p;
@@ -2511,6 +2511,6 @@ describe('position-relative', () => {
     BODY.appendChild(p);
     BODY.appendChild(outer);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-position/position-static.ts
+++ b/integration_tests/specs/css/css-position/position-static.ts
@@ -43,7 +43,7 @@ describe('position-static', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('001', async () => {
     let p;
@@ -97,6 +97,6 @@ describe('position-static', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-position/position-sticky.ts
+++ b/integration_tests/specs/css/css-position/position-sticky.ts
@@ -62,7 +62,7 @@ describe('position-sticky', () => {
     );
     BODY.appendChild(scroller);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('change-top-ref', async () => {
@@ -87,7 +87,7 @@ describe('position-sticky', () => {
     BODY.appendChild(box);
     BODY.appendChild(spacer);
 
-    await matchViewportSnapshot(0.4);
+    await snapshot(0.4);
   });
   it('change-top', async () => {
     let marker;
@@ -121,7 +121,7 @@ describe('position-sticky', () => {
     BODY.appendChild(sticky);
     BODY.appendChild(spacer);
 
-    await matchViewportSnapshot(0.1);
+    await snapshot(0.1);
   });
   it('child-multicolumn-ref', async () => {
     let contents;
@@ -200,7 +200,7 @@ describe('position-sticky', () => {
     // wait for image load
     await sleep(1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('child-multicolumn', async () => {
     let contents;
@@ -275,7 +275,7 @@ describe('position-sticky', () => {
       scroller.scrollTop = 100;
     });
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('flexbox-ref', async () => {
     let flexItem;
@@ -447,7 +447,7 @@ describe('position-sticky', () => {
     BODY.appendChild(scroller2);
     BODY.appendChild(scroller3);
     BODY.appendChild(p);
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('flexbox', async () => {
     let indicator;
@@ -634,7 +634,7 @@ describe('position-sticky', () => {
     BODY.appendChild(scroller2);
     BODY.appendChild(scroller3);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('get-bounding-client-rect', async () => {
     let sticky1;
@@ -725,7 +725,7 @@ describe('position-sticky', () => {
     BODY.appendChild(scroller2);
     BODY.appendChild(scroller3);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('inflow-position', async () => {
     let before;
@@ -772,7 +772,7 @@ describe('position-sticky', () => {
     BODY.appendChild(scroller);
 
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('inline-ref', async () => {
     let indicator;
@@ -932,7 +932,7 @@ describe('position-sticky', () => {
     BODY.appendChild(group_1);
     BODY.appendChild(group_2);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('inline', async () => {
     let indicator;
@@ -1188,7 +1188,7 @@ describe('position-sticky', () => {
     BODY.appendChild(group_1);
     BODY.appendChild(group_2);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('large-top-2-ref', async () => {
     let sticky;
@@ -1282,9 +1282,9 @@ describe('position-sticky', () => {
       // document.getElementById("scroll2").scrollTop = 50;
     }
 
-    await matchViewportSnapshot();
+    await snapshot();
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('large-top-2.tentative', async () => {
     let sticky;
@@ -1366,7 +1366,7 @@ describe('position-sticky', () => {
     BODY.appendChild(scroll);
     BODY.appendChild(scroll2);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('large-top-ref', async () => {
     let sticky;
@@ -1442,7 +1442,7 @@ describe('position-sticky', () => {
       scroll2.scrollTop = 50;
     }
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('large-top.tentative', async () => {
     let sticky;
@@ -1510,7 +1510,7 @@ describe('position-sticky', () => {
       scroll2.scrollTop = 50;
     }
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('left', async () => {
     let prepadding;
@@ -1578,7 +1578,7 @@ describe('position-sticky', () => {
     );
     BODY.appendChild(scroller);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('margins', async () => {
     let prepadding;
@@ -1643,7 +1643,7 @@ describe('position-sticky', () => {
     );
     BODY.appendChild(scroller);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('nested-bottom', async () => {
     let prepadding;
@@ -1725,7 +1725,7 @@ describe('position-sticky', () => {
     );
     BODY.appendChild(scroller);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('nested-inline-ref', async () => {
     let outerIndicator;
@@ -1931,7 +1931,7 @@ describe('position-sticky', () => {
     BODY.appendChild(group_2);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('nested-inline', async () => {
     let outerIndicator;
@@ -2262,7 +2262,7 @@ describe('position-sticky', () => {
     BODY.appendChild(group_1);
     BODY.appendChild(group_2);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('nested-left', async () => {
     let prepadding;
@@ -2344,9 +2344,9 @@ describe('position-sticky', () => {
     );
     BODY.appendChild(scroller);
 
-    await matchViewportSnapshot();
+    await snapshot();
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('nested-right', async () => {
     let prepadding;
@@ -2434,9 +2434,9 @@ describe('position-sticky', () => {
     );
     BODY.appendChild(scroller);
 
-    await matchViewportSnapshot();
+    await snapshot();
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('nested-top', async () => {
     let prepadding;
@@ -2513,7 +2513,7 @@ describe('position-sticky', () => {
     );
     BODY.appendChild(scroller);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('offset-overflow', async () => {
     let sticky;
@@ -2539,7 +2539,7 @@ describe('position-sticky', () => {
     );
     BODY.appendChild(scroller1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('offset-top-left', async () => {
     let sticky;
@@ -2573,7 +2573,7 @@ describe('position-sticky', () => {
     );
     BODY.appendChild(scroller1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('overflow-hidden', async () => {
     let div;
@@ -2612,7 +2612,7 @@ describe('position-sticky', () => {
       ]
     );
     BODY.appendChild(div);
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('overflow-padding', async () => {
     let prepadding;
@@ -2677,9 +2677,9 @@ describe('position-sticky', () => {
     );
     BODY.appendChild(scroller);
 
-    await matchViewportSnapshot();
+    await snapshot();
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('scroll-reposition', async (done) => {
     let sticky: any;
@@ -2712,11 +2712,11 @@ describe('position-sticky', () => {
     );
     BODY.appendChild(scroller);
 
-    await matchViewportSnapshot();
+    await snapshot();
 
     requestAnimationFrame(async () => {
       sticky.style.top = '5px';
-      await matchViewportSnapshot();
+      await snapshot();
       done();
     });
 
@@ -2749,11 +2749,11 @@ describe('position-sticky', () => {
     );
     BODY.appendChild(container);
 
-    await matchViewportSnapshot();
+    await snapshot();
 
     requestAnimationFrame(async () => {
       bigItem.style.display = 'none';
-      await matchViewportSnapshot();
+      await snapshot();
       done();
     });
   });
@@ -2780,7 +2780,7 @@ describe('position-sticky', () => {
     BODY.appendChild(indicator);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('stacking-context', async () => {
     let indicator;
@@ -2830,7 +2830,7 @@ describe('position-sticky', () => {
     BODY.appendChild(sticky);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('transforms-translate', async () => {
     let prepadding;
@@ -2895,9 +2895,9 @@ describe('position-sticky', () => {
     );
     BODY.appendChild(scroller);
 
-    await matchViewportSnapshot();
+    await snapshot();
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('should work with image', async () => {
@@ -2935,10 +2935,10 @@ describe('position-sticky', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
     div.scrollBy(0, 100);
-    await matchViewportSnapshot();
+    await snapshot();
     div.scrollTo(0, 300);
-    await matchViewportSnapshot(0.2);
+    await snapshot(0.2);
   });
 });

--- a/integration_tests/specs/css/css-position/position.ts
+++ b/integration_tests/specs/css/css-position/position.ts
@@ -40,7 +40,7 @@ describe('Position', () => {
 
     container2.appendChild(div2);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('should work with flex', async () => {
@@ -91,7 +91,7 @@ describe('Position', () => {
     container.appendChild(absoluteEl);
 
     document.body.appendChild(container);
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('property static', async () => {
@@ -108,7 +108,7 @@ describe('Position', () => {
 
     document.body.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('proeprty relative', async () => {
@@ -136,7 +136,7 @@ describe('Position', () => {
     div2.appendChild(document.createTextNode('relative bottom & right'));
     document.body.appendChild(div2);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('property fixed', async () => {
@@ -164,7 +164,7 @@ describe('Position', () => {
 
     container1.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   xit('peroperty sticky', async () => {
@@ -249,6 +249,6 @@ describe('Position', () => {
     document.body.appendChild(sticky4);
     document.body.appendChild(block4);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-position/position.ts~fix_test
+++ b/integration_tests/specs/css/css-position/position.ts~fix_test
@@ -49,7 +49,7 @@ describe('position', () => {
     BODY.appendChild(p);
     BODY.appendChild(wrapper);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('002', async () => {
     let p;
@@ -100,7 +100,7 @@ describe('position', () => {
     BODY.appendChild(p);
     BODY.appendChild(wrapper);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('003', async () => {
     let p;
@@ -152,7 +152,7 @@ describe('position', () => {
     BODY.appendChild(p);
     BODY.appendChild(wrapper);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('004', async () => {
     let p;
@@ -217,7 +217,7 @@ describe('position', () => {
     BODY.appendChild(p);
     BODY.appendChild(wrapper);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('005', async () => {
     let p;
@@ -270,7 +270,7 @@ describe('position', () => {
     BODY.appendChild(p);
     BODY.appendChild(wrapper);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('006', async () => {
     let p;
@@ -300,6 +300,6 @@ describe('position', () => {
     BODY.appendChild(p);
     BODY.appendChild(p_1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-position/positioning-float.ts
+++ b/integration_tests/specs/css/css-position/positioning-float.ts
@@ -24,6 +24,6 @@ describe('positioning-float', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-position/relative.ts
+++ b/integration_tests/specs/css/css-position/relative.ts
@@ -24,7 +24,7 @@ describe('Position relative', () => {
     div2.appendChild(document.createTextNode('relative bottom & right'));
     document.body.appendChild(div2);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('should be a green square below', async done => {
@@ -41,11 +41,11 @@ describe('Position relative', () => {
     });
     append(parent, child);
     append(BODY, parent);
-    await matchElementImageSnapshot(parent);
+    await snapshot(parent);
 
     requestAnimationFrame(async () => {
       child.style.left = '150px';
-      await matchElementImageSnapshot(parent);
+      await snapshot(parent);
       done();
     });
   });
@@ -74,7 +74,7 @@ describe('Position relative', () => {
 
     document.body.appendChild(parent);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('works with child remove' , async () => {
@@ -112,7 +112,7 @@ describe('Position relative', () => {
     BODY.appendChild(n1);
     n1.removeChild(n2);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('should work with update position relative when comment node exists', async (done) => {
@@ -144,14 +144,14 @@ describe('Position relative', () => {
     );
     append(BODY, cont);
 
-    await matchViewportSnapshot();
+    await snapshot();
 
     requestAnimationFrame(async () => {
       row1.style.position = 'static';
       row1.style.position = 'relative';
       row2.style.position = 'static';
       row2.style.position = 'relative';
-      await matchViewportSnapshot();
+      await snapshot();
       done();
     });
   });

--- a/integration_tests/specs/css/css-position/relpos-calcs.ts
+++ b/integration_tests/specs/css/css-position/relpos-calcs.ts
@@ -32,7 +32,7 @@ describe('relpos-calcs', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('001', async () => {
     let p;
@@ -119,7 +119,7 @@ describe('relpos-calcs', () => {
     BODY.appendChild(container);
     BODY.appendChild(control);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('002', async () => {
     let p;
@@ -206,7 +206,7 @@ describe('relpos-calcs', () => {
     BODY.appendChild(container);
     BODY.appendChild(control);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('003', async () => {
     let p;
@@ -293,7 +293,7 @@ describe('relpos-calcs', () => {
     BODY.appendChild(control);
     BODY.appendChild(container);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('004', async () => {
     let p;
@@ -390,7 +390,7 @@ describe('relpos-calcs', () => {
     BODY.appendChild(control);
     BODY.appendChild(container);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('005', async () => {
     let p;
@@ -487,7 +487,7 @@ describe('relpos-calcs', () => {
     BODY.appendChild(control);
     BODY.appendChild(container);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('006', async () => {
     let p;
@@ -579,11 +579,11 @@ describe('relpos-calcs', () => {
     BODY.appendChild(control);
     BODY.appendChild(container);
 
-    await matchViewportSnapshot();
+    await snapshot();
 
-    await matchViewportSnapshot();
+    await snapshot();
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('007', async () => {
     let p;
@@ -670,6 +670,6 @@ describe('relpos-calcs', () => {
     BODY.appendChild(container);
     BODY.appendChild(control);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-position/relpos-percentage.ts
+++ b/integration_tests/specs/css/css-position/relpos-percentage.ts
@@ -60,6 +60,6 @@ describe('relpos-percentage', () => {
     BODY.appendChild(container);
 
     container.scrollLeft = 123456;
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-position/right-004.ts
+++ b/integration_tests/specs/css/css-position/right-004.ts
@@ -49,6 +49,6 @@ describe('right-004', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-position/right-007.ts
+++ b/integration_tests/specs/css/css-position/right-007.ts
@@ -42,6 +42,6 @@ describe('right-007', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-position/right-019.ts
+++ b/integration_tests/specs/css/css-position/right-019.ts
@@ -42,6 +42,6 @@ describe('right-019', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-position/right-031.ts
+++ b/integration_tests/specs/css/css-position/right-031.ts
@@ -42,6 +42,6 @@ describe('right-031', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-position/right-079.ts
+++ b/integration_tests/specs/css/css-position/right-079.ts
@@ -42,6 +42,6 @@ describe('right-079', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot(0.1);
+    await snapshot(0.1);
   });
 });

--- a/integration_tests/specs/css/css-position/right-100.ts
+++ b/integration_tests/specs/css/css-position/right-100.ts
@@ -49,6 +49,6 @@ describe('right-100', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot(0.5);
+    await snapshot(0.5);
   });
 });

--- a/integration_tests/specs/css/css-position/right-103.ts
+++ b/integration_tests/specs/css/css-position/right-103.ts
@@ -42,6 +42,6 @@ describe('right-103', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-position/right-applies.ts
+++ b/integration_tests/specs/css/css-position/right-applies.ts
@@ -36,7 +36,7 @@ describe('right-applies', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('to-008', async () => {
     let p;
@@ -72,7 +72,7 @@ describe('right-applies', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('to-009', async () => {
     let p;
@@ -116,7 +116,7 @@ describe('right-applies', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('to-012', async () => {
     let p;
@@ -186,6 +186,6 @@ describe('right-applies', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-position/right-offset.ts
+++ b/integration_tests/specs/css/css-position/right-offset.ts
@@ -82,7 +82,7 @@ describe('right-offset', () => {
     BODY.appendChild(p);
     BODY.appendChild(inlineBlock);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('001', async () => {
     let p;
@@ -142,7 +142,7 @@ describe('right-offset', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('002', async () => {
     let p;
@@ -190,7 +190,7 @@ describe('right-offset', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('003', async () => {
     let p;
@@ -250,7 +250,7 @@ describe('right-offset', () => {
     BODY.appendChild(p);
     BODY.appendChild(container);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('004', async () => {
     let p;
@@ -304,7 +304,7 @@ describe('right-offset', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot(0.5);
+    await snapshot(0.5);
   });
   it('percentage-001-ref', async () => {
     let p;
@@ -344,7 +344,7 @@ describe('right-offset', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('percentage-001', async () => {
     let p;
@@ -393,6 +393,6 @@ describe('right-offset', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-position/right.ts
+++ b/integration_tests/specs/css/css-position/right.ts
@@ -54,7 +54,7 @@ describe('right', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('005', async () => {
     let p;
@@ -110,7 +110,7 @@ describe('right', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('006', async () => {
     let p;
@@ -166,7 +166,7 @@ describe('right', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('007', async () => {
     let p;
@@ -223,7 +223,7 @@ describe('right', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('008', async () => {
     let p;
@@ -280,7 +280,7 @@ describe('right', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('016', async () => {
     let p;
@@ -336,7 +336,7 @@ describe('right', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('017', async () => {
     let p;
@@ -392,7 +392,7 @@ describe('right', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('018', async () => {
     let p;
@@ -448,7 +448,7 @@ describe('right', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('019', async () => {
     let p;
@@ -505,7 +505,7 @@ describe('right', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('020', async () => {
     let p;
@@ -562,6 +562,6 @@ describe('right', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-position/static-to-nostatic.ts
+++ b/integration_tests/specs/css/css-position/static-to-nostatic.ts
@@ -57,6 +57,6 @@ describe('Position static', () => {
     div3.style.position = 'fixed';
     div4.style.position = 'sticky';
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-position/static.ts
+++ b/integration_tests/specs/css/css-position/static.ts
@@ -13,6 +13,6 @@ describe('Position static', () => {
 
     document.body.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-position/sticky.ts
+++ b/integration_tests/specs/css/css-position/sticky.ts
@@ -81,6 +81,6 @@ describe('Position sticky', () => {
     document.body.appendChild(sticky4);
     document.body.appendChild(block4);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-position/toogle-abspos.ts
+++ b/integration_tests/specs/css/css-position/toogle-abspos.ts
@@ -71,6 +71,6 @@ describe('toogle-abspos', () => {
     document.body.offsetTop;
     victim.style.position = 'absolute';
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-position/top-applies.ts
+++ b/integration_tests/specs/css/css-position/top-applies.ts
@@ -28,7 +28,7 @@ describe('top-applies', () => {
     BODY.appendChild(div);
     BODY.appendChild(p);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('to-008', async () => {
     let p;
@@ -65,7 +65,7 @@ describe('top-applies', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('to-009', async () => {
     let p;
@@ -110,7 +110,7 @@ describe('top-applies', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('to-012', async () => {
     let p;
@@ -181,6 +181,6 @@ describe('top-applies', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-position/top-offset.ts
+++ b/integration_tests/specs/css/css-position/top-offset.ts
@@ -57,7 +57,7 @@ describe('top-offset', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('002', async () => {
     let p;
@@ -104,7 +104,7 @@ describe('top-offset', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('003-ref', async () => {
     let p;
@@ -189,7 +189,7 @@ describe('top-offset', () => {
     BODY.appendChild(p);
     BODY.appendChild(inlineBlock);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('003', async () => {
     let p;
@@ -249,7 +249,7 @@ describe('top-offset', () => {
     BODY.appendChild(p);
     BODY.appendChild(container);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('percentage-001-ref', async () => {
     let p;
@@ -299,7 +299,7 @@ describe('top-offset', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('percentage-001', async () => {
     let p;
@@ -371,7 +371,7 @@ describe('top-offset', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('percentage-002', async () => {
     let p;
@@ -456,6 +456,6 @@ describe('top-offset', () => {
     BODY.appendChild(p);
     BODY.appendChild(grandParentAbsPos);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-position/top.ts
+++ b/integration_tests/specs/css/css-position/top.ts
@@ -52,7 +52,7 @@ describe('top', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('005', async () => {
     let p;
@@ -106,7 +106,7 @@ describe('top', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('006', async () => {
     let p;
@@ -160,7 +160,7 @@ describe('top', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('007', async () => {
     let p;
@@ -215,7 +215,7 @@ describe('top', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('008', async () => {
     let p;
@@ -270,7 +270,7 @@ describe('top', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('019', async () => {
     let p;
@@ -336,7 +336,7 @@ describe('top', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('020', async () => {
     let p;
@@ -402,7 +402,7 @@ describe('top', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('043', async () => {
     let p;
@@ -468,7 +468,7 @@ describe('top', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   xit('044', async () => {
     let p;
@@ -534,7 +534,7 @@ describe('top', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('052', async () => {
     let p;
@@ -588,6 +588,6 @@ describe('top', () => {
     BODY.appendChild(p);
     BODY.appendChild(div1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-position/z-index-old.ts
+++ b/integration_tests/specs/css/css-position/z-index-old.ts
@@ -37,6 +37,6 @@ describe('ZIndex', () => {
 
     container1.appendChild(div2);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-position/z-index.ts
+++ b/integration_tests/specs/css/css-position/z-index.ts
@@ -40,7 +40,7 @@ describe('z-index', () => {
       });
     });
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('with flex-item', async () => {
@@ -88,7 +88,7 @@ describe('z-index', () => {
     );
     BODY.appendChild(root);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('two flex items with both zIndex', async () => {
@@ -137,7 +137,7 @@ describe('z-index', () => {
     );
     BODY.appendChild(root);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('two flex items of zIndex and no zIndex', async () => {
@@ -184,7 +184,7 @@ describe('z-index', () => {
     );
     BODY.appendChild(root);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('two flex items of both no zIndex', async () => {
@@ -230,7 +230,7 @@ describe('z-index', () => {
     );
     BODY.appendChild(root);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('without flex-item', async () => {
@@ -278,7 +278,7 @@ describe('z-index', () => {
 
     BODY.appendChild(root);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('with z-index change', async (done) => {
@@ -331,11 +331,11 @@ describe('z-index', () => {
 
     BODY.appendChild(root);
 
-    await matchViewportSnapshot();
+    await snapshot();
 
     requestAnimationFrame(async () => {
       div1.style.zIndex = 99;
-      await matchViewportSnapshot(0.1);
+      await snapshot(0.1);
       done();
     });
   });
@@ -388,7 +388,7 @@ describe('z-index', () => {
 
     BODY.appendChild(root);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('works with z-index compare 2', async () => {
@@ -439,6 +439,6 @@ describe('z-index', () => {
 
     BODY.appendChild(root);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-sizing/aspect-ratio.ts
+++ b/integration_tests/specs/css/css-sizing/aspect-ratio.ts
@@ -71,7 +71,7 @@ describe('aspect-ratio', () => {
       if (container != null) {
         container.style.height = '100px';
       }
-      await matchViewportSnapshot();
+      await snapshot();
       done();
     });
   });

--- a/integration_tests/specs/css/css-sizing/auto-scrollbar.ts
+++ b/integration_tests/specs/css/css-sizing/auto-scrollbar.ts
@@ -38,7 +38,7 @@ describe('auto-scrollbar', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('inside-stf-abspos', async () => {
     let p;
@@ -88,6 +88,6 @@ describe('auto-scrollbar', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-sizing/available-height.ts
+++ b/integration_tests/specs/css/css-sizing/available-height.ts
@@ -41,6 +41,6 @@ describe('available-height', () => {
     BODY.appendChild(log);
     BODY.appendChild(wrapper);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-sizing/block-fit.ts
+++ b/integration_tests/specs/css/css-sizing/block-fit.ts
@@ -24,7 +24,7 @@ describe('block-fit', () => {
     );
     BODY.appendChild(parent);
 
-    await matchViewportSnapshot(0.1);
+    await snapshot(0.1);
   });
   xit('content-as-initial', async () => {
     let child;
@@ -52,6 +52,6 @@ describe('block-fit', () => {
     );
     BODY.appendChild(parent);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-sizing/block-image.ts
+++ b/integration_tests/specs/css/css-sizing/block-image.ts
@@ -62,6 +62,6 @@ describe('block-image', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-sizing/canvas-intrinsic.ts
+++ b/integration_tests/specs/css/css-sizing/canvas-intrinsic.ts
@@ -37,6 +37,6 @@ describe('canvas-intrinsic', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-sizing/height.ts
+++ b/integration_tests/specs/css/css-sizing/height.ts
@@ -9,7 +9,7 @@ describe('Height', () => {
 
     document.body.appendChild(div);
     div.style.height = '200px';
-    await expectAsync(div.toBlob(1)).toMatchImageSnapshot('');
+    await expectAsync(div.toBlob(1)).toMatchSnapshot('');
   });
 
   describe('element style has height', () => {
@@ -22,7 +22,7 @@ describe('Height', () => {
         createText('foobar'),
       ]);
       append(BODY, element);
-      await matchViewportSnapshot();
+      await snapshot();
     });
 
     it('element is inline-block', async () => {
@@ -34,7 +34,7 @@ describe('Height', () => {
         createText('foobar'),
       ]);
       append(BODY, element);
-      await matchViewportSnapshot();
+      await snapshot();
     });
 
     it('element is inline-flex', async () => {
@@ -46,7 +46,7 @@ describe('Height', () => {
         createText('foobar'),
       ]);
       append(BODY, element);
-      await matchViewportSnapshot();
+      await snapshot();
     });
 
     it('element is block', async () => {
@@ -58,7 +58,7 @@ describe('Height', () => {
         createText('foobar'),
       ]);
       append(BODY, element);
-      await matchViewportSnapshot();
+      await snapshot();
     });
 
     it('element is flex', async () => {
@@ -70,7 +70,7 @@ describe('Height', () => {
         createText('foobar'),
       ]);
       append(BODY, element);
-      await matchViewportSnapshot();
+      await snapshot();
     });
   });
 
@@ -113,7 +113,7 @@ describe('Height', () => {
       });
       container.appendChild(child3);
 
-      await matchViewportSnapshot();
+      await snapshot();
     });
 
     it('when parent is flex with no height and align-items stretch', async () => {
@@ -152,7 +152,7 @@ describe('Height', () => {
       });
       container.appendChild(child3);
 
-      await matchViewportSnapshot();
+      await snapshot();
     });
 
     it('when nested in flex parents with align-items stretch', async () => {
@@ -203,7 +203,7 @@ describe('Height', () => {
       });
       container.appendChild(child3);
 
-      await matchViewportSnapshot();
+      await snapshot();
     });
 
     it('set element\'s height to auto', async () => {
@@ -215,10 +215,10 @@ describe('Height', () => {
       }, [createText('1234')]);
       BODY.appendChild(container);
 
-      await matchViewportSnapshot();
+      await snapshot();
 
       container.style.height = 'auto';
-      await matchViewportSnapshot();
+      await snapshot();
     });
   });
 
@@ -263,7 +263,7 @@ describe('Height', () => {
     );
 
     BODY.appendChild(div);
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('should work with percentage in flex layout in row direction', async () => {
@@ -308,7 +308,7 @@ describe('Height', () => {
     );
 
     BODY.appendChild(div);
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('should work with percentage in flex layout in column direction', async () => {
@@ -354,7 +354,7 @@ describe('Height', () => {
     );
 
     BODY.appendChild(div);
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('should work with percentage and flow layout of no height', async (done) => {
@@ -394,11 +394,11 @@ describe('Height', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
 
     requestAnimationFrame(async () => {
       text.data = 'three';
-      await matchViewportSnapshot(0.1);
+      await snapshot(0.1);
       done();
     });
   });
@@ -441,11 +441,11 @@ describe('Height', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
 
     requestAnimationFrame(async () => {
       text.data = 'three';
-      await matchViewportSnapshot(0.1);
+      await snapshot(0.1);
       done();
     });
   });
@@ -489,11 +489,11 @@ describe('Height', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
 
     requestAnimationFrame(async () => {
       text.data = 'three';
-      await matchViewportSnapshot(0.1);
+      await snapshot(0.1);
       done();
     });
   });
@@ -538,11 +538,11 @@ describe('Height', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
 
     requestAnimationFrame(async () => {
       text.data = 'three';
-      await matchViewportSnapshot(0.1);
+      await snapshot(0.1);
       done();
     });
   });

--- a/integration_tests/specs/css/css-sizing/image-min.ts
+++ b/integration_tests/specs/css/css-sizing/image-min.ts
@@ -13,6 +13,6 @@ describe('image-min', () => {
     });
     BODY.appendChild(img);
 
-    await matchViewportSnapshot(0.1);
+    await snapshot(0.1);
   });
 });

--- a/integration_tests/specs/css/css-sizing/image-percentage.ts
+++ b/integration_tests/specs/css/css-sizing/image-percentage.ts
@@ -56,6 +56,6 @@ describe('image-percentage', () => {
     BODY.appendChild(p);
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-sizing/max-height.ts
+++ b/integration_tests/specs/css/css-sizing/max-height.ts
@@ -11,7 +11,7 @@ describe('max-height', () => {
     ]);
     BODY.appendChild(containingBlock);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it("should work with display inline-block when it has no children and height not exist", async () => {
@@ -25,7 +25,7 @@ describe('max-height', () => {
     });
     BODY.appendChild(containingBlock);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it("should work with display block when it has no children and height not exist", async () => {
@@ -39,7 +39,7 @@ describe('max-height', () => {
     });
     BODY.appendChild(containingBlock);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it("should work with display inline-flex when it has no children and height not exist", async () => {
@@ -53,7 +53,7 @@ describe('max-height', () => {
     });
     BODY.appendChild(containingBlock);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it("should work with display flex when it has no children and height not exist", async () => {
@@ -67,7 +67,7 @@ describe('max-height', () => {
     });
     BODY.appendChild(containingBlock);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it("should work with display inline-block when child height is larger than max-height", async () => {
@@ -82,7 +82,7 @@ describe('max-height', () => {
     ]);
     BODY.appendChild(containingBlock);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it("should work with display inline-block when child height is smaller than max-height", async () => {
@@ -97,7 +97,7 @@ describe('max-height', () => {
     ]);
     BODY.appendChild(containingBlock);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it("should work with display inline-flex when child height is larger than max-height", async () => {
@@ -112,7 +112,7 @@ describe('max-height', () => {
     ]);
     BODY.appendChild(containingBlock);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it("should work with display inline-flex when child height is smaller than max-height", async () => {
@@ -127,7 +127,7 @@ describe('max-height', () => {
     ]);
     BODY.appendChild(containingBlock);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it("should work with display block when child height is larger than max-height", async () => {
@@ -142,7 +142,7 @@ describe('max-height', () => {
     ]);
     BODY.appendChild(containingBlock);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it("should work with display block when child length is smaller than max-height", async () => {
@@ -157,7 +157,7 @@ describe('max-height', () => {
     ]);
     BODY.appendChild(containingBlock);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
 
@@ -173,7 +173,7 @@ describe('max-height', () => {
     ]);
     BODY.appendChild(containingBlock);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it("should work with display flex when child height is smaller than max-height", async () => {
@@ -188,7 +188,7 @@ describe('max-height', () => {
     ]);
     BODY.appendChild(containingBlock);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('should work with replaced element when element height is smaller than intrinsic height', async () => {
@@ -217,7 +217,7 @@ describe('max-height', () => {
     );
     BODY.appendChild(flexbox);
 
-    await matchViewportSnapshot(0.1);
+    await snapshot(0.1);
   });
 
   it('should work with replaced element when element height is larger than intrinsic height', async () => {
@@ -246,7 +246,7 @@ describe('max-height', () => {
     );
     BODY.appendChild(flexbox);
 
-    await matchViewportSnapshot(0.1);
+    await snapshot(0.1);
   });
 
   it('should work with percentage in flow layout', async () => {
@@ -283,7 +283,7 @@ describe('max-height', () => {
     );
 
     BODY.appendChild(div);
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('should work with percentage in flex layout in row direction', async () => {
@@ -321,7 +321,7 @@ describe('max-height', () => {
     );
 
     BODY.appendChild(div);
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('should work with percentage in flex layout in column direction', async () => {
@@ -360,7 +360,7 @@ describe('max-height', () => {
     );
 
     BODY.appendChild(div);
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('change from not none to none', async (done) => {
@@ -379,11 +379,11 @@ describe('max-height', () => {
     );
     append(BODY, cont);
 
-    await matchViewportSnapshot();
+    await snapshot();
 
     requestAnimationFrame(async () => {
       cont.style.maxHeight = 'none';
-      await matchViewportSnapshot(0.1);
+      await snapshot(0.1);
       done();
     });
   });

--- a/integration_tests/specs/css/css-sizing/max-width.ts
+++ b/integration_tests/specs/css/css-sizing/max-width.ts
@@ -11,7 +11,7 @@ describe('max-width', () => {
     ]);
     BODY.appendChild(containingBlock);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it("should work with display inline-block when it has no children and width not exist", async () => {
@@ -25,7 +25,7 @@ describe('max-width', () => {
     });
     BODY.appendChild(containingBlock);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it("should work with display block when it has no children and width not exist", async () => {
@@ -39,7 +39,7 @@ describe('max-width', () => {
     });
     BODY.appendChild(containingBlock);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it("should work with display inline-flex when it has no children and width not exist", async () => {
@@ -53,7 +53,7 @@ describe('max-width', () => {
     });
     BODY.appendChild(containingBlock);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it("should work with display flex when it has no children and width not exist", async () => {
@@ -67,7 +67,7 @@ describe('max-width', () => {
     });
     BODY.appendChild(containingBlock);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it("should work with display inline-block when child length is larger than max-width", async () => {
@@ -82,7 +82,7 @@ describe('max-width', () => {
     ]);
     BODY.appendChild(containingBlock);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it("should work with display inline-block when child length is smaller than max-width", async () => {
@@ -97,7 +97,7 @@ describe('max-width', () => {
     ]);
     BODY.appendChild(containingBlock);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it("should work with display inline-flex when child length is larger than max-width", async () => {
@@ -112,7 +112,7 @@ describe('max-width', () => {
     ]);
     BODY.appendChild(containingBlock);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it("should work with display inline-flex when child length is smaller than max-width", async () => {
@@ -127,7 +127,7 @@ describe('max-width', () => {
     ]);
     BODY.appendChild(containingBlock);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it("should work with display block when child length is larger than max-width", async () => {
@@ -142,7 +142,7 @@ describe('max-width', () => {
     ]);
     BODY.appendChild(containingBlock);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it("should work with display block when child length is smaller than max-width", async () => {
@@ -157,7 +157,7 @@ describe('max-width', () => {
     ]);
     BODY.appendChild(containingBlock);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
 
@@ -173,7 +173,7 @@ describe('max-width', () => {
     ]);
     BODY.appendChild(containingBlock);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it("should work with display flex when child length is smaller than max-width", async () => {
@@ -188,7 +188,7 @@ describe('max-width', () => {
     ]);
     BODY.appendChild(containingBlock);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('should work with replaced element when element width is smaller than intrinsic width', async () => {
@@ -217,7 +217,7 @@ describe('max-width', () => {
     );
     BODY.appendChild(flexbox);
 
-    await matchViewportSnapshot(0.1);
+    await snapshot(0.1);
   });
 
   it('should work with replaced element when element width is larger than intrinsic width', async () => {
@@ -246,7 +246,7 @@ describe('max-width', () => {
     );
     BODY.appendChild(flexbox);
 
-    await matchViewportSnapshot(0.1);
+    await snapshot(0.1);
   });
 
   it('should work with percentage in flow layout', async () => {
@@ -281,7 +281,7 @@ describe('max-width', () => {
     );
 
     BODY.appendChild(div);
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('should work with percentage in flex layout in row direction', async () => {
@@ -319,7 +319,7 @@ describe('max-width', () => {
     );
 
     BODY.appendChild(div);
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('should work with percentage in flex layout in column direction', async () => {
@@ -356,7 +356,7 @@ describe('max-width', () => {
     );
 
     BODY.appendChild(div);
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('change from not none to none', async (done) => {
@@ -374,11 +374,11 @@ describe('max-width', () => {
     );
     append(BODY, cont);
 
-    await matchViewportSnapshot();
+    await snapshot();
 
     requestAnimationFrame(async () => {
       cont.style.maxWidth = 'none';
-      await matchViewportSnapshot(0.1);
+      await snapshot(0.1);
       done();
     });
   });

--- a/integration_tests/specs/css/css-sizing/min-height.ts
+++ b/integration_tests/specs/css/css-sizing/min-height.ts
@@ -11,7 +11,7 @@ describe('min-height', () => {
     ]);
     BODY.appendChild(containingBlock);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it("should work with display inline-block when it has no children and height not exist", async () => {
@@ -25,7 +25,7 @@ describe('min-height', () => {
     });
     BODY.appendChild(containingBlock);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it("should work with display block when it has no children and height not exist", async () => {
@@ -39,7 +39,7 @@ describe('min-height', () => {
     });
     BODY.appendChild(containingBlock);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it("should work with display inline-flex when it has no children and height not exist", async () => {
@@ -53,7 +53,7 @@ describe('min-height', () => {
     });
     BODY.appendChild(containingBlock);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it("should work with display flex when it has no children and height not exist", async () => {
@@ -67,7 +67,7 @@ describe('min-height', () => {
     });
     BODY.appendChild(containingBlock);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it("should work with display inline-block when child height is larger than min-height", async () => {
@@ -82,7 +82,7 @@ describe('min-height', () => {
     ]);
     BODY.appendChild(containingBlock);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it("should work with display inline-block when child height is smaller than min-height", async () => {
@@ -97,7 +97,7 @@ describe('min-height', () => {
     ]);
     BODY.appendChild(containingBlock);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it("should work with display inline-flex when child height is larger than min-height", async () => {
@@ -112,7 +112,7 @@ describe('min-height', () => {
     ]);
     BODY.appendChild(containingBlock);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it("should work with display inline-flex when child height is smaller than min-height", async () => {
@@ -127,7 +127,7 @@ describe('min-height', () => {
     ]);
     BODY.appendChild(containingBlock);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it("should work with display block when child height is larger than min-height", async () => {
@@ -142,7 +142,7 @@ describe('min-height', () => {
     ]);
     BODY.appendChild(containingBlock);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it("should work with display block when child length is smaller than min-height", async () => {
@@ -157,7 +157,7 @@ describe('min-height', () => {
     ]);
     BODY.appendChild(containingBlock);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
 
@@ -173,7 +173,7 @@ describe('min-height', () => {
     ]);
     BODY.appendChild(containingBlock);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it("should work with display flex when child height is smaller than min-height", async () => {
@@ -188,7 +188,7 @@ describe('min-height', () => {
     ]);
     BODY.appendChild(containingBlock);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('should work with replaced element when element height is smaller than intrinsic height', async () => {
@@ -217,7 +217,7 @@ describe('min-height', () => {
     );
     BODY.appendChild(flexbox);
 
-    await matchViewportSnapshot(0.1);
+    await snapshot(0.1);
   });
 
   it('should work with replaced element when element height is larger than intrinsic height', async () => {
@@ -246,7 +246,7 @@ describe('min-height', () => {
     );
     BODY.appendChild(flexbox);
 
-    await matchViewportSnapshot(0.1);
+    await snapshot(0.1);
   });
 
   it('should work with percentage in flow layout', async () => {
@@ -282,7 +282,7 @@ describe('min-height', () => {
     );
 
     BODY.appendChild(div);
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('should work with percentage in flex layout in row direction', async () => {
@@ -320,7 +320,7 @@ describe('min-height', () => {
     );
 
     BODY.appendChild(div);
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('should work with percentage in flex layout in column direction', async () => {
@@ -358,7 +358,7 @@ describe('min-height', () => {
     );
 
     BODY.appendChild(div);
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
 });

--- a/integration_tests/specs/css/css-sizing/min-width.ts
+++ b/integration_tests/specs/css/css-sizing/min-width.ts
@@ -11,7 +11,7 @@ describe('min-width', () => {
     ]);
     BODY.appendChild(containingBlock);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it("should work with display inline-block when it has no children and width not exist", async () => {
@@ -25,7 +25,7 @@ describe('min-width', () => {
     });
     BODY.appendChild(containingBlock);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it("should work with display block when it has no children and width not exist", async () => {
@@ -39,7 +39,7 @@ describe('min-width', () => {
     });
     BODY.appendChild(containingBlock);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it("should work with display inline-flex when it has no children and width not exist", async () => {
@@ -53,7 +53,7 @@ describe('min-width', () => {
     });
     BODY.appendChild(containingBlock);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it("should work with display flex when it has no children and width not exist", async () => {
@@ -67,7 +67,7 @@ describe('min-width', () => {
     });
     BODY.appendChild(containingBlock);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it("should work with display inline-block when child length is larger than min-width", async () => {
@@ -82,7 +82,7 @@ describe('min-width', () => {
     ]);
     BODY.appendChild(containingBlock);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it("should work with display inline-block when child length is smaller than min-width", async () => {
@@ -97,7 +97,7 @@ describe('min-width', () => {
     ]);
     BODY.appendChild(containingBlock);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it("should work with display inline-flex when child length is larger than min-width", async () => {
@@ -112,7 +112,7 @@ describe('min-width', () => {
     ]);
     BODY.appendChild(containingBlock);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it("should work with display inline-flex when child length is smaller than min-width", async () => {
@@ -127,7 +127,7 @@ describe('min-width', () => {
     ]);
     BODY.appendChild(containingBlock);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it("should work with display block when child length is larger than min-width", async () => {
@@ -142,7 +142,7 @@ describe('min-width', () => {
     ]);
     BODY.appendChild(containingBlock);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it("should work with display block when child length is smaller than min-width", async () => {
@@ -157,7 +157,7 @@ describe('min-width', () => {
     ]);
     BODY.appendChild(containingBlock);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
 
@@ -173,7 +173,7 @@ describe('min-width', () => {
     ]);
     BODY.appendChild(containingBlock);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it("should work with display flex when child length is smaller than min-width", async () => {
@@ -188,7 +188,7 @@ describe('min-width', () => {
     ]);
     BODY.appendChild(containingBlock);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('should work with replaced element when element width is smaller than intrinsic width', async () => {
@@ -217,7 +217,7 @@ describe('min-width', () => {
     );
     BODY.appendChild(flexbox);
 
-    await matchViewportSnapshot(0.1);
+    await snapshot(0.1);
   });
 
   it('should work with replaced element when element width is larger than intrinsic width', async () => {
@@ -246,7 +246,7 @@ describe('min-width', () => {
     );
     BODY.appendChild(flexbox);
 
-    await matchViewportSnapshot(0.1);
+    await snapshot(0.1);
   });
 
   it('should work with percentage in flow layout', async () => {
@@ -284,7 +284,7 @@ describe('min-width', () => {
     );
 
     BODY.appendChild(div);
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('should work with percentage in flex layout in row direction', async () => {
@@ -323,7 +323,7 @@ describe('min-width', () => {
     );
 
     BODY.appendChild(div);
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('should work with percentage in flex layout in column direction', async () => {
@@ -363,6 +363,6 @@ describe('min-width', () => {
     );
 
     BODY.appendChild(div);
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-sizing/width.ts
+++ b/integration_tests/specs/css/css-sizing/width.ts
@@ -9,7 +9,7 @@ describe('Width', function() {
 
     document.body.appendChild(div);
     div.style.width = '200px';
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   describe('element style has width', () => {
@@ -22,7 +22,7 @@ describe('Width', function() {
         createText('foobar'),
       ]);
       append(BODY, element);
-      await matchViewportSnapshot();
+      await snapshot();
     });
 
     it('element is inline-block', async () => {
@@ -34,7 +34,7 @@ describe('Width', function() {
         createText('foobar'),
       ]);
       append(BODY, element);
-      await matchViewportSnapshot();
+      await snapshot();
     });
 
     it('element is inline-flex', async () => {
@@ -46,7 +46,7 @@ describe('Width', function() {
         createText('foobar'),
       ]);
       append(BODY, element);
-      await matchViewportSnapshot();
+      await snapshot();
     });
 
     it('element is block', async () => {
@@ -58,7 +58,7 @@ describe('Width', function() {
         createText('foobar'),
       ]);
       append(BODY, element);
-      await matchViewportSnapshot();
+      await snapshot();
     });
 
     it('element is flex', async () => {
@@ -70,7 +70,7 @@ describe('Width', function() {
         createText('foobar'),
       ]);
       append(BODY, element);
-      await matchViewportSnapshot();
+      await snapshot();
     });
   });
 
@@ -95,7 +95,7 @@ describe('Width', function() {
       ]);
 
       append(BODY, container);
-      await matchViewportSnapshot();
+      await snapshot();
     });
 
     it('parent is inline-block and has width', async () => {
@@ -113,7 +113,7 @@ describe('Width', function() {
       ]);
 
       append(BODY, container);
-      await matchViewportSnapshot();
+      await snapshot();
     });
 
     it('parent is inline-block and has no width', async () => {
@@ -130,7 +130,7 @@ describe('Width', function() {
       ]);
 
       append(BODY, container);
-      await matchViewportSnapshot();
+      await snapshot();
     });
 
     it('parent is block and has width', async () => {
@@ -148,7 +148,7 @@ describe('Width', function() {
       ]);
 
       append(BODY, container);
-      await matchViewportSnapshot();
+      await snapshot();
     });
 
     it('parent is block and has no width', async () => {
@@ -165,7 +165,7 @@ describe('Width', function() {
       ]);
 
       append(BODY, container);
-      await matchViewportSnapshot();
+      await snapshot();
     });
 
     it('set element\'s width to auto', async () => {
@@ -177,10 +177,10 @@ describe('Width', function() {
       }, [createText('1234')]);
       BODY.appendChild(container);
 
-      await matchViewportSnapshot();
+      await snapshot();
 
       container.style.width = 'auto';
-      await matchViewportSnapshot();
+      await snapshot();
     });
   });
 
@@ -225,7 +225,7 @@ describe('Width', function() {
     );
 
     BODY.appendChild(div);
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('should work with percentage and multiple children in flow layout', async () => {
@@ -261,7 +261,7 @@ describe('Width', function() {
     );
 
     BODY.appendChild(div);
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('should work with percentage in flex layout in row direction', async () => {
@@ -306,7 +306,7 @@ describe('Width', function() {
     );
 
     BODY.appendChild(div);
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('should work with percentage in flex layout in column direction', async () => {
@@ -352,7 +352,7 @@ describe('Width', function() {
     );
 
     BODY.appendChild(div);
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('should work with percentage and multiple children in flex layout ', async () => {
@@ -390,6 +390,6 @@ describe('Width', function() {
     );
 
     BODY.appendChild(div);
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-text-decor/text-decoration.ts
+++ b/integration_tests/specs/css/css-text-decor/text-decoration.ts
@@ -35,7 +35,7 @@ describe('Text TextDecoration', () => {
           );
           append(BODY, cont);
 
-          return matchViewportSnapshot();
+          return snapshot();
         });
 
         // Merged property.
@@ -53,7 +53,7 @@ describe('Text TextDecoration', () => {
           );
           append(BODY, cont);
 
-          return matchViewportSnapshot();
+          return snapshot();
         });
       });
     });

--- a/integration_tests/specs/css/css-text-decor/text-shadow.ts
+++ b/integration_tests/specs/css/css-text-decor/text-shadow.ts
@@ -22,7 +22,7 @@ describe('Text TextDecoration', () => {
       );
       append(BODY, cont);
 
-      return matchElementImageSnapshot(cont);
+      return snapshot(cont);
     });
   });
 });

--- a/integration_tests/specs/css/css-text/letter-spacing.ts
+++ b/integration_tests/specs/css/css-text/letter-spacing.ts
@@ -14,7 +14,7 @@ describe('Text LetterSpacing', () => {
       );
       append(BODY, cont);
 
-      return matchElementImageSnapshot(cont);
+      return snapshot(cont);
     });
   });
 });

--- a/integration_tests/specs/css/css-text/line-clamp.ts
+++ b/integration_tests/specs/css/css-text/line-clamp.ts
@@ -14,7 +14,7 @@ describe('Text LineClamp', () => {
     );
     append(BODY, cont);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('should work with none', async () => {
@@ -32,7 +32,7 @@ describe('Text LineClamp', () => {
     );
     append(BODY, cont);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('should work with none to positive number', async (done) => {
@@ -53,11 +53,11 @@ describe('Text LineClamp', () => {
     setTimeout(async () => {
       // @ts-ignore
       cont.style.lineClamp = 3;
-      await matchViewportSnapshot();
+      await snapshot();
       done();
     }, 100);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('should work with positive number to none', async (done) => {
@@ -78,10 +78,10 @@ describe('Text LineClamp', () => {
     setTimeout(async () => {
       // @ts-ignore
       cont.style.lineClamp = 'none';
-      await matchViewportSnapshot();
+      await snapshot();
       done();
     }, 100);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-text/text-align.ts
+++ b/integration_tests/specs/css/css-text/text-align.ts
@@ -26,7 +26,7 @@ describe('Text TextAlign', () => {
       );
       append(BODY, cont);
 
-      return matchElementImageSnapshot(cont);
+      return snapshot(cont);
     });
   });
 
@@ -55,7 +55,7 @@ describe('Text TextAlign', () => {
     );
     document.body.appendChild(cont);
 
-    await matchViewportSnapshot();
+    await snapshot();
 
   });
 
@@ -84,7 +84,7 @@ describe('Text TextAlign', () => {
     );
     document.body.appendChild(cont);
 
-    await matchViewportSnapshot();
+    await snapshot();
 
   });
 });

--- a/integration_tests/specs/css/css-text/text-indent.ts
+++ b/integration_tests/specs/css/css-text/text-indent.ts
@@ -14,7 +14,7 @@ xdescribe('Text TextIndent', () => {
       );
       append(BODY, cont);
 
-      return matchElementImageSnapshot(cont);
+      return snapshot(cont);
     });
   });
 });

--- a/integration_tests/specs/css/css-text/text-overflow.ts
+++ b/integration_tests/specs/css/css-text/text-overflow.ts
@@ -15,7 +15,7 @@ describe('Text Overflow', () => {
 
     append(BODY, cont);
 
-    return matchViewportSnapshot();
+    return snapshot();
   });
 
   it('should work with clip with overflow no visible', () => {
@@ -36,7 +36,7 @@ describe('Text Overflow', () => {
 
     append(BODY, cont);
 
-    return matchViewportSnapshot();
+    return snapshot();
   });
 
   it('should not work with clip with overflow visible', () => {
@@ -57,7 +57,7 @@ describe('Text Overflow', () => {
 
     append(BODY, cont);
 
-    return matchViewportSnapshot();
+    return snapshot();
   });
 
   it('should work with ellipsis when overflow not visible and whiteSpace nowrap', () => {
@@ -78,7 +78,7 @@ describe('Text Overflow', () => {
 
     append(BODY, cont);
 
-    return matchViewportSnapshot();
+    return snapshot();
   });
 
   it('should not work with ellipsis when overflow visible', () => {
@@ -99,7 +99,7 @@ describe('Text Overflow', () => {
 
     append(BODY, cont);
 
-    return matchViewportSnapshot();
+    return snapshot();
   });
 
   it('should not work with ellipsis when whiteSpace normal', () => {
@@ -120,7 +120,7 @@ describe('Text Overflow', () => {
 
     append(BODY, cont);
 
-    return matchViewportSnapshot();
+    return snapshot();
   });
 
   it('should work with text-overflow: ellipsis', async () => {
@@ -158,6 +158,6 @@ describe('Text Overflow', () => {
     container.appendChild(child1);
     child1.appendChild(document.createTextNode('block with no height'));
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-text/white-space.ts
+++ b/integration_tests/specs/css/css-text/white-space.ts
@@ -6,7 +6,7 @@ describe('Text WhiteSpace', () => {
     );
     document.body.appendChild(document.createTextNode(' new line'));
 
-    return matchViewportSnapshot();
+    return snapshot();
   });
 
   it('should work with default value', () => {
@@ -24,7 +24,7 @@ describe('Text WhiteSpace', () => {
 
     append(BODY, cont);
 
-    return matchViewportSnapshot();
+    return snapshot();
   });
 
   it('should work with normal', () => {
@@ -43,7 +43,7 @@ describe('Text WhiteSpace', () => {
 
     append(BODY, cont);
 
-    return matchViewportSnapshot();
+    return snapshot();
   });
 
   it('should work with no-wrap', () => {
@@ -62,7 +62,7 @@ describe('Text WhiteSpace', () => {
 
     append(BODY, cont);
 
-    return matchViewportSnapshot();
+    return snapshot();
   });
 
 
@@ -81,11 +81,11 @@ describe('Text WhiteSpace', () => {
 
     append(BODY, cont);
 
-    await matchViewportSnapshot();
+    await snapshot();
 
     requestAnimationFrame(async () => {
       cont.style.whiteSpace = 'nowrap';
-      await matchViewportSnapshot(0.1);
+      await snapshot(0.1);
       done();
     });
   });
@@ -105,11 +105,11 @@ describe('Text WhiteSpace', () => {
 
     append(BODY, cont);
 
-    await matchViewportSnapshot();
+    await snapshot();
 
     requestAnimationFrame(async () => {
       cont.style.whiteSpace = 'normal';
-      await matchViewportSnapshot(0.1);
+      await snapshot(0.1);
       done();
     });
   });
@@ -201,7 +201,7 @@ describe('Inline level element', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it("should work with normal", async () => {
@@ -288,7 +288,7 @@ describe('Inline level element', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it("should work with change from nowrap to normal", async (done) => {
@@ -376,11 +376,11 @@ describe('Inline level element', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
 
     requestAnimationFrame(async () => {
       div.style.whiteSpace = 'normal';
-      await matchViewportSnapshot(0.1);
+      await snapshot(0.1);
       done();
     });
   });
@@ -470,11 +470,11 @@ describe('Inline level element', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
 
     requestAnimationFrame(async () => {
       div.style.whiteSpace = 'nowrap';
-      await matchViewportSnapshot(0.1);
+      await snapshot(0.1);
       done();
     });
   });

--- a/integration_tests/specs/css/css-text/word-spacing.ts
+++ b/integration_tests/specs/css/css-text/word-spacing.ts
@@ -14,7 +14,7 @@ describe('Text WordSpacing', () => {
       );
       append(BODY, cont);
 
-      return matchElementImageSnapshot(cont);
+      return snapshot(cont);
     });
   });
 });

--- a/integration_tests/specs/css/css-transforms/matrix.ts
+++ b/integration_tests/specs/css/css-transforms/matrix.ts
@@ -9,6 +9,6 @@ describe('Transform matrix', () => {
       })
     );
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-transforms/matrix3d.ts
+++ b/integration_tests/specs/css/css-transforms/matrix3d.ts
@@ -10,6 +10,6 @@ describe('Transform matrix3d', function() {
       })
     );
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-transforms/rotate.ts
+++ b/integration_tests/specs/css/css-transforms/rotate.ts
@@ -9,6 +9,6 @@ describe('Transform rotate', function() {
       })
     );
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-transforms/scale.ts
+++ b/integration_tests/specs/css/css-transforms/scale.ts
@@ -10,7 +10,7 @@ describe('Transform scale', () => {
       })
     );
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('002', async () => {
@@ -24,6 +24,6 @@ describe('Transform scale', () => {
         })
       );
 
-      await matchViewportSnapshot();
+      await snapshot();
     });
 });

--- a/integration_tests/specs/css/css-transforms/scale3d.ts
+++ b/integration_tests/specs/css/css-transforms/scale3d.ts
@@ -10,6 +10,6 @@ describe('Transform scale3d', () => {
       })
     );
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-transforms/skew.ts
+++ b/integration_tests/specs/css/css-transforms/skew.ts
@@ -10,6 +10,6 @@ describe('Transform skew', function() {
       })
     );
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-transforms/transform-change.ts
+++ b/integration_tests/specs/css/css-transforms/transform-change.ts
@@ -18,11 +18,11 @@ describe('transform change', () => {
     );
     append(BODY, cont);
 
-    await matchViewportSnapshot();
+    await snapshot();
 
     requestAnimationFrame(async () => {
       cont.style.transform = 'none';
-      await matchViewportSnapshot(0.1);
+      await snapshot(0.1);
       done();
     });
   });
@@ -47,11 +47,11 @@ describe('transform change', () => {
     );
     append(BODY, cont);
 
-    await matchViewportSnapshot();
+    await snapshot();
 
     requestAnimationFrame(async () => {
       cont.style.transform = 'none';
-      await matchViewportSnapshot(0.1);
+      await snapshot(0.1);
       done();
     });
   });
@@ -75,11 +75,11 @@ describe('transform change', () => {
     );
     append(BODY, cont);
 
-    await matchViewportSnapshot();
+    await snapshot();
 
     requestAnimationFrame(async () => {
       cont.style.transform = 'translate(100px, 0)';
-      await matchViewportSnapshot(0.1);
+      await snapshot(0.1);
       done();
     });
   });
@@ -104,11 +104,11 @@ describe('transform change', () => {
     );
     append(BODY, cont);
 
-    await matchViewportSnapshot();
+    await snapshot();
 
     requestAnimationFrame(async () => {
       cont.style.transform = 'translate(100px, 0)';
-      await matchViewportSnapshot(0.1);
+      await snapshot(0.1);
       done();
     });
   });

--- a/integration_tests/specs/css/css-transforms/transform-origin.ts
+++ b/integration_tests/specs/css/css-transforms/transform-origin.ts
@@ -10,7 +10,7 @@ describe('Transform origin', () => {
       })
     );
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
   it('percent', async function() {
       document.body.appendChild(
@@ -23,7 +23,7 @@ describe('Transform origin', () => {
         })
       );
 
-      await matchViewportSnapshot();
+      await snapshot();
     });
     it('keyword', async function() {
         document.body.appendChild(
@@ -36,7 +36,7 @@ describe('Transform origin', () => {
           })
         );
 
-        await matchViewportSnapshot();
+        await snapshot();
       });
       it('keyword center', async function() {
               document.body.appendChild(
@@ -49,7 +49,7 @@ describe('Transform origin', () => {
                 })
               );
 
-              await matchViewportSnapshot();
+              await snapshot();
             });
 
     xit('works width margin' , async () => {
@@ -81,6 +81,6 @@ describe('Transform origin', () => {
        );
       BODY.appendChild(n1);
 
-      await matchViewportSnapshot();
+      await snapshot();
     });
 });

--- a/integration_tests/specs/css/css-transforms/translate.ts
+++ b/integration_tests/specs/css/css-transforms/translate.ts
@@ -9,7 +9,7 @@ describe('Transform translate', () => {
       })
     );
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('should work with percentage with one value', async () => {
@@ -37,7 +37,7 @@ describe('Transform translate', () => {
     );
 
     BODY.appendChild(div);
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('should work with percentage with two values', async () => {
@@ -65,7 +65,7 @@ describe('Transform translate', () => {
     );
 
     BODY.appendChild(div);
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('should work with percentage translate and percentage sizing in flow layout', async () => {
@@ -93,7 +93,7 @@ describe('Transform translate', () => {
     );
 
     BODY.appendChild(div);
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('should work with percentage translate and percentage sizing in flex layout', async () => {
@@ -122,6 +122,6 @@ describe('Transform translate', () => {
     );
 
     BODY.appendChild(div);
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/css/css-transitions/all.ts
+++ b/integration_tests/specs/css/css-transitions/all.ts
@@ -19,7 +19,7 @@ describe('Transition all', () => {
 
       // Wait for animation finished.
       setTimeout(async () => {
-        await matchViewportSnapshot();
+        await snapshot();
         done();
       }, 1100);
     });
@@ -36,10 +36,10 @@ describe('Transition all', () => {
       createText('1234')
     ]);
     BODY.appendChild(container);
-    await matchViewportSnapshot();
+    await snapshot();
     requestAnimationFrame(async () => {
       container.style.height = '50px';
-      await matchViewportSnapshot();
+      await snapshot();
       done();
     });
   });
@@ -54,10 +54,10 @@ describe('Transition all', () => {
       createText('1234')
     ]);
     BODY.appendChild(container);
-    await matchViewportSnapshot();
+    await snapshot();
     requestAnimationFrame(async () => {
       container.style.width = '100px';
-      await matchViewportSnapshot();
+      await snapshot();
       done();
     });
   });
@@ -73,10 +73,10 @@ describe('Transition all', () => {
       createText('1234')
     ]);
     BODY.appendChild(container);
-    await matchViewportSnapshot();
+    await snapshot();
     requestAnimationFrame(async () => {
       container.style.top = '100px';
-      await matchViewportSnapshot();
+      await snapshot();
       done();
     });
   });
@@ -92,10 +92,10 @@ describe('Transition all', () => {
       createText('1234')
     ]);
     BODY.appendChild(container);
-    await matchViewportSnapshot();
+    await snapshot();
     requestAnimationFrame(async () => {
       container.style.left = '100px';
-      await matchViewportSnapshot();
+      await snapshot();
       done();
     });
   });
@@ -111,10 +111,10 @@ describe('Transition all', () => {
       createText('1234')
     ]);
     BODY.appendChild(container);
-    await matchViewportSnapshot();
+    await snapshot();
     requestAnimationFrame(async () => {
       container.style.right = '100px';
-      await matchViewportSnapshot();
+      await snapshot();
       done();
     });
   });
@@ -130,10 +130,10 @@ describe('Transition all', () => {
       createText('1234')
     ]);
     BODY.appendChild(container);
-    await matchViewportSnapshot();
+    await snapshot();
     requestAnimationFrame(async () => {
       container.style.bottom = '100px';
-      await matchViewportSnapshot();
+      await snapshot();
       done();
     });
   });
@@ -151,18 +151,18 @@ describe('Transition all', () => {
     ]);
     BODY.appendChild(container);
 
-    await matchViewportSnapshot();
+    await snapshot();
     requestAnimationFrame(() => {
       container.style.width = '200px';
 
       setTimeout(() => {
         container.style.transition = 'height 0.5s ease 0.5s';
         requestAnimationFrame(async () => {
-          await matchViewportSnapshot();
+          await snapshot();
           container.style.height = '200px';
 
           setTimeout(async () => {
-            await matchViewportSnapshot();
+            await snapshot();
             doneFn();
           }, 1200);
         });
@@ -185,11 +185,11 @@ describe('Transition all', () => {
     );
 
     BODY.appendChild(container);
-    await matchViewportSnapshot();
+    await snapshot();
 
     // background color will not change anymore.
     setTimeout(async () => {
-      await matchViewportSnapshot();
+      await snapshot();
       doneFn();
     }, 100);
   });

--- a/integration_tests/specs/css/css-transitions/transform-matrix.ts
+++ b/integration_tests/specs/css/css-transitions/transform-matrix.ts
@@ -15,13 +15,13 @@ describe('Transition transform', () => {
     container1.appendChild(document.createTextNode('DIV 1'));
 
     requestAnimationFrame(async () => {
-      await matchViewportSnapshot();
+      await snapshot();
       setElementStyle(container1, {
         transform: 'matrix(0,1,1,1,10,10)',
       });
       // Wait for animation finished.
       setTimeout(async () => {
-        await matchViewportSnapshot();
+        await snapshot();
         done();
       }, 1100);
     });
@@ -45,12 +45,12 @@ describe('Transition transform', () => {
     container1.appendChild(document.createTextNode('DIV 1'));
 
     requestAnimationFrame(async () => {
-      await matchViewportSnapshot();
+      await snapshot();
       setElementStyle(container1, {
         transform: 'matrix3d(0,1,1,1,10,10,1,0,0,1,1,1,1,1,0)',
       });
       setTimeout(async () => {
-        await matchViewportSnapshot();
+        await snapshot();
         done();
       }, 1100);
     });

--- a/integration_tests/specs/css/css-transitions/transform-origin.ts
+++ b/integration_tests/specs/css/css-transitions/transform-origin.ts
@@ -15,13 +15,13 @@ describe('Transition transform origin', () => {
     container1.appendChild(document.createTextNode('DIV 1'));
 
     requestAnimationFrame(async () => {
-      await matchViewportSnapshot();
+      await snapshot();
       setElementStyle(container1, {
         transform: 'rotateZ(0.6turn)',
         transformOrigin: '10px 10px',
       });
       setTimeout(async () => {
-        await matchViewportSnapshot();
+        await snapshot();
         done();
       }, 1100);
     });
@@ -45,13 +45,13 @@ describe('Transition transform origin', () => {
     container1.appendChild(document.createTextNode('DIV 1'));
 
     requestAnimationFrame(async () => {
-      await matchViewportSnapshot();
+      await snapshot();
       setElementStyle(container1, {
         transform: 'rotateZ(0.6turn)',
         transformOrigin: '80% 80%',
       });
       setTimeout(async () => {
-        await matchViewportSnapshot();
+        await snapshot();
         done();
       }, 1100);
     });
@@ -75,13 +75,13 @@ describe('Transition transform', () => {
     container1.appendChild(document.createTextNode('DIV 1'));
 
     requestAnimationFrame(async () => {
-      await matchViewportSnapshot();
+      await snapshot();
       setElementStyle(container1, {
         transform: 'rotateZ(0.1turn)',
         transformOrigin: 'top left',
       });
       setTimeout(async () => {
-        await matchViewportSnapshot();
+        await snapshot();
         done();
       }, 1100);
     });

--- a/integration_tests/specs/css/css-transitions/transform-rotate.ts
+++ b/integration_tests/specs/css/css-transitions/transform-rotate.ts
@@ -15,12 +15,12 @@ describe('Transition transform', () => {
     container1.appendChild(document.createTextNode('DIV 1'));
 
     requestAnimationFrame(async () => {
-      await matchViewportSnapshot();
+      await snapshot();
       setElementStyle(container1, {
         transform: 'rotateZ(0.6turn)',
       });
       setTimeout(async () => {
-        await matchViewportSnapshot();
+        await snapshot();
         done();
       }, 1100);
     });
@@ -44,12 +44,12 @@ describe('Transition transform', () => {
     container1.appendChild(document.createTextNode('DIV 1'));
 
     requestAnimationFrame(async () => {
-      await matchViewportSnapshot();
+      await snapshot();
       setElementStyle(container1, {
         transform: 'rotate3d(10, 10, 10, 0.6turn)',
       });
       setTimeout(async () => {
-        await matchViewportSnapshot();
+        await snapshot();
         done();
       }, 1100);
     });
@@ -73,12 +73,12 @@ describe('Transition transform', () => {
     container1.appendChild(document.createTextNode('DIV 1'));
 
     requestAnimationFrame(async () => {
-      await matchViewportSnapshot();
+      await snapshot();
       setElementStyle(container1, {
         transform: 'rotateX(0.6turn)',
       });
       setTimeout(async () => {
-        await matchViewportSnapshot();
+        await snapshot();
         done();
       }, 1100);
     });
@@ -102,12 +102,12 @@ describe('Transition transform', () => {
     container1.appendChild(document.createTextNode('DIV 1'));
 
     requestAnimationFrame(async () => {
-      await matchViewportSnapshot();
+      await snapshot();
       setElementStyle(container1, {
         transform: 'rotateY(0.6turn)',
       });
       setTimeout(async () => {
-        await matchViewportSnapshot();
+        await snapshot();
         done();
       }, 1100);
     });

--- a/integration_tests/specs/css/css-transitions/transform-scale.ts
+++ b/integration_tests/specs/css/css-transitions/transform-scale.ts
@@ -15,12 +15,12 @@ describe('Transition transform', () => {
     container1.appendChild(document.createTextNode('DIV 1'));
 
     requestAnimationFrame(async () => {
-      await matchViewportSnapshot();
+      await snapshot();
       setElementStyle(container1, {
         transform: 'scale(2,2)',
       });
       setTimeout(async () => {
-        await matchViewportSnapshot();
+        await snapshot();
         done();
       }, 1100);
     });
@@ -44,12 +44,12 @@ describe('Transition transform', () => {
     container1.appendChild(document.createTextNode('DIV 1'));
 
     requestAnimationFrame(async () => {
-      await matchViewportSnapshot();
+      await snapshot();
       setElementStyle(container1, {
         transform: 'scale3d(2, 2, 2)',
       });
       setTimeout(async () => {
-        await matchViewportSnapshot();
+        await snapshot();
         done();
       }, 1100);
     });
@@ -73,12 +73,12 @@ describe('Transition transform', () => {
     container1.appendChild(document.createTextNode('DIV 1'));
 
     requestAnimationFrame(async () => {
-          await matchViewportSnapshot();
+          await snapshot();
       setElementStyle(container1, {
         transform: 'scaleX(2)',
       });
       setTimeout(async () => {
-        await matchViewportSnapshot();
+        await snapshot();
         done();
       }, 1100);
     });
@@ -102,12 +102,12 @@ describe('Transition transform', () => {
     container1.appendChild(document.createTextNode('DIV 1'));
 
     requestAnimationFrame(async () => {
-      await matchViewportSnapshot();
+      await snapshot();
       setElementStyle(container1, {
         transform: 'scaleY(2)',
       });
       setTimeout(async () => {
-        await matchViewportSnapshot();
+        await snapshot();
         done();
       }, 1100);
     });

--- a/integration_tests/specs/css/css-transitions/transform-skew.ts
+++ b/integration_tests/specs/css/css-transitions/transform-skew.ts
@@ -15,12 +15,12 @@ describe('Transition transform', () => {
     container1.appendChild(document.createTextNode('DIV 1'));
 
     requestAnimationFrame(async () => {
-      await matchViewportSnapshot();
+      await snapshot();
       setElementStyle(container1, {
         transform: 'skew(0.3turn,0.6turn)',
       });
       setTimeout(async () => {
-        await matchViewportSnapshot();
+        await snapshot();
         done();
       }, 1100);
     });
@@ -44,12 +44,12 @@ describe('Transition transform', () => {
     container1.appendChild(document.createTextNode('DIV 1'));
 
     requestAnimationFrame(async () => {
-      await matchViewportSnapshot();
+      await snapshot();
       setElementStyle(container1, {
         transform: 'skewX(0.3turn)',
       });
       setTimeout(async () => {
-        await matchViewportSnapshot();
+        await snapshot();
         done();
       }, 1100);
     });
@@ -73,12 +73,12 @@ describe('Transition transform', () => {
     container1.appendChild(document.createTextNode('DIV 1'));
 
     requestAnimationFrame(async () => {
-      await matchViewportSnapshot();
+      await snapshot();
       setElementStyle(container1, {
         transform: 'skewY(0.3turn)',
       });
       setTimeout(async () => {
-        await matchViewportSnapshot();
+        await snapshot();
         done();
       }, 1100);
     });

--- a/integration_tests/specs/css/css-transitions/transform-translate.ts
+++ b/integration_tests/specs/css/css-transitions/transform-translate.ts
@@ -15,12 +15,12 @@ describe('Transition transform', () => {
     container1.appendChild(document.createTextNode('DIV 1'));
 
     requestAnimationFrame(async () => {
-      await matchViewportSnapshot();
+      await snapshot();
       setElementStyle(container1, {
         transform: 'translate(10px,20px)',
       });
       setTimeout(async () => {
-        await matchViewportSnapshot();
+        await snapshot();
         done();
       }, 1100);
     });
@@ -44,12 +44,12 @@ describe('Transition transform', () => {
     container1.appendChild(document.createTextNode('DIV 1'));
 
     requestAnimationFrame(async () => {
-      await matchViewportSnapshot();
+      await snapshot();
       setElementStyle(container1, {
         transform: 'translate3d(10px, 10px, 20px)',
       });
       setTimeout(async () => {
-        await matchViewportSnapshot();
+        await snapshot();
         done();
       }, 1100);
     });
@@ -73,13 +73,13 @@ describe('Transition transform', () => {
     container1.appendChild(document.createTextNode('DIV 1'));
 
     requestAnimationFrame(async () => {
-      await matchViewportSnapshot();
+      await snapshot();
       setElementStyle(container1, {
         transform: 'translateX(20px)',
       });
     });
 
-    await matchViewportSnapshot(1.1);
+    await snapshot(1.1);
   });
 });
 
@@ -100,12 +100,12 @@ describe('Transition transform', () => {
     container1.appendChild(document.createTextNode('DIV 1'));
 
     requestAnimationFrame(async () => {
-      await matchViewportSnapshot();
+      await snapshot();
       setElementStyle(container1, {
         transform: 'translateY(10px)',
       });
       setTimeout(async () => {
-        await matchViewportSnapshot();
+        await snapshot();
         done();
       }, 1100);
     });
@@ -138,7 +138,7 @@ describe('Multiple transition transform', () => {
     div.appendChild(container1);
 
     requestAnimationFrame(async () => {
-      await matchViewportSnapshot();
+      await snapshot();
       setElementStyle(container1, {
         transform: 'translate3d(-100px, 0vw, 0vw)',
       });
@@ -146,7 +146,7 @@ describe('Multiple transition transform', () => {
         transform: 'translate3d(-100px, 0px, 0px)',
       });
       setTimeout(async () => {
-        await matchViewportSnapshot();
+        await snapshot();
         done();
       }, 1000);
     });

--- a/integration_tests/specs/css/css-transitions/transition-events.ts
+++ b/integration_tests/specs/css/css-transitions/transition-events.ts
@@ -57,12 +57,12 @@ describe('Transition events', () => {
 
     container1.addEventListener('transitionend', async function self() {
       container1.removeEventListener('transitionend', self);
-      await matchViewportSnapshot();
+      await snapshot();
       done();
     });
     requestAnimationFrame(async () => {
       await sleep(0.1);
-      await matchViewportSnapshot();
+      await snapshot();
       setElementStyle(container1, {
         transform: 'translate(10px,20px)',
       });
@@ -95,12 +95,12 @@ describe('Transition events', () => {
 
     function second() {
       container1.removeEventListener('transitionend', second);
-      matchViewportSnapshot().then(done);
+      snapshot().then(done);
     }
 
     container1.addEventListener('transitionend', first);
     requestAnimationFrame(async () => {
-      await matchViewportSnapshot();
+      await snapshot();
       setElementStyle(container1, {
         transform: 'translate(30px,30px)',
       });

--- a/integration_tests/specs/css/css-values/px.ts
+++ b/integration_tests/specs/css/css-values/px.ts
@@ -13,7 +13,7 @@ describe('px', () => {
     );
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('transition', done => {
@@ -41,7 +41,7 @@ describe('px', () => {
 
       // Wait for animation finished.
       setTimeout(async () => {
-        await matchViewportSnapshot();
+        await snapshot();
         done();
       }, 600);
     });

--- a/integration_tests/specs/css/css-values/vmin-vmax.ts
+++ b/integration_tests/specs/css/css-values/vmin-vmax.ts
@@ -8,7 +8,7 @@ describe('vmin-vmax', () => {
     let div = <div style={style} />;
     BODY.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('transition', done => {
@@ -25,7 +25,7 @@ describe('vmin-vmax', () => {
     BODY.appendChild(div);
 
     div.addEventListener('transitionend', async () => {
-      await matchViewportSnapshot();
+      await snapshot();
       done();
     });
 

--- a/integration_tests/specs/css/css-values/vw-vh.ts
+++ b/integration_tests/specs/css/css-values/vw-vh.ts
@@ -8,7 +8,7 @@ describe('vw-vh', () => {
     let div = <div style={style} />;
 
     BODY.appendChild(div);
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('transition', done => {
@@ -26,7 +26,7 @@ describe('vw-vh', () => {
     BODY.appendChild(div);
 
     div.addEventListener('transitionend', async () => {
-      await matchViewportSnapshot();
+      await snapshot();
       done();
     });
 

--- a/integration_tests/specs/css/css-variables/environment.ts
+++ b/integration_tests/specs/css/css-variables/environment.ts
@@ -12,7 +12,7 @@ describe('CSS Environment', () => {
       container.style.background = 'red';
       document.body.appendChild(document.createTextNode('PASS if no red appears.'));
       document.body.appendChild(container);
-      await matchViewportSnapshot();
+      await snapshot();
   });
 
   it('work with safe-area-inset fallback', async () => {
@@ -28,6 +28,6 @@ describe('CSS Environment', () => {
       container.style.background = 'red';
       document.body.appendChild(document.createTextNode('PASS if no red appears.'));
       document.body.appendChild(container);
-      await matchViewportSnapshot();
+      await snapshot();
   });
 });

--- a/integration_tests/specs/css/filter-effects/filter.ts
+++ b/integration_tests/specs/css/filter-effects/filter.ts
@@ -9,7 +9,7 @@ describe('CSS Filter Effects', () => {
     document.body.appendChild(div);
     div.style.filter = 'grayscale(1)';
     await sleep(0.5);
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('blur', async () => {
@@ -22,6 +22,6 @@ describe('CSS Filter Effects', () => {
     document.body.appendChild(div);
     div.style.filter = 'blur(2px)';
     await sleep(0.5);
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/dom/elements/animation-player.ts
+++ b/integration_tests/specs/dom/elements/animation-player.ts
@@ -16,14 +16,14 @@ describe('AnimationPlayer', () => {
 
       // Need to impl onload event.
       await sleep(1);
-      await matchViewportSnapshot();
+      await snapshot();
 
       animationPlayer.play('hands_up');
       // Wait for animation end.
       // Need to impl animation_end event.
       await sleep(1);
 
-      await matchViewportSnapshot();
+      await snapshot();
     });
   });
 });

--- a/integration_tests/specs/dom/elements/br.ts
+++ b/integration_tests/specs/dom/elements/br.ts
@@ -2,6 +2,6 @@ describe('br-element', () => {
   it('basic', async () => {
     const p = <p> Hello World! <br /> 你好，世界！</p>;
     document.body.appendChild(p);
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/dom/elements/canvas/canvas.ts
+++ b/integration_tests/specs/dom/elements/canvas/canvas.ts
@@ -6,7 +6,7 @@ describe('Canvas Tag', () => {
       backgroundColor: 'blue',
     });
     append(BODY, canvas);
-    await matchElementImageSnapshot(canvas);
+    await snapshot(canvas);
   });
 
   it('behavior like inline element', async () => {
@@ -23,6 +23,6 @@ describe('Canvas Tag', () => {
     append(wrapper, canvas);
     append(wrapper, text);
     append(BODY, wrapper);
-    await matchElementImageSnapshot(wrapper);
+    await snapshot(wrapper);
   });
 });

--- a/integration_tests/specs/dom/elements/canvas/context2d.ts
+++ b/integration_tests/specs/dom/elements/canvas/context2d.ts
@@ -25,6 +25,6 @@ describe('Canvas context 2d', () => {
 
     document.body.appendChild(div);
 
-    await expectAsync(canvas.toBlob(1.0)).toMatchImageSnapshot();
+    await expectAsync(canvas.toBlob(1.0)).toMatchSnapshot();
   });
 });

--- a/integration_tests/specs/dom/elements/div.ts
+++ b/integration_tests/specs/dom/elements/div.ts
@@ -7,6 +7,6 @@ describe('Tags div', () => {
 
     document.body.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/dom/elements/iframe.ts
+++ b/integration_tests/specs/dom/elements/iframe.ts
@@ -22,6 +22,6 @@ describe('IframeElement', () => {
     // There are no load event fired at desktop kraken.
     // MOCK async logic.
     await sleep(2);
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/dom/elements/img.ts
+++ b/integration_tests/specs/dom/elements/img.ts
@@ -2,7 +2,7 @@ describe('Tags img', () => {
   it('basic', (done) => {
     const img = document.createElement('img');
     img.addEventListener('load', async () => {
-      await matchElementImageSnapshot(img);
+      await snapshot(img);
       done();
     });
     img.style.width = '60px';
@@ -43,7 +43,7 @@ describe('Tags img', () => {
         );
 
         img.addEventListener('load', async () => {
-          await matchElementImageSnapshot(img);
+          await snapshot(img);
           done();
         });
 
@@ -73,7 +73,7 @@ describe('Tags img', () => {
         );
 
         img.addEventListener('load', async () => {
-          await matchElementImageSnapshot(img);
+          await snapshot(img);
           done();
         });
 
@@ -91,10 +91,10 @@ describe('Tags img', () => {
     expect(src).toBe('assets/rabbit.png');
     // have to wait for asset load?
     await sleep(0.1);
-    await matchViewportSnapshot();
+    await snapshot();
     img.src = 'assets/solidblue.png';
     await sleep(0.1);
-    await matchViewportSnapshot();
+    await snapshot();
     src = img.src;
     expect(src).toBe('assets/solidblue.png');
   });
@@ -104,7 +104,7 @@ describe('Tags img', () => {
     img.onload = async () => {
       expect(img.width).toBe(70);
       expect(img.height).toBe(72);
-      await matchViewportSnapshot();
+      await snapshot();
       done();
     };
     img.src = 'assets/rabbit.png';
@@ -116,16 +116,16 @@ describe('Tags img', () => {
       src: 'assets/rabbit.png'
     }) as HTMLImageElement;
     BODY.appendChild(img);
-    await matchViewportSnapshot(0.2);
+    await snapshot(0.2);
     img.src = 'assets/300x150-green.png';
-    await matchViewportSnapshot(0.2);
+    await snapshot(0.2);
   });
 
   it('support base64 data url', async () => {
     var img = document.createElement('img');
     img.src = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAA8AAAAPCAIAAAC0tAIdAAAACXBIWXMAAA7DAAAOwwHHb6hkAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAgY0hSTQAAeiYAAICEAAD6AAAAgOgAAHUwAADqYAAAOpgAABdwnLpRPAAAACJJREFUKFNjZGD4z0AKAKomHpGgFOQK4g0eVY01rEZCCAIAC+rSL3tdVQUAAAAASUVORK5CYII=';
     document.body.appendChild(img);
-    await matchViewportSnapshot(0.2);
+    await snapshot(0.2);
   });
 
   it('minwidth and minheight of image is 0', async () => {
@@ -135,7 +135,7 @@ describe('Tags img', () => {
     img.style.minHeight = '0';
     img.style.display = 'inline';
     document.body.appendChild(img);
-    await matchViewportSnapshot(0.2);
+    await snapshot(0.2);
   });
 
   it('image size and image natural size', (done) => {
@@ -172,7 +172,7 @@ describe('Tags img', () => {
     document.body.appendChild(img);
 
     img.onload = async () => {
-      await matchElementImageSnapshot(img);
+      await snapshot(img);
       done();
     };
   });

--- a/integration_tests/specs/dom/elements/input.ts
+++ b/integration_tests/specs/dom/elements/input.ts
@@ -6,7 +6,7 @@ describe('Tags input', () => {
     input.setAttribute('value', 'Hello World');
     document.body.appendChild(input);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('with default width', async () => {
@@ -15,7 +15,7 @@ describe('Tags input', () => {
     input.setAttribute('value', 'Hello World Hello World Hello World Hello World');
     document.body.appendChild(input);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('event blur', (done) => {

--- a/integration_tests/specs/dom/elements/p.ts
+++ b/integration_tests/specs/dom/elements/p.ts
@@ -7,6 +7,6 @@ describe('Tags p', () => {
     p.appendChild(document.createTextNode('This is a paragraph.'));
 
     document.body.appendChild(p);
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/dom/elements/pre.ts
+++ b/integration_tests/specs/dom/elements/pre.ts
@@ -10,6 +10,6 @@ line breaks
     `));
 
     document.body.appendChild(pre);
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/dom/elements/span.ts
+++ b/integration_tests/specs/dom/elements/span.ts
@@ -22,6 +22,6 @@ describe('Tags span', () => {
     span2.style.fontFamily = 'georgia';
     document.body.appendChild(span2);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/dom/events/event.ts
+++ b/integration_tests/specs/dom/events/event.ts
@@ -36,7 +36,7 @@ describe('Event', () => {
     wrapper.appendChild(document.createTextNode('Click DIV 2: '));
 
     container2.click();
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('do not trigger click when scrolling', async () => {

--- a/integration_tests/specs/dom/events/scroll.ts
+++ b/integration_tests/specs/dom/events/scroll.ts
@@ -20,7 +20,7 @@ describe('Event scroll', () => {
     function scrollListener(event) {
       if (event.currentTarget.scrollTop === 50) {
         container.removeEventListener('scroll', scrollListener);
-        matchViewportSnapshot().then(() => done());
+        snapshot().then(() => done());
       }
     }
 

--- a/integration_tests/specs/dom/nodes/append-child.tsx
+++ b/integration_tests/specs/dom/nodes/append-child.tsx
@@ -19,7 +19,7 @@ describe('Append child', () => {
     let n1 = <div style={style} />;
     BODY.appendChild(n1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('with orphan textNode', async () => {
@@ -27,7 +27,7 @@ describe('Append child', () => {
     n1 = createText('foobar');
     BODY.appendChild(n1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('with element which has parent and connected', async () => {
@@ -55,7 +55,7 @@ describe('Append child', () => {
     BODY.appendChild(n2);
     n1.appendChild(n2);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('with textNode which has parent and connected', async () => {
@@ -76,7 +76,7 @@ describe('Append child', () => {
     BODY.appendChild(n2);
     n1.appendChild(n2);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('with element which has parent but not connected', async () => {
@@ -102,7 +102,7 @@ describe('Append child', () => {
     );
     BODY.appendChild(n2);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('with textNode which has parent but not connected', async () => {
@@ -121,7 +121,7 @@ describe('Append child', () => {
     );
     BODY.appendChild(n2);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('with connected and not connected children which has parent', async () => {
@@ -168,7 +168,7 @@ describe('Append child', () => {
     BODY.appendChild(n2);
     BODY.appendChild(n4);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   // https://developer.mozilla.org/en-US/docs/Web/API/Node/appendChild

--- a/integration_tests/specs/dom/nodes/clone-node.ts
+++ b/integration_tests/specs/dom/nodes/clone-node.ts
@@ -10,7 +10,7 @@ describe('Clone node', () => {
     const div2 = div.cloneNode(true);
     document.body.appendChild(div2)
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('with a div when deep is false', async () => {
@@ -24,7 +24,7 @@ describe('Clone node', () => {
     const div2 = div.cloneNode(true);
     document.body.appendChild(div2)
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('with Multi-level div nesting when deep is true', async () => {
@@ -52,7 +52,7 @@ describe('Clone node', () => {
     const div2 = div.cloneNode(true);
     document.body.appendChild(div2)
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('with Multi-level div nesting when deep is false', async () => {
@@ -80,7 +80,7 @@ describe('Clone node', () => {
     const div2 = div.cloneNode(false);
     document.body.appendChild(div2)
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('text node', async () => {
@@ -90,7 +90,7 @@ describe('Clone node', () => {
     const text2 = text.cloneNode(true);
     document.body.appendChild(text2);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('element node nested text node', async () => {
@@ -103,7 +103,7 @@ describe('Clone node', () => {
     const div2 = div.cloneNode(true);
     document.body.appendChild(div2);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });
   

--- a/integration_tests/specs/dom/nodes/document.ts
+++ b/integration_tests/specs/dom/nodes/document.ts
@@ -12,7 +12,7 @@ describe('Document api', () => {
     container.appendChild(document.createComment('This is a comment'));
     document.body.appendChild(container);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('documentElement', async () => {
@@ -25,7 +25,7 @@ describe('Document api', () => {
     const text2 = document.createTextNode('documentElement height: ' + documentElementHeight + '\n');
     document.body.appendChild(text2);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('document.all', () => {

--- a/integration_tests/specs/dom/nodes/insert-before.ts
+++ b/integration_tests/specs/dom/nodes/insert-before.ts
@@ -41,7 +41,7 @@ describe('Insert before', () => {
     insertSpan.appendChild(insertText);
     div.insertBefore(insertSpan, span);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('referenceNode is null', async () => {
@@ -56,7 +56,7 @@ describe('Insert before', () => {
     );
     BODY.insertBefore(n1, null);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('with orphan element', async () => {
@@ -81,7 +81,7 @@ describe('Insert before', () => {
     BODY.appendChild(n1);
     BODY.insertBefore(n2, n1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('with element which has parent and connected', async () => {
@@ -109,7 +109,7 @@ describe('Insert before', () => {
     BODY.appendChild(n2);
     n1.insertBefore(n2, null);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('with element which has parent but not connected', async () => {
@@ -136,7 +136,7 @@ describe('Insert before', () => {
     BODY.appendChild(n1);
     BODY.insertBefore(n2, n1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
 });

--- a/integration_tests/specs/dom/nodes/node.ts
+++ b/integration_tests/specs/dom/nodes/node.ts
@@ -35,7 +35,7 @@ describe('Node API', () => {
     const child_3 = document.createTextNode('fourth child');
     el.replaceChild(child_3, child_1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('ChildNode.prototype.remove', () => {
@@ -101,10 +101,10 @@ describe('Node API', () => {
     expect(container.childNodes.length == 3);
     expect(container.textContent).toBe('1234567890');
     BODY.appendChild(container);
-    await matchViewportSnapshot();
+    await snapshot();
     container.textContent = '';
     expect(container.childNodes.length == 1);
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('should work with ownerDocument', () => {

--- a/integration_tests/specs/dom/nodes/offset.ts
+++ b/integration_tests/specs/dom/nodes/offset.ts
@@ -45,6 +45,6 @@ describe('Offset api', () => {
 
     document.body.appendChild(document.createTextNode(str));
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/dom/nodes/remove-child.ts
+++ b/integration_tests/specs/dom/nodes/remove-child.ts
@@ -18,6 +18,6 @@ describe('Remove child', () => {
     document.body.appendChild(block2);
     document.body.removeChild(block1);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/dom/nodes/textNode.ts
+++ b/integration_tests/specs/dom/nodes/textNode.ts
@@ -6,7 +6,7 @@ describe('TextNode', () => {
     document.body.appendChild(div);
     div.appendChild(text);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('should work with text update', async () => {
@@ -18,7 +18,7 @@ describe('TextNode', () => {
 
     text.data = 'after modified';
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('should work with style update of non empty text', async () => {
@@ -35,7 +35,7 @@ describe('TextNode', () => {
     div.style.color = 'blue';
     document.body.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('should work with style update of empty text', async () => {
@@ -52,7 +52,7 @@ describe('TextNode', () => {
     div.style.color = 'blue';
     document.body.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('should work with set textContent', async () => {
@@ -64,7 +64,7 @@ describe('TextNode', () => {
 
     text.textContent = 'after modified';
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('createTextNode should not has height when the text is a empty string', async () => {
@@ -82,7 +82,7 @@ describe('TextNode', () => {
     child2.style.backgroundColor = 'red';
     document.body.appendChild(child2);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 
   it('createTextNode should not has height when the text is a empty string and flex layout', async () => {
@@ -106,6 +106,6 @@ describe('TextNode', () => {
     child2.style.backgroundColor = 'red';
     div.appendChild(child2);
 
-    await matchViewportSnapshot();
+    await snapshot();
   });
 });

--- a/integration_tests/specs/window/scroll.ts
+++ b/integration_tests/specs/window/scroll.ts
@@ -8,11 +8,11 @@ describe('window scroll API', () => {
     div.appendChild(text);
     document.body.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
 
     requestAnimationFrame(async () => {
       window.scrollTo(0, 55);
-      await matchViewportSnapshot();
+      await snapshot();
       expect(window.scrollX).toBe(0);
       expect(window.scrollY).toBe(55);
       doneFn();
@@ -28,11 +28,11 @@ describe('window scroll API', () => {
     div.appendChild(text);
     document.body.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
 
     requestAnimationFrame(async () => {
       window.scroll(0, 40);
-      await matchViewportSnapshot();
+      await snapshot();
 
       expect(window.scrollX).toBe(0);
       expect(window.scrollY).toBe(40);
@@ -49,12 +49,12 @@ describe('window scroll API', () => {
     div.appendChild(text);
     document.body.appendChild(div);
 
-    await matchViewportSnapshot();
+    await snapshot();
 
     requestAnimationFrame(async () => {
       window.scroll(0, 5);
       window.scrollBy(0, 20);
-      await matchViewportSnapshot();
+      await snapshot();
 
       expect(window.scrollX).toBe(0);
       expect(window.scrollY).toBe(25);


### PR DESCRIPTION
1. toMatchImageSnapshot -> toMatchSnapshot,  未来有可能基于 RenderObject 结构树的文本对比
2. matchElementSnapshot/matchViewportSnapshot -> snapshot, 简化命名，统一到一个方法，通过参数来区别