### PR TITLE
fix: remove fit

### DIFF
--- a/integration_tests/specs/css/css-values/rem.ts
+++ b/integration_tests/specs/css/css-values/rem.ts
@@ -1,5 +1,5 @@
 describe("rem", () => {
-  fit("should works with font size of html", async () => {
+  it("should works with font size of html", async (done) => {
     let div;
     let div2;
     let div3;

--- a/integration_tests/specs/css/css-values/rem.ts
+++ b/integration_tests/specs/css/css-values/rem.ts
@@ -1,5 +1,5 @@
 describe("rem", () => {
-  it("should works with font size of html", async (done) => {
+  it("should works with font size of html", async () => {
     let div;
     let div2;
     let div3;

--- a/kraken/lib/src/dom/element.dart
+++ b/kraken/lib/src/dom/element.dart
@@ -214,7 +214,6 @@ class Element extends Node
 
   RenderObject _beforeRendererAttach() {
     willAttachRenderer();
-    style.applyTargetProperties();
     return renderer!;
   }
 

--- a/kraken/lib/src/dom/elements/canvas/canvas.dart
+++ b/kraken/lib/src/dom/elements/canvas/canvas.dart
@@ -80,6 +80,8 @@ class CanvasElement extends Element {
     painter = CanvasPainter(repaint: repaintNotifier);
   }
 
+  late CanvasRenderingContext2D context2d;
+
   @override
   void willAttachRenderer() {
     super.willAttachRenderer();
@@ -90,6 +92,16 @@ class CanvasElement extends Element {
 
     addChild(renderCustomPaint!);
     style.addStyleChangeListener(_styleChangedListener);
+  }
+
+  @override
+  void didAttachRenderer() {
+    super.didAttachRenderer();
+    double? rootFontSize = renderBoxModel!.elementDelegate.getRootElementFontSize();
+    double? fontSize = renderBoxModel!.renderStyle.fontSize;
+    context2d.viewportSize = viewportSize;
+    context2d.rootFontSize = rootFontSize;
+    context2d.fontSize = fontSize;
   }
 
   @override
@@ -105,9 +117,8 @@ class CanvasElement extends Element {
     switch (contextId) {
       case '2d':
         if (painter.context == null) {
-          CanvasRenderingContext2D context2d = CanvasRenderingContext2D();
+          context2d = CanvasRenderingContext2D();
           context2d.canvas = this;
-          context2d.renderStyle = renderBoxModel!.renderStyle;
           painter.context = context2d;
         }
         return painter.context!;

--- a/kraken/lib/src/dom/elements/canvas/canvas.dart
+++ b/kraken/lib/src/dom/elements/canvas/canvas.dart
@@ -80,7 +80,8 @@ class CanvasElement extends Element {
     painter = CanvasPainter(repaint: repaintNotifier);
   }
 
-  late CanvasRenderingContext2D context2d;
+  // Currently only 2d rendering context for canvas is supported.
+  CanvasRenderingContext2D? context2d;
 
   @override
   void willAttachRenderer() {
@@ -99,9 +100,12 @@ class CanvasElement extends Element {
     super.didAttachRenderer();
     double? rootFontSize = renderBoxModel!.elementDelegate.getRootElementFontSize();
     double? fontSize = renderBoxModel!.renderStyle.fontSize;
-    context2d.viewportSize = viewportSize;
-    context2d.rootFontSize = rootFontSize;
-    context2d.fontSize = fontSize;
+    if (context2d == null) {
+      context2d = CanvasRenderingContext2D();
+    }
+    context2d!.viewportSize = viewportSize;
+    context2d!.rootFontSize = rootFontSize;
+    context2d!.fontSize = fontSize;
   }
 
   @override
@@ -117,8 +121,10 @@ class CanvasElement extends Element {
     switch (contextId) {
       case '2d':
         if (painter.context == null) {
-          context2d = CanvasRenderingContext2D();
-          context2d.canvas = this;
+          if (context2d == null) {
+            context2d = CanvasRenderingContext2D();
+          }
+          context2d!.canvas = this;
           painter.context = context2d;
         }
         return painter.context!;

--- a/kraken/lib/src/dom/elements/canvas/canvas_context_2d.dart
+++ b/kraken/lib/src/dom/elements/canvas/canvas_context_2d.dart
@@ -364,7 +364,9 @@ class CanvasRenderingContext2D {
 
   CanvasRenderingContext2DSettings getContextAttributes() => _settings;
 
-  late RenderStyle renderStyle;
+  late Size viewportSize;
+  late double? fontSize;
+  late double? rootFontSize;
   late CanvasElement canvas;
   // HACK: We need record the current matrix state because flutter canvas not export resetTransform now.
   // https://github.com/flutter/engine/pull/25449
@@ -870,20 +872,17 @@ class CanvasRenderingContext2D {
     if (_fontProperties.isEmpty) {
       _parseFont(_DEFAULT_FONT);
     }
-    Size viewportSize = renderStyle.viewportSize;
-    RenderBoxModel renderBoxModel = renderStyle.renderBoxModel!;
-    double rootFontSize = renderBoxModel.elementDelegate.getRootElementFontSize();
-    double? fontSize = CSSLength.toDisplayPortValue(
+    double? _fontSize = CSSLength.toDisplayPortValue(
       _fontProperties[FONT_SIZE] ?? '10px',
       viewportSize: viewportSize,
       rootFontSize: rootFontSize,
-      fontSize: renderStyle.fontSize
+      fontSize: fontSize
     );
     var fontFamilyFallback = CSSText.parseFontFamilyFallback(_fontProperties[FONT_FAMILY] ?? 'sans-serif');
     FontWeight fontWeight = CSSText.parseFontWeight(_fontProperties[FONT_WEIGHT]);
     if (shouldStrokeText) {
       return TextStyle(
-          fontSize: fontSize,
+          fontSize: _fontSize,
           fontFamilyFallback: fontFamilyFallback,
           foreground: Paint()
             ..strokeJoin = lineJoin
@@ -897,7 +896,7 @@ class CanvasRenderingContext2D {
     } else {
       return TextStyle(
         color: color,
-        fontSize: fontSize,
+        fontSize: _fontSize,
         fontFamilyFallback: fontFamilyFallback,
         fontWeight: fontWeight,
       );

--- a/kraken/lib/src/dom/elements/canvas/canvas_context_2d.dart
+++ b/kraken/lib/src/dom/elements/canvas/canvas_context_2d.dart
@@ -13,7 +13,6 @@ import 'package:flutter/painting.dart';
 import 'package:kraken/bridge.dart';
 import 'package:kraken/css.dart';
 import 'package:kraken/dom.dart';
-import 'package:kraken/rendering.dart';
 import 'package:vector_math/vector_math_64.dart';
 import 'canvas_context.dart';
 import 'canvas_path_2d.dart';


### PR DESCRIPTION
* 修复 https://github.com/openkraken/kraken/pull/475 PR 中 fit 未移除导致未发现的测试失败的问题：
    - 去除 test 中 fit。
    - 在 renderer before attach 时不需要 apply style properties。
    - canvas.dart 中取 fontSize 与 rootFontSize 时由于 renderBoxModel 未创建导致测试用例 crash，取将取 fontSize 与 rootFontSize 时机移到 didAttachRenderer。