### PR TITLE
chore: fixed ndk version.

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ By contributing to Kraken, you agree that your contributions will be licensed un
     * [Flutter](https://flutter.dev/docs/get-started/install) version in the `kraken/pubspec.yaml`
     * [CMake](https://cmake.org/) v3.2.0 or later
     * [Xcode](https://developer.apple.com/xcode/) (10.12) or later (Running on macOS or iOS)
-    * [Android NDK](https://developer.android.com/studio/projects/install-ndk) version `20.0.5594570` or later (Running on Android)
+    * [Android NDK](https://developer.android.com/studio/projects/install-ndk) version `21.4.7075529` (Running on Android)
 
 1. Install
 

--- a/scripts/tasks.js
+++ b/scripts/tasks.js
@@ -420,15 +420,10 @@ task('build-android-kraken-lib', (done) => {
   }
 
   const ndkDir = path.join(androidHome, 'ndk');
-  let installedNDK = fs.readdirSync(ndkDir).filter(d => d[0] != '.');
-  if (installedNDK.length == 0) {
-    throw new Error('Android NDK not Found. Please install one');
-  }
+  const ndkVersion = '21.4.7075529';
 
-  const ndkVersion = installedNDK.slice(-1)[0];
-
-  if (parseInt(ndkVersion.substr(0, 2)) < 20) {
-    throw new Error('Android NDK version must at least >= 20');
+  if (!fs.existsSync(path.join(ndkDir, ndkVersion))) {
+    throw new Error('Android NDK version (21.4.7075529) not installed.');
   }
 
   const archs = ['arm64-v8a', 'armeabi-v7a'];


### PR DESCRIPTION
社区反馈 android 版本的 bridge 无法构建， 使用 21.4.7075529 版本的 NDK 可以正常进行构建。