### PR TITLE
fix: remove unnecessary flushUICommand

### DIFF
--- a/bridge/bindings/jsc/DOM/element.cc
+++ b/bridge/bindings/jsc/DOM/element.cc
@@ -404,8 +404,6 @@ JSValueRef JSElement::setAttribute(JSContextRef ctx, JSObjectRef function, JSObj
   std::string &&name = JSStringToStdString(nameStringRef);
   std::transform(name.begin(), name.end(), name.begin(), ::tolower);
 
-  getDartMethod()->flushUICommand();
-
   auto elementInstance = reinterpret_cast<ElementInstance *>(JSObjectGetPrivate(thisObject));
 
   JSStringRetain(valueStringRef);

--- a/bridge/bindings/jsc/DOM/elements/input_element.cc
+++ b/bridge/bindings/jsc/DOM/elements/input_element.cc
@@ -75,14 +75,14 @@ JSValueRef JSInputElement::InputElementInstance::getProperty(std::string &name, 
   };
 
   if (propertyMap.count(name) > 0) {
-    getDartMethod()->flushUICommand();
-
     auto property = propertyMap[name];
     switch (property) {
     case InputElementProperty::width: {
+      getDartMethod()->flushUICommand();
       return JSValueMakeNumber(_hostClass->ctx, nativeInputElement->getInputWidth(nativeInputElement));
     }
     case InputElementProperty::height: {
+      getDartMethod()->flushUICommand();
       return JSValueMakeNumber(_hostClass->ctx, nativeInputElement->getInputHeight(nativeInputElement));
     }
     default: {


### PR DESCRIPTION
Kraken 中很多代码针对需要 flushUICommand 的场景，都已经做了特殊处理，因此不需要在一些通用的链路添加这个调用，会影响通道的传输性能