### PR TITLE
fix: should protect StyleDeclaration and attribute valueRef.

### DIFF
--- a/bridge/bindings/jsc/DOM/element.cc
+++ b/bridge/bindings/jsc/DOM/element.cc
@@ -71,6 +71,8 @@ JSValueRef JSElementAttributes::getAttribute(std::string &name) {
 void JSElementAttributes::setAttribute(std::string &name, JSValueRef value) {
   bool numberIndex = isNumberIndex(name);
 
+  JSValueProtect(ctx, value);
+
   if (numberIndex) {
     int64_t index = std::stoi(name);
 
@@ -95,7 +97,7 @@ bool JSElementAttributes::hasAttribute(std::string &name) {
 
 void JSElementAttributes::removeAttribute(std::string &name) {
   JSValueRef value = m_attributes[name];
-
+  JSValueUnprotect(ctx, value);
   auto index = std::find(v_attributes.begin(), v_attributes.end(), value);
   v_attributes.erase(index);
 

--- a/bridge/bindings/jsc/DOM/style_declaration.cc
+++ b/bridge/bindings/jsc/DOM/style_declaration.cc
@@ -116,6 +116,8 @@ bool StyleDeclarationInstance::internalSetProperty(std::string &name, JSValueRef
   }
 
   name = parseJavaScriptCSSPropertyName(name);
+
+  JSValueProtect(ctx, value);
   properties[name] = value;
 
   NativeString args_01{};
@@ -134,6 +136,8 @@ void StyleDeclarationInstance::internalRemoveProperty(std::string &name, JSValue
     return;
   }
 
+  JSValueRef value = properties[name];
+  JSValueUnprotect(ctx, value);
   properties.erase(name);
 
   NativeString args_01{};


### PR DESCRIPTION
存储在 StyleDeclaration 和 ElementAttributes 中的值需要保留引用，以免被 GC 回收导致 bad access。

