### PR TITLE
fix: Fix the crash caused by navigation in dart

### DIFF
--- a/kraken/lib/src/module/navigation.dart
+++ b/kraken/lib/src/module/navigation.dart
@@ -39,8 +39,9 @@ class NavigationModule extends BaseModule {
   @override
   String invoke(String method, dynamic params, callback) {
     if (method == 'goTo') {
-      String url = params[0];
-      String sourceUrl = moduleManager.controller.bundleURL;
+      assert(params is String, 'URL must be string.');
+      String url = params;
+      String sourceUrl = moduleManager.controller.bundlePath ?? moduleManager.controller.bundleURL;
 
       Uri targetUri = Uri.parse(url);
       Uri sourceUri = Uri.parse(sourceUrl);


### PR DESCRIPTION
1. 修复 url 取参错误导致 location.href 跳转闪退，并加类型判断
2. 兼容当前路由是本地注册的情况，否则取不到 sourceUrl 会导致报错

已验证 location.href 以下四种场景的跳转：
1. url → assets
2. url → url
3. assets → url
4. assets → assets