### PR TITLE
feat: add scripts for debuggable jsc.

### DIFF
--- a/bridge/CMakeLists.txt
+++ b/bridge/CMakeLists.txt
@@ -74,7 +74,12 @@ if ($ENV{KRAKEN_JS_ENGINE} MATCHES "jsc")
     list(APPEND BRIDGE_LINK_LIBS
             JavaScriptCore
             )
-  else ()
+  elseif (EXISTS ${DEBUG_JSC_ENGINE})
+    list(APPEND BRIDGE_INCLUDE ${DEBUG_JSC_ENGINE}/Headers)
+    add_library(JavaScriptCore SHARED IMPORTED)
+    set_target_properties(JavaScriptCore PROPERTIES IMPORTED_LOCATION ${DEBUG_JSC_ENGINE}/JavaScriptCore)
+    list(APPEND BRIDGE_LINK_LIBS JavaScriptCore)
+  else()
     add_compile_options(-DIS_APPLE=1)
     list(APPEND BRIDGE_LINK_LIBS "-framework JavaScriptCore")
   endif ()


### PR DESCRIPTION
添加一些必要的脚本，用来支持和一个 debug 版本进行编译构建。

除了这些脚本之外，能够运行之前还需要以下三个步骤 （macOS 系统）：

1. 去这里下载 debug 版本的 jsc  https://github.com/openkraken/jsc/releases
2. 在 pubspec.yaml 里面添加 jsc 的依赖 （通常在 `~/.pub-cache/hosted/` 目录下）
3. 将下载的 debug 版本的 jsc 打包成 zip，然后替换掉 `jsc/macos` 中的 JavaScriptCore.framework.zip
4. 使用 `node scripts/build_darwin_dylib.js --built-with-debug-jsc` 重新构建 bridge
5. flutter run
