### PR TITLE
fix: fix bridge with getStringProperty on InputElement.

### DIFF
--- a/bridge/bindings/jsc/DOM/element.cc
+++ b/bridge/bindings/jsc/DOM/element.cc
@@ -765,6 +765,7 @@ BoundingClientRect::BoundingClientRect(JSContext *context, NativeBoundingClientR
   : HostObject(context, "BoundingClientRect"), nativeBoundingClientRect(boundingClientRect) {}
 
 JSValueRef ElementInstance::getStringValueProperty(std::string &name) {
+  getDartMethod()->flushUICommand();
   JSStringRef stringRef = JSStringCreateWithUTF8CString(name.c_str());
   NativeString *nativeString = stringRefToNativeString(stringRef);
   NativeString *returnedString = nativeElement->getStringValueProperty(nativeElement, nativeString);

--- a/integration_tests/specs/dom/nodes/element.ts
+++ b/integration_tests/specs/dom/nodes/element.ts
@@ -57,4 +57,10 @@ describe('DOM Element API', () => {
     expect(container.children[0]).toBe(a);
     expect(container.children[1]).toBe(b);
   });
+
+  it('should work with string value property', () => {
+    let input = document.createElement('input');
+    input.value = 'helloworld';
+    expect(input.value).toBe('helloworld');
+  });
 });


### PR DESCRIPTION
读取 Element 属性之前，需要先 flushUICommand 创建 Element。

这是这个性能优化引发的一个 Bug，https://github.com/openkraken/kraken/pulls?q=is%3Apr+is%3Aclosed

经检查，其他类似的情况都添加了 flushUICommand 的调用