### PR TITLE
fix: 修复野指针可能导致的不可预知问题

### DIFF
--- a/bridge/kraken_bridge.cc
+++ b/bridge/kraken_bridge.cc
@@ -65,7 +65,7 @@ void printError(int32_t contextId, const char* errmsg) {
 namespace {
 
 void disposeAllBridge() {
-  for (int i = 0; i <= poolIndex; i++) {
+  for (int i = 0; i <= poolIndex && i < maxPoolSize; i++) {
     disposeContext(i);
   }
   poolIndex = 0;


### PR DESCRIPTION
disposeAllBridge方法里面使用的小于等于poolIndex，而poolIndex可能会大于maxPoolSize。
复现步骤：连续打开关闭kraken页面，使得poolIndex大于等于maxPoolSize，然后使用热重载或者销毁FlutterEngine再启动，再次打开kraken页面时有可能会crash。