### PR TITLE
fix: allocate new context error

### DIFF
--- a/bridge/kraken_bridge.cc
+++ b/bridge/kraken_bridge.cc
@@ -126,7 +126,7 @@ int32_t allocateNewContext(int32_t targetContextId) {
                                                 .c_str());
   auto context = new kraken::JSBridge(targetContextId, printError);
   contextPool[targetContextId] = context;
-  return poolIndex;
+  return targetContextId;
 }
 
 void *getJSContext(int32_t contextId) {


### PR DESCRIPTION
修复创建JSBridge时返回错误的contextId的问题