### PR TITLE
fix. gradient check wrong when has more than one right bracket

### DIFF
--- a/integration_tests/specs/css/css-backgrounds/linear-gradient.ts
+++ b/integration_tests/specs/css/css-backgrounds/linear-gradient.ts
@@ -12,6 +12,19 @@ describe('Background linear-gradient', () => {
     await snapshot(div1);
   });
 
+  it('linear-gradient with many right brackets', async () => {
+    var div1 = document.createElement('div');
+    Object.assign(div1.style, {
+      width: '200px',
+      height: '100px',
+      backgroundImage: 'linear-gradient(to right, rgba(35, 35, 35, 0.8), rgba(35, 35, 35, 0.1))'
+    });
+
+    append(BODY, div1);
+    await snapshot(div1);
+  });
+
+
   it('linear-gradient and remove', async (done) => {
     var div1 = document.createElement('div');
     Object.assign(div1.style, {

--- a/integration_tests/specs/css/css-images/linear-gradient.ts
+++ b/integration_tests/specs/css/css-images/linear-gradient.ts
@@ -30,6 +30,23 @@ describe('linear-gradient', () => {
 
     await snapshot();
   });
+
+  it('3', async () => {
+    let gradient;
+    gradient = createElement('div', {
+      id: 'gradient',
+      style: {
+        width: '400px',
+        height: '300px',
+        'background-image': 'linear-gradient(to right, rgba(35, 35, 35, 0.8), rgba(35, 35, 35, 0.1))',
+        'box-sizing': 'border-box',
+      },
+    });
+    BODY.appendChild(gradient);
+
+    await snapshot();
+  });
+
   it('ref', async () => {
     let gradient;
     gradient = createElement('div', {

--- a/integration_tests/specs/css/css-images/linear-gradient.ts
+++ b/integration_tests/specs/css/css-images/linear-gradient.ts
@@ -31,7 +31,7 @@ describe('linear-gradient', () => {
     await snapshot();
   });
 
-  it('3 linear-gradient with many right brackets', async () => {
+  it('linear-gradient with many right brackets', async () => {
     let gradient;
     gradient = createElement('div', {
       id: 'gradient',

--- a/integration_tests/specs/css/css-images/linear-gradient.ts
+++ b/integration_tests/specs/css/css-images/linear-gradient.ts
@@ -31,7 +31,7 @@ describe('linear-gradient', () => {
     await snapshot();
   });
 
-  it('3', async () => {
+  it('3 linear-gradient with many right brackets', async () => {
     let gradient;
     gradient = createElement('div', {
       id: 'gradient',

--- a/kraken/lib/src/css/background.dart
+++ b/kraken/lib/src/css/background.dart
@@ -50,7 +50,7 @@ class CSSBackground {
   }
 
   static bool isValidBackgroundImageValue(String value) {
-    return (value.indexOf(')') == value.length - 1) &&
+    return (value.lastIndexOf(')') == value.length - 1) &&
         (value.startsWith('url(') ||
         value.startsWith('linear-gradient(') ||
         value.startsWith('repeating-linear-gradient(') ||
@@ -153,7 +153,7 @@ class CSSBackground {
       Size viewportSize = renderStyle.viewportSize;
       double rootFontSize = renderBoxModel.elementDelegate.getRootElementFontSize();
       double fontSize = renderStyle.fontSize;
-      
+
       switch (method.name) {
         case 'linear-gradient':
         case 'repeating-linear-gradient':
@@ -395,7 +395,7 @@ class CSSBackground {
           Size viewportSize = renderStyle.viewportSize;
           double rootFontSize = renderBoxModel.elementDelegate.getRootElementFontSize();
           double fontSize = renderStyle.fontSize;
-          
+
           for (int i = 1; i < strings.length; i++) {
             if (CSSPercentage.isPercentage(strings[i])) {
               stop = CSSPercentage.parsePercentage(strings[i]);


### PR DESCRIPTION
Closes #511 

原因：针对渐变校验计算规则错误，对于有多个右括号的校验无法命中，导致渐变无法渲染，示例
linear-gradient(to right, rgba(35, 35, 35, 0.8), rgba(35, 35, 35, 0.1))
修复：改为校验最后一个右括号作为完整校验

![image](https://user-images.githubusercontent.com/5905365/126162196-6879e3ca-a3fc-40f9-bbeb-5b5efddb7d06.png)

