### PR TITLE
chore: update device_info, fix #260

### DIFF
--- a/kraken/pubspec.yaml
+++ b/kraken/pubspec.yaml
@@ -15,7 +15,7 @@ dependencies:
   ffi: ^0.1.3
   connectivity: ^0.4.8
   shared_preferences: ^0.5.6
-  device_info: ^0.4.1 # Only support iOS and Android.
+  device_info: ^1.0.0 # Only support iOS and Android.
   path_provider: ^1.1.0
   dio: ^3.0.9
   vector_math: ^2.0.8


### PR DESCRIPTION
现象：device_info 目前版本太低，导致 kraken 集成到业务侧会遇到依赖冲突。

解决方案：升级 device_info 至 1.0.0。

注意：已验证接口上 1.0.0 与目前 0.4.1 是对齐的，直接升级即可。暂无法升级到 2.0.0，因其需要 Flutter 2.x，而 Kraken 对于 Flutter 2.x 还未完全适配。