### PR TITLE
:ambulance: hotfix: solve dart analysis problems.

### DIFF
--- a/integration_tests/lib/bridge/from_native.dart
+++ b/integration_tests/lib/bridge/from_native.dart
@@ -122,10 +122,6 @@ final Pointer<NativeFunction<Native_SimulatePointer>> _nativeSimulatePointer = P
 
 void _simulateKeyPress(Pointer<NativeString> nativeChars) {
   String chars = nativeStringToString(nativeChars);
-  if (chars == null) {
-    print('Warning: simulateKeyPress chars is null.');
-    return;
-  }
   if (InputElement.focusInputElement != null) {
     InputElement current = InputElement.focusInputElement!;
     TextEditingValue currentValue = current.textSelectionDelegate.textEditingValue;

--- a/sdk/pubspec.yaml
+++ b/sdk/pubspec.yaml
@@ -8,12 +8,15 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  kraken:
-    path: ../kraken
+  kraken: ^0.8.0
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
+
+dependency_overrides:
+  kraken:
+    path: ../kraken
 
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec


### PR DESCRIPTION
1. chars 非空, 不需要再判断了
2. sdk 的 pubspec.yml 有一个 dart analysis 的规则 lint, 绕一下