### PR TITLE
fix: fix kraken.methodChannel.setMethodCallHandler did't get called before kraken.invokeMethod called.

### DIFF
--- a/integration_tests/specs/method-channel/method-channel.ts
+++ b/integration_tests/specs/method-channel/method-channel.ts
@@ -1,4 +1,14 @@
 describe('MethodChannel', () => {
+  it('setMethodCallHandler multi params', async (done) => {
+    kraken.methodChannel.setMethodCallHandler((method: string, args: any[]) => {
+      expect(method).toBe('helloworld');
+      expect(args).toEqual(['abc', 1234, null, /* undefined will be converted to */ null, [], true, false, {name: 1}]);
+      done();
+    });
+    let result = await kraken.methodChannel.invokeMethod('helloworld', 'abc', 1234, null, undefined, [], true, false, {name: 1});
+    expect(result).toBe('method: helloworld');
+  });
+
   it('invokeMethod', async () => {
     let result = await kraken.methodChannel.invokeMethod('helloworld', 'abc');
     // TEST App will return method string
@@ -12,16 +22,6 @@ describe('MethodChannel', () => {
       done();
     });
     let result = await kraken.methodChannel.invokeMethod('helloworld', 'abc');
-    expect(result).toBe('method: helloworld');
-  });
-
-  it('setMethodCallHandler multi params', async (done) => {
-    kraken.methodChannel.setMethodCallHandler((method: string, args: any[]) => {
-      expect(method).toBe('helloworld');
-      expect(args).toEqual(['abc', 1234, null, /* undefined will be converted to */ null, [], true, false, {name: 1}]);
-      done();
-    });
-    let result = await kraken.methodChannel.invokeMethod('helloworld', 'abc', 1234, null, undefined, [], true, false, {name: 1});
     expect(result).toBe('method: helloworld');
   });
 

--- a/kraken/lib/src/launcher/controller.dart
+++ b/kraken/lib/src/launcher/controller.dart
@@ -471,7 +471,7 @@ class KrakenController {
     }
 
     _methodChannel = methodChannel;
-    setJSMethodCallCallback(this);
+    KrakenMethodChannel.setJSMethodCallCallback(this);
 
     _view = KrakenViewController(viewportWidth, viewportHeight,
         background: background,

--- a/kraken/lib/src/launcher/controller.dart
+++ b/kraken/lib/src/launcher/controller.dart
@@ -471,6 +471,8 @@ class KrakenController {
     }
 
     _methodChannel = methodChannel;
+    setJSMethodCallCallback(this);
+
     _view = KrakenViewController(viewportWidth, viewportHeight,
         background: background,
         showPerformanceOverlay: showPerformanceOverlay,

--- a/kraken/lib/src/module/method_channel.dart
+++ b/kraken/lib/src/module/method_channel.dart
@@ -15,15 +15,12 @@ Future<dynamic> _invokeMethodFromJavaScript(KrakenController controller, String 
   return controller.methodChannel._invokeMethodFromJavaScript(method, args);
 }
 
+const METHOD_CHANNEL_NAME = 'MethodChannel';
+
 class MethodChannelModule extends BaseModule {
   @override
-  String get name => 'MethodChannel';
-  MethodChannelModule(ModuleManager moduleManager) : super(moduleManager) {
-    if (moduleManager == null) return;
-    moduleManager.controller.methodChannel._onJSMethodCall = (String method, dynamic arguments) async {
-      moduleManager.emitModuleEvent(name, data: [method, arguments]);
-    };
-  }
+  String get name => METHOD_CHANNEL_NAME;
+  MethodChannelModule(ModuleManager moduleManager) : super(moduleManager);
 
   @override
   void dispose() {}
@@ -39,6 +36,14 @@ class MethodChannelModule extends BaseModule {
     }
     return '';
   }
+}
+
+void setJSMethodCallCallback(KrakenController controller) {
+  if (controller.methodChannel == null) return;
+
+  controller.methodChannel._onJSMethodCall = (String method, dynamic arguments) async {
+    controller.module.moduleManager.emitModuleEvent(METHOD_CHANNEL_NAME, data: [method, arguments]);
+  };
 }
 
 class KrakenMethodChannel {

--- a/kraken/lib/src/module/method_channel.dart
+++ b/kraken/lib/src/module/method_channel.dart
@@ -38,14 +38,6 @@ class MethodChannelModule extends BaseModule {
   }
 }
 
-void setJSMethodCallCallback(KrakenController controller) {
-  if (controller.methodChannel == null) return;
-
-  controller.methodChannel._onJSMethodCall = (String method, dynamic arguments) async {
-    controller.module.moduleManager.emitModuleEvent(METHOD_CHANNEL_NAME, data: [method, arguments]);
-  };
-}
-
 class KrakenMethodChannel {
   MethodCallCallback _onJSMethodCallCallback;
 
@@ -55,6 +47,14 @@ class KrakenMethodChannel {
   }
 
   Future<dynamic> _invokeMethodFromJavaScript(String method, List arguments) async {}
+
+  static void setJSMethodCallCallback(KrakenController controller) {
+    if (controller.methodChannel == null) return;
+
+    controller.methodChannel._onJSMethodCall = (String method, dynamic arguments) async {
+      controller.module.moduleManager.emitModuleEvent(METHOD_CHANNEL_NAME, data: [method, arguments]);
+    };
+  }
 }
 
 class KrakenJavaScriptChannel extends KrakenMethodChannel {


### PR DESCRIPTION
Fixed #287

在之前的实现中，由于 Dart 向 JS 侧发送消息的回调函数会在 MethodChannel module 初始化的时候绑定，而 module 的设计是只有调用方法的时候才进行初始化，这就导致了在 MethodChannelModule 在初始化之前，都无法调用 JS 侧的方法。

将回调函数的绑定移动到 KrakenController 初始化阶段即可解决这个问题。