### PR TITLE
fix: correct context pool index

### DIFF
--- a/bridge/kraken_bridge.cc
+++ b/bridge/kraken_bridge.cc
@@ -114,7 +114,7 @@ void disposeContext(int32_t contextId) {
 
 int32_t allocateNewContext(int32_t targetContextId) {
   if (targetContextId == -1) {
-    targetContextId = poolIndex++;
+    targetContextId = ++poolIndex;
   }
 
   if (targetContextId >= maxPoolSize) {


### PR DESCRIPTION
修复一个问题：
1.JSContext被覆盖，contextPool[0]被重复赋值。
复现步骤：首次启动，打开一个kraken页面，contextPool[0]会被赋值，在当前kraken页面再打开一个kraken页面，此时contextPool[0]又会被赋一次值。