### PR TITLE
fix: add exception report when viewportSize is 0

### DIFF
--- a/kraken/lib/widget.dart
+++ b/kraken/lib/widget.dart
@@ -152,6 +152,11 @@ class _KrakenRenderObjectWidget extends SingleChildRenderObjectWidget {
 
     double viewportWidth = _krakenWidget.viewportWidth ?? window.physicalSize.width / window.devicePixelRatio;
     double viewportHeight = _krakenWidget.viewportHeight ?? window.physicalSize.height / window.devicePixelRatio;
+    
+    if (viewportWidth == 0.0 && viewportHeight == 0.0) {
+      throw FlutterError('''Can\'t get viewportSize from window. Please set viewportWidth and viewportHeight manually.
+This situation often happened when you trying creating kraken when FlutterView not initialized.''');
+    };
 
     KrakenController controller = KrakenController(shortHash(_krakenWidget.hashCode), viewportWidth, viewportHeight,
       background: _krakenWidget.background,


### PR DESCRIPTION
Fixed #485 

提前预热 FlutterEngine 而没有创建 FlutterViewController 会导致 Kraken 读取到的 window.physicalSize 为 0， 从而无法正常渲染页面。

对于这种情况，最佳的方式就是交给用户自行处理，让用户在 Native 侧获取尺寸并传递给 kraken。

> Kraken 可以监听 window.onMetricsChanged 回调来自动进行渲染 resize，但是这样并不高效，而且 FlutterView 在进行手势动画的过程中，iOS 会修改 FlutterView 的尺寸，从而触发大量 window.onMetricsChanged 调用。
> 所以让用户自己在 native 提前获取尺寸才是最好的方式