### PR TITLE
Bridge 支持 Flutter 多 Engine 实例

### DIFF
--- a/bridge/bindings/jsc/DOM/document.cc
+++ b/bridge/bindings/jsc/DOM/document.cc
@@ -263,7 +263,7 @@ DocumentInstance::DocumentInstance(JSDocument *document)
                       documentElement->object, kJSPropertyAttributeReadOnly, nullptr);
 
   instanceMap[document->context] = this;
-  getDartMethod()->initDocument(contextId, nativeDocument);
+  getDartMethod(document->context->getOwner())->initDocument(contextId, nativeDocument);
 }
 
 JSValueRef DocumentInstance::getProperty(std::string &name, JSValueRef *exception) {

--- a/bridge/bindings/jsc/DOM/element.cc
+++ b/bridge/bindings/jsc/DOM/element.cc
@@ -164,14 +164,15 @@ ElementInstance::ElementInstance(JSElement *element, JSStringRef tagNameStringRe
   m_tagName.setString(tagNameStringRef);
   // Do not needs to send create element for HTML element.
   if (targetId == HTML_TARGET_ID) {
-      if (std::getenv("ENABLE_KRAKEN_JS_LOG") != nullptr && strcmp(std::getenv("ENABLE_KRAKEN_JS_LOG"), "true") == 0) {
-          KRAKEN_LOG(VERBOSE) << "ElementInstance: &HTML_TARGET_ID element: " << element << std::endl;
-          KRAKEN_LOG(VERBOSE) << "ElementInstance: &HTML_TARGET_ID element->context" << element->context << std::endl;
-          KRAKEN_LOG(VERBOSE)
-          << "ElementInstance: &HTML_TARGET_ID element->context->getOwner()" << element->context->getOwner()
-          << std::endl;
-      }
-    assert_m(getDartMethod(element->context->getOwner())->initHTML != nullptr, "Failed to execute initHTML(): dart method is nullptr.");
+    if (std::getenv("ENABLE_KRAKEN_JS_LOG") != nullptr && strcmp(std::getenv("ENABLE_KRAKEN_JS_LOG"), "true") == 0) {
+      KRAKEN_LOG(VERBOSE) << "ElementInstance: &HTML_TARGET_ID element: " << element << std::endl;
+      KRAKEN_LOG(VERBOSE) << "ElementInstance: &HTML_TARGET_ID element->context" << element->context << std::endl;
+      KRAKEN_LOG(VERBOSE)
+      << "ElementInstance: &HTML_TARGET_ID element->context->getOwner()" << element->context->getOwner()
+      << std::endl;
+    }
+    assert_m(getDartMethod(element->context->getOwner())->initHTML != nullptr,
+             "Failed to execute initHTML(): dart method is nullptr.");
     getDartMethod(element->context->getOwner())->initHTML(element->contextId, nativeElement);
   }
 }
@@ -525,8 +526,8 @@ JSValueRef JSElement::toBlob(JSContextRef ctx, JSObjectRef function, JSObjectRef
     return nullptr;
   }
 
-    auto elementInstance = reinterpret_cast<ElementInstance *>(JSObjectGetPrivate(thisObject));
-    auto context = elementInstance->context;
+  auto elementInstance = reinterpret_cast<ElementInstance *>(JSObjectGetPrivate(thisObject));
+  auto context = elementInstance->context;
 
   if (getDartMethod(context->getOwner())->toBlob == nullptr) {
     throwJSError(ctx, "Failed to export blob: dart method (toBlob) is not registered.", exception);
@@ -579,8 +580,9 @@ JSValueRef JSElement::toBlob(JSContextRef ctx, JSObjectRef function, JSObjectRef
     toBlobPromiseContext->bridge->bridgeCallback->registerCallback<void>(
       std::move(callbackContext), [toBlobPromiseContext, handleTransientToBlobCallback](
                                     BridgeCallback::Context *callbackContext, int32_t contextId) {
-        getDartMethod(toBlobPromiseContext->bridge)->toBlob(callbackContext, contextId, handleTransientToBlobCallback, toBlobPromiseContext->id,
-                                toBlobPromiseContext->devicePixelRatio);
+        getDartMethod(toBlobPromiseContext->bridge)->toBlob(callbackContext, contextId, handleTransientToBlobCallback,
+                                                            toBlobPromiseContext->id,
+                                                            toBlobPromiseContext->devicePixelRatio);
       });
 
     delete toBlobPromiseContext;

--- a/bridge/bindings/jsc/DOM/element.cc
+++ b/bridge/bindings/jsc/DOM/element.cc
@@ -164,8 +164,15 @@ ElementInstance::ElementInstance(JSElement *element, JSStringRef tagNameStringRe
   m_tagName.setString(tagNameStringRef);
   // Do not needs to send create element for HTML element.
   if (targetId == HTML_TARGET_ID) {
-    assert_m(getDartMethod()->initHTML != nullptr, "Failed to execute initHTML(): dart method is nullptr.");
-    getDartMethod()->initHTML(element->contextId, nativeElement);
+      if (std::getenv("ENABLE_KRAKEN_JS_LOG") != nullptr && strcmp(std::getenv("ENABLE_KRAKEN_JS_LOG"), "true") == 0) {
+          KRAKEN_LOG(VERBOSE) << "ElementInstance: &HTML_TARGET_ID element: " << element << std::endl;
+          KRAKEN_LOG(VERBOSE) << "ElementInstance: &HTML_TARGET_ID element->context" << element->context << std::endl;
+          KRAKEN_LOG(VERBOSE)
+          << "ElementInstance: &HTML_TARGET_ID element->context->getOwner()" << element->context->getOwner()
+          << std::endl;
+      }
+    assert_m(getDartMethod(element->context->getOwner())->initHTML != nullptr, "Failed to execute initHTML(): dart method is nullptr.");
+    getDartMethod(element->context->getOwner())->initHTML(element->contextId, nativeElement);
   }
 }
 
@@ -177,7 +184,7 @@ ElementInstance::~ElementInstance() {
 JSValueRef JSElement::getBoundingClientRect(JSContextRef ctx, JSObjectRef function, JSObjectRef thisObject,
                                             size_t argumentCount, const JSValueRef *arguments, JSValueRef *exception) {
   auto elementInstance = reinterpret_cast<ElementInstance *>(JSObjectGetPrivate(thisObject));
-  getDartMethod()->flushUICommand();
+  getDartMethod(elementInstance->context->getOwner())->flushUICommand();
   assert_m(elementInstance->nativeElement->getBoundingClientRect != nullptr,
            "Failed to execute getBoundingClientRect(): dart method is nullptr.");
   NativeBoundingClientRect *nativeBoundingClientRect =
@@ -211,84 +218,84 @@ JSValueRef ElementInstance::getProperty(std::string &name, JSValueRef *exception
     return nullptr;
   }
   case JSElement::ElementProperty::offsetLeft: {
-    getDartMethod()->flushUICommand();
+    getDartMethod(context->getOwner())->flushUICommand();
     assert_m(nativeElement->getViewModuleProperty != nullptr,
              "Failed to execute getViewModuleProperty(): dart method is nullptr.");
     return JSValueMakeNumber(_hostClass->ctx, nativeElement->getViewModuleProperty(
                                                 nativeElement, static_cast<int64_t>(ViewModuleProperty::offsetLeft)));
   }
   case JSElement::ElementProperty::offsetTop: {
-    getDartMethod()->flushUICommand();
+    getDartMethod(context->getOwner())->flushUICommand();
     assert_m(nativeElement->getViewModuleProperty != nullptr,
              "Failed to execute getViewModuleProperty(): dart method is nullptr.");
     return JSValueMakeNumber(_hostClass->ctx, nativeElement->getViewModuleProperty(
                                                 nativeElement, static_cast<int64_t>(ViewModuleProperty::offsetTop)));
   }
   case JSElement::ElementProperty::offsetWidth: {
-    getDartMethod()->flushUICommand();
+    getDartMethod(context->getOwner())->flushUICommand();
     assert_m(nativeElement->getViewModuleProperty != nullptr,
              "Failed to execute getViewModuleProperty(): dart method is nullptr.");
     return JSValueMakeNumber(_hostClass->ctx, nativeElement->getViewModuleProperty(
                                                 nativeElement, static_cast<int64_t>(ViewModuleProperty::offsetWidth)));
   }
   case JSElement::ElementProperty::offsetHeight: {
-    getDartMethod()->flushUICommand();
+    getDartMethod(context->getOwner())->flushUICommand();
     assert_m(nativeElement->getViewModuleProperty != nullptr,
              "Failed to execute getViewModuleProperty(): dart method is nullptr.");
     return JSValueMakeNumber(_hostClass->ctx, nativeElement->getViewModuleProperty(
                                                 nativeElement, static_cast<int64_t>(ViewModuleProperty::offsetHeight)));
   }
   case JSElement::ElementProperty::clientWidth: {
-    getDartMethod()->flushUICommand();
+    getDartMethod(context->getOwner())->flushUICommand();
     assert_m(nativeElement->getViewModuleProperty != nullptr,
              "Failed to execute getViewModuleProperty(): dart method is nullptr.");
     return JSValueMakeNumber(_hostClass->ctx, nativeElement->getViewModuleProperty(
                                                 nativeElement, static_cast<int64_t>(ViewModuleProperty::clientWidth)));
   }
   case JSElement::ElementProperty::clientHeight: {
-    getDartMethod()->flushUICommand();
+    getDartMethod(context->getOwner())->flushUICommand();
     assert_m(nativeElement->getViewModuleProperty != nullptr,
              "Failed to execute getViewModuleProperty(): dart method is nullptr.");
     return JSValueMakeNumber(_hostClass->ctx, nativeElement->getViewModuleProperty(
                                                 nativeElement, static_cast<int64_t>(ViewModuleProperty::clientHeight)));
   }
   case JSElement::ElementProperty::clientTop: {
-    getDartMethod()->flushUICommand();
+    getDartMethod(context->getOwner())->flushUICommand();
     assert_m(nativeElement->getViewModuleProperty != nullptr,
              "Failed to execute getViewModuleProperty(): dart method is nullptr.");
     return JSValueMakeNumber(_hostClass->ctx, nativeElement->getViewModuleProperty(
                                                 nativeElement, static_cast<int64_t>(ViewModuleProperty::clientTop)));
   }
   case JSElement::ElementProperty::clientLeft: {
-    getDartMethod()->flushUICommand();
+    getDartMethod(context->getOwner())->flushUICommand();
     assert_m(nativeElement->getViewModuleProperty != nullptr,
              "Failed to execute getViewModuleProperty(): dart method is nullptr.");
     return JSValueMakeNumber(_hostClass->ctx, nativeElement->getViewModuleProperty(
                                                 nativeElement, static_cast<int64_t>(ViewModuleProperty::clientLeft)));
   }
   case JSElement::ElementProperty::scrollTop: {
-    getDartMethod()->flushUICommand();
+    getDartMethod(context->getOwner())->flushUICommand();
     assert_m(nativeElement->getViewModuleProperty != nullptr,
              "Failed to execute getViewModuleProperty(): dart method is nullptr.");
     return JSValueMakeNumber(_hostClass->ctx, nativeElement->getViewModuleProperty(
                                                 nativeElement, static_cast<int64_t>(ViewModuleProperty::scrollTop)));
   }
   case JSElement::ElementProperty::scrollLeft: {
-    getDartMethod()->flushUICommand();
+    getDartMethod(context->getOwner())->flushUICommand();
     assert_m(nativeElement->getViewModuleProperty != nullptr,
              "Failed to execute getViewModuleProperty(): dart method is nullptr.");
     return JSValueMakeNumber(_hostClass->ctx, nativeElement->getViewModuleProperty(
                                                 nativeElement, static_cast<int64_t>(ViewModuleProperty::scrollLeft)));
   }
   case JSElement::ElementProperty::scrollHeight: {
-    getDartMethod()->flushUICommand();
+    getDartMethod(context->getOwner())->flushUICommand();
     assert_m(nativeElement->getViewModuleProperty != nullptr,
              "Failed to execute getViewModuleProperty(): dart method is nullptr.");
     return JSValueMakeNumber(_hostClass->ctx, nativeElement->getViewModuleProperty(
                                                 nativeElement, static_cast<int64_t>(ViewModuleProperty::scrollHeight)));
   }
   case JSElement::ElementProperty::scrollWidth: {
-    getDartMethod()->flushUICommand();
+    getDartMethod(context->getOwner())->flushUICommand();
     assert_m(nativeElement->getViewModuleProperty != nullptr,
              "Failed to execute getViewModuleProperty(): dart method is nullptr.");
     return JSValueMakeNumber(_hostClass->ctx, nativeElement->getViewModuleProperty(
@@ -325,7 +332,7 @@ bool ElementInstance::setProperty(std::string &name, JSValueRef value, JSValueRe
     case JSElement::ElementProperty::attributes:
       return false;
     case JSElement::ElementProperty::scrollTop: {
-      getDartMethod()->flushUICommand();
+      getDartMethod(context->getOwner())->flushUICommand();
       assert_m(nativeElement->setViewModuleProperty != nullptr,
                "Failed to execute setScrollTop(): dart method is nullptr.");
       nativeElement->setViewModuleProperty(nativeElement, static_cast<int64_t>(ViewModuleProperty::scrollTop),
@@ -333,7 +340,7 @@ bool ElementInstance::setProperty(std::string &name, JSValueRef value, JSValueRe
       break;
     }
     case JSElement::ElementProperty::scrollLeft: {
-      getDartMethod()->flushUICommand();
+      getDartMethod(context->getOwner())->flushUICommand();
       assert_m(nativeElement->setViewModuleProperty != nullptr,
                "Failed to execute setScrollLeft(): dart method is nullptr.");
       nativeElement->setViewModuleProperty(nativeElement, static_cast<int64_t>(ViewModuleProperty::scrollLeft),
@@ -518,14 +525,15 @@ JSValueRef JSElement::toBlob(JSContextRef ctx, JSObjectRef function, JSObjectRef
     return nullptr;
   }
 
-  if (getDartMethod()->toBlob == nullptr) {
+    auto elementInstance = reinterpret_cast<ElementInstance *>(JSObjectGetPrivate(thisObject));
+    auto context = elementInstance->context;
+
+  if (getDartMethod(context->getOwner())->toBlob == nullptr) {
     throwJSError(ctx, "Failed to export blob: dart method (toBlob) is not registered.", exception);
     return nullptr;
   }
 
-  auto elementInstance = reinterpret_cast<ElementInstance *>(JSObjectGetPrivate(thisObject));
-  auto context = elementInstance->context;
-  getDartMethod()->flushUICommand();
+  getDartMethod(context->getOwner())->flushUICommand();
 
   double devicePixelRatio = JSValueToNumber(ctx, devicePixelRatioValueRef, exception);
   auto bridge = static_cast<JSBridge *>(context->getOwner());
@@ -571,7 +579,7 @@ JSValueRef JSElement::toBlob(JSContextRef ctx, JSObjectRef function, JSObjectRef
     toBlobPromiseContext->bridge->bridgeCallback->registerCallback<void>(
       std::move(callbackContext), [toBlobPromiseContext, handleTransientToBlobCallback](
                                     BridgeCallback::Context *callbackContext, int32_t contextId) {
-        getDartMethod()->toBlob(callbackContext, contextId, handleTransientToBlobCallback, toBlobPromiseContext->id,
+        getDartMethod(toBlobPromiseContext->bridge)->toBlob(callbackContext, contextId, handleTransientToBlobCallback, toBlobPromiseContext->id,
                                 toBlobPromiseContext->devicePixelRatio);
       });
 
@@ -586,7 +594,7 @@ JSValueRef JSElement::toBlob(JSContextRef ctx, JSObjectRef function, JSObjectRef
 JSValueRef JSElement::click(JSContextRef ctx, JSObjectRef function, JSObjectRef thisObject, size_t argumentCount,
                             const JSValueRef *arguments, JSValueRef *exception) {
   auto elementInstance = reinterpret_cast<ElementInstance *>(JSObjectGetPrivate(thisObject));
-  getDartMethod()->flushUICommand();
+  getDartMethod(elementInstance->context->getOwner())->flushUICommand();
   assert_m(elementInstance->nativeElement->click != nullptr, "Failed to execute click(): dart method is nullptr.");
   elementInstance->nativeElement->click(elementInstance->nativeElement);
 
@@ -610,7 +618,7 @@ JSValueRef JSElement::scroll(JSContextRef ctx, JSObjectRef function, JSObjectRef
   }
 
   auto elementInstance = reinterpret_cast<ElementInstance *>(JSObjectGetPrivate(thisObject));
-  getDartMethod()->flushUICommand();
+  getDartMethod(elementInstance->context->getOwner())->flushUICommand();
   assert_m(elementInstance->nativeElement->scroll != nullptr, "Failed to execute scroll(): dart method is nullptr.");
   elementInstance->nativeElement->scroll(elementInstance->nativeElement, x, y);
 
@@ -634,7 +642,7 @@ JSValueRef JSElement::scrollBy(JSContextRef ctx, JSObjectRef function, JSObjectR
   }
 
   auto elementInstance = reinterpret_cast<ElementInstance *>(JSObjectGetPrivate(thisObject));
-  getDartMethod()->flushUICommand();
+  getDartMethod(elementInstance->context->getOwner())->flushUICommand();
   assert_m(elementInstance->nativeElement->scrollBy != nullptr,
            "Failed to execute scrollBy(): dart method is nullptr.");
   elementInstance->nativeElement->scrollBy(elementInstance->nativeElement, x, y);
@@ -771,7 +779,7 @@ BoundingClientRect::BoundingClientRect(JSContext *context, NativeBoundingClientR
   : HostObject(context, "BoundingClientRect"), nativeBoundingClientRect(boundingClientRect) {}
 
 JSValueRef ElementInstance::getStringValueProperty(std::string &name) {
-  getDartMethod()->flushUICommand();
+  getDartMethod(context->getOwner())->flushUICommand();
   JSStringRef stringRef = JSStringCreateWithUTF8CString(name.c_str());
   NativeString *nativeString = stringRefToNativeString(stringRef);
   NativeString *returnedString = nativeElement->getStringValueProperty(nativeElement, nativeString);

--- a/bridge/bindings/jsc/DOM/element.cc
+++ b/bridge/bindings/jsc/DOM/element.cc
@@ -164,13 +164,6 @@ ElementInstance::ElementInstance(JSElement *element, JSStringRef tagNameStringRe
   m_tagName.setString(tagNameStringRef);
   // Do not needs to send create element for HTML element.
   if (targetId == HTML_TARGET_ID) {
-    if (std::getenv("ENABLE_KRAKEN_JS_LOG") != nullptr && strcmp(std::getenv("ENABLE_KRAKEN_JS_LOG"), "true") == 0) {
-      KRAKEN_LOG(VERBOSE) << "ElementInstance: &HTML_TARGET_ID element: " << element << std::endl;
-      KRAKEN_LOG(VERBOSE) << "ElementInstance: &HTML_TARGET_ID element->context" << element->context << std::endl;
-      KRAKEN_LOG(VERBOSE)
-      << "ElementInstance: &HTML_TARGET_ID element->context->getOwner()" << element->context->getOwner()
-      << std::endl;
-    }
     assert_m(getDartMethod(element->context->getOwner())->initHTML != nullptr,
              "Failed to execute initHTML(): dart method is nullptr.");
     getDartMethod(element->context->getOwner())->initHTML(element->contextId, nativeElement);

--- a/bridge/bindings/jsc/DOM/elements/canvas_element.cc
+++ b/bridge/bindings/jsc/DOM/elements/canvas_element.cc
@@ -136,7 +136,7 @@ JSValueRef JSCanvasElement::getContext(JSContextRef ctx, JSObjectRef function,
   NativeString contextId{};
   contextId.string = JSStringGetCharactersPtr(contextIdStringRef);
   contextId.length = JSStringGetLength(contextIdStringRef);
-    auto elementInstance = reinterpret_cast<JSCanvasElement::CanvasElementInstance *>(JSObjectGetPrivate(thisObject));
+  auto elementInstance = reinterpret_cast<JSCanvasElement::CanvasElementInstance *>(JSObjectGetPrivate(thisObject));
 
   getDartMethod(elementInstance->context->getOwner())->flushUICommand();
 

--- a/bridge/bindings/jsc/DOM/elements/canvas_element.cc
+++ b/bridge/bindings/jsc/DOM/elements/canvas_element.cc
@@ -136,10 +136,10 @@ JSValueRef JSCanvasElement::getContext(JSContextRef ctx, JSObjectRef function,
   NativeString contextId{};
   contextId.string = JSStringGetCharactersPtr(contextIdStringRef);
   contextId.length = JSStringGetLength(contextIdStringRef);
+    auto elementInstance = reinterpret_cast<JSCanvasElement::CanvasElementInstance *>(JSObjectGetPrivate(thisObject));
 
-  getDartMethod()->flushUICommand();
+  getDartMethod(elementInstance->context->getOwner())->flushUICommand();
 
-  auto elementInstance = reinterpret_cast<JSCanvasElement::CanvasElementInstance *>(JSObjectGetPrivate(thisObject));
   assert_m(elementInstance->nativeCanvasElement->getContext != nullptr,
            "Failed to call getContext(): dart method is nullptr");
   NativeCanvasRenderingContext2D *nativeCanvasRenderingContext2D =
@@ -229,7 +229,7 @@ bool CanvasRenderingContext2D::CanvasRenderingContext2DInstance::setProperty(std
   if (propertyMap.count(name) > 0) {
     auto property = propertyMap[name];
 
-    getDartMethod()->flushUICommand();
+    getDartMethod(context->getOwner())->flushUICommand();
 
     switch (property) {
     case CanvasRenderingContext2DProperty::direction: {
@@ -402,7 +402,7 @@ JSValueRef CanvasRenderingContext2D::arc(JSContextRef ctx, JSObjectRef function,
   auto instance =
     reinterpret_cast<CanvasRenderingContext2D::CanvasRenderingContext2DInstance *>(JSObjectGetPrivate(thisObject));
 
-  getDartMethod()->flushUICommand();
+  getDartMethod(instance->context->getOwner())->flushUICommand();
   assert_m(instance->nativeCanvasRenderingContext2D->arc != nullptr,
            "Failed to execute arc(): dart method is nullptr.");
   instance->nativeCanvasRenderingContext2D->arc(instance->nativeCanvasRenderingContext2D, x, y, radius, startAngle, endAngle, counterclockwise ? 1 : 0);
@@ -432,7 +432,7 @@ JSValueRef CanvasRenderingContext2D::arcTo(JSContextRef ctx, JSObjectRef functio
   auto instance =
     reinterpret_cast<CanvasRenderingContext2D::CanvasRenderingContext2DInstance *>(JSObjectGetPrivate(thisObject));
 
-  getDartMethod()->flushUICommand();
+  getDartMethod(instance->context->getOwner())->flushUICommand();
   assert_m(instance->nativeCanvasRenderingContext2D->arcTo != nullptr,
            "Failed to execute arcTo(): dart method is nullptr.");
   instance->nativeCanvasRenderingContext2D->arcTo(instance->nativeCanvasRenderingContext2D, x1, y1, x2, y2, radius);
@@ -447,7 +447,7 @@ JSValueRef CanvasRenderingContext2D::beginPath(JSContextRef ctx, JSObjectRef fun
   auto instance =
     reinterpret_cast<CanvasRenderingContext2D::CanvasRenderingContext2DInstance *>(JSObjectGetPrivate(thisObject));
 
-  getDartMethod()->flushUICommand();
+  getDartMethod(instance->context->getOwner())->flushUICommand();
   assert_m(instance->nativeCanvasRenderingContext2D->beginPath != nullptr,
            "Failed to execute beginPath(): dart method is nullptr.");
   instance->nativeCanvasRenderingContext2D->beginPath(instance->nativeCanvasRenderingContext2D);
@@ -477,7 +477,7 @@ JSValueRef CanvasRenderingContext2D::bezierCurveTo(JSContextRef ctx, JSObjectRef
   auto instance =
     reinterpret_cast<CanvasRenderingContext2D::CanvasRenderingContext2DInstance *>(JSObjectGetPrivate(thisObject));
 
-  getDartMethod()->flushUICommand();
+  getDartMethod(instance->context->getOwner())->flushUICommand();
   assert_m(instance->nativeCanvasRenderingContext2D->bezierCurveTo != nullptr,
            "Failed to execute bezierCurveTo(): dart method is nullptr.");
   instance->nativeCanvasRenderingContext2D->bezierCurveTo(instance->nativeCanvasRenderingContext2D, cp1x, cp1y, cp2x, cp2y, x, y);
@@ -492,7 +492,7 @@ JSValueRef CanvasRenderingContext2D::closePath(JSContextRef ctx, JSObjectRef fun
   auto instance =
     reinterpret_cast<CanvasRenderingContext2D::CanvasRenderingContext2DInstance *>(JSObjectGetPrivate(thisObject));
 
-  getDartMethod()->flushUICommand();
+  getDartMethod(instance->context->getOwner())->flushUICommand();
   assert_m(instance->nativeCanvasRenderingContext2D->closePath != nullptr,
            "Failed to execute closePath(): dart method is nullptr.");
   instance->nativeCanvasRenderingContext2D->closePath(instance->nativeCanvasRenderingContext2D);
@@ -522,7 +522,7 @@ JSValueRef CanvasRenderingContext2D::clip(JSContextRef ctx, JSObjectRef function
   auto instance =
     reinterpret_cast<CanvasRenderingContext2D::CanvasRenderingContext2DInstance *>(JSObjectGetPrivate(thisObject));
 
-  getDartMethod()->flushUICommand();
+  getDartMethod(instance->context->getOwner())->flushUICommand();
   assert_m(instance->nativeCanvasRenderingContext2D->clip != nullptr,
            "Failed to execute clip(): dart method is nullptr.");
   instance->nativeCanvasRenderingContext2D->clip(instance->nativeCanvasRenderingContext2D, &fillRuleNativeString);
@@ -567,7 +567,7 @@ JSValueRef CanvasRenderingContext2D::drawImage(JSContextRef ctx, JSObjectRef fun
   auto instance =
     reinterpret_cast<CanvasRenderingContext2D::CanvasRenderingContext2DInstance *>(JSObjectGetPrivate(thisObject));
 
-  getDartMethod()->flushUICommand();
+  getDartMethod(instance->context->getOwner())->flushUICommand();
   assert_m(instance->nativeCanvasRenderingContext2D->drawImage != nullptr,
            "Failed to execute drawImage(): dart method is nullptr.");
   instance->nativeCanvasRenderingContext2D->drawImage(instance->nativeCanvasRenderingContext2D,
@@ -608,7 +608,7 @@ JSValueRef CanvasRenderingContext2D::ellipse(JSContextRef ctx, JSObjectRef funct
   auto instance =
     reinterpret_cast<CanvasRenderingContext2D::CanvasRenderingContext2DInstance *>(JSObjectGetPrivate(thisObject));
 
-  getDartMethod()->flushUICommand();
+  getDartMethod(instance->context->getOwner())->flushUICommand();
   assert_m(instance->nativeCanvasRenderingContext2D->ellipse != nullptr,
            "Failed to execute ellipse(): dart method is nullptr.");
   instance->nativeCanvasRenderingContext2D->ellipse(instance->nativeCanvasRenderingContext2D, x, y, radiusX, radiusY, rotation, startAngle, endAngle, counterclockwise ? 1 : 0);
@@ -639,7 +639,7 @@ JSValueRef CanvasRenderingContext2D::fill(JSContextRef ctx, JSObjectRef function
   auto instance =
     reinterpret_cast<CanvasRenderingContext2D::CanvasRenderingContext2DInstance *>(JSObjectGetPrivate(thisObject));
 
-  getDartMethod()->flushUICommand();
+  getDartMethod(instance->context->getOwner())->flushUICommand();
   assert_m(instance->nativeCanvasRenderingContext2D->fill != nullptr,
            "Failed to execute fill(): dart method is nullptr.");
   instance->nativeCanvasRenderingContext2D->fill(instance->nativeCanvasRenderingContext2D, &fillRuleNativeString);
@@ -665,7 +665,7 @@ JSValueRef CanvasRenderingContext2D::translate(JSContextRef ctx, JSObjectRef fun
   auto instance =
     reinterpret_cast<CanvasRenderingContext2D::CanvasRenderingContext2DInstance *>(JSObjectGetPrivate(thisObject));
 
-  getDartMethod()->flushUICommand();
+  getDartMethod(instance->context->getOwner())->flushUICommand();
   assert_m(instance->nativeCanvasRenderingContext2D->translate != nullptr,
            "Failed to execute translate(): dart method is nullptr.");
   instance->nativeCanvasRenderingContext2D->translate(instance->nativeCanvasRenderingContext2D, x, y);
@@ -693,7 +693,7 @@ JSValueRef CanvasRenderingContext2D::fillRect(JSContextRef ctx, JSObjectRef func
   auto instance =
     reinterpret_cast<CanvasRenderingContext2D::CanvasRenderingContext2DInstance *>(JSObjectGetPrivate(thisObject));
 
-  getDartMethod()->flushUICommand();
+  getDartMethod(instance->context->getOwner())->flushUICommand();
   assert_m(instance->nativeCanvasRenderingContext2D->fillRect != nullptr,
            "Failed to execute fillRect(): dart method is nullptr.");
   instance->nativeCanvasRenderingContext2D->fillRect(instance->nativeCanvasRenderingContext2D, x, y, width, height);
@@ -722,7 +722,7 @@ JSValueRef CanvasRenderingContext2D::rect(JSContextRef ctx, JSObjectRef function
   auto instance =
     reinterpret_cast<CanvasRenderingContext2D::CanvasRenderingContext2DInstance *>(JSObjectGetPrivate(thisObject));
 
-  getDartMethod()->flushUICommand();
+  getDartMethod(instance->context->getOwner())->flushUICommand();
   assert_m(instance->nativeCanvasRenderingContext2D->rect != nullptr,
            "Failed to execute rect(): dart method is nullptr.");
   instance->nativeCanvasRenderingContext2D->rect(instance->nativeCanvasRenderingContext2D, x, y, width, height);
@@ -748,7 +748,7 @@ JSValueRef CanvasRenderingContext2D::rotate(JSContextRef ctx, JSObjectRef functi
   auto instance =
     reinterpret_cast<CanvasRenderingContext2D::CanvasRenderingContext2DInstance *>(JSObjectGetPrivate(thisObject));
 
-  getDartMethod()->flushUICommand();
+  getDartMethod(instance->context->getOwner())->flushUICommand();
   assert_m(instance->nativeCanvasRenderingContext2D->rotate != nullptr,
            "Failed to execute rotate(): dart method is nullptr.");
   instance->nativeCanvasRenderingContext2D->rotate(instance->nativeCanvasRenderingContext2D, angle);
@@ -777,7 +777,7 @@ JSValueRef CanvasRenderingContext2D::clearRect(JSContextRef ctx, JSObjectRef fun
   auto instance =
     reinterpret_cast<CanvasRenderingContext2D::CanvasRenderingContext2DInstance *>(JSObjectGetPrivate(thisObject));
 
-  getDartMethod()->flushUICommand();
+  getDartMethod(instance->context->getOwner())->flushUICommand();
   assert_m(instance->nativeCanvasRenderingContext2D->clearRect != nullptr,
            "Failed to execute clearRect(): dart method is nullptr.");
   instance->nativeCanvasRenderingContext2D->clearRect(instance->nativeCanvasRenderingContext2D, x, y, width, height);
@@ -804,7 +804,7 @@ JSValueRef CanvasRenderingContext2D::strokeRect(
   auto instance =
     reinterpret_cast<CanvasRenderingContext2D::CanvasRenderingContext2DInstance *>(JSObjectGetPrivate(thisObject));
 
-  getDartMethod()->flushUICommand();
+  getDartMethod(instance->context->getOwner())->flushUICommand();
   assert_m(instance->nativeCanvasRenderingContext2D->strokeRect != nullptr,
            "Failed to execute strokeRect(): dart method is nullptr.");
   instance->nativeCanvasRenderingContext2D->strokeRect(instance->nativeCanvasRenderingContext2D, x, y, width, height);
@@ -842,7 +842,7 @@ JSValueRef CanvasRenderingContext2D::fillText(JSContextRef ctx, JSObjectRef func
   auto instance =
     reinterpret_cast<CanvasRenderingContext2D::CanvasRenderingContext2DInstance *>(JSObjectGetPrivate(thisObject));
 
-  getDartMethod()->flushUICommand();
+  getDartMethod(instance->context->getOwner())->flushUICommand();
   assert_m(instance->nativeCanvasRenderingContext2D->fillText != nullptr,
            "Failed to execute fillText(): dart method is nullptr.");
   instance->nativeCanvasRenderingContext2D->fillText(instance->nativeCanvasRenderingContext2D, &text, x, y, maxWidth);
@@ -868,7 +868,7 @@ JSValueRef CanvasRenderingContext2D::lineTo(JSContextRef ctx, JSObjectRef functi
   auto instance =
     reinterpret_cast<CanvasRenderingContext2D::CanvasRenderingContext2DInstance *>(JSObjectGetPrivate(thisObject));
 
-  getDartMethod()->flushUICommand();
+  getDartMethod(instance->context->getOwner())->flushUICommand();
   assert_m(instance->nativeCanvasRenderingContext2D->lineTo != nullptr,
            "Failed to execute lineTo(): dart method is nullptr.");
   instance->nativeCanvasRenderingContext2D->lineTo(instance->nativeCanvasRenderingContext2D, x, y);
@@ -894,7 +894,7 @@ JSValueRef CanvasRenderingContext2D::moveTo(JSContextRef ctx, JSObjectRef functi
   auto instance =
     reinterpret_cast<CanvasRenderingContext2D::CanvasRenderingContext2DInstance *>(JSObjectGetPrivate(thisObject));
 
-  getDartMethod()->flushUICommand();
+  getDartMethod(instance->context->getOwner())->flushUICommand();
   assert_m(instance->nativeCanvasRenderingContext2D->moveTo != nullptr,
            "Failed to execute moveTo(): dart method is nullptr.");
   instance->nativeCanvasRenderingContext2D->moveTo(instance->nativeCanvasRenderingContext2D, x, y);
@@ -920,7 +920,7 @@ JSValueRef CanvasRenderingContext2D::quadraticCurveTo(
   auto instance =
     reinterpret_cast<CanvasRenderingContext2D::CanvasRenderingContext2DInstance *>(JSObjectGetPrivate(thisObject));
 
-  getDartMethod()->flushUICommand();
+  getDartMethod(instance->context->getOwner())->flushUICommand();
   assert_m(instance->nativeCanvasRenderingContext2D->quadraticCurveTo != nullptr,
            "Failed to execute quadraticCurveTo(): dart method is nullptr.");
   instance->nativeCanvasRenderingContext2D->quadraticCurveTo(instance->nativeCanvasRenderingContext2D, cpx, cpy, x, y);
@@ -956,7 +956,7 @@ JSValueRef CanvasRenderingContext2D::strokeText(
   auto instance =
     reinterpret_cast<CanvasRenderingContext2D::CanvasRenderingContext2DInstance *>(JSObjectGetPrivate(thisObject));
 
-  getDartMethod()->flushUICommand();
+  getDartMethod(instance->context->getOwner())->flushUICommand();
   assert_m(instance->nativeCanvasRenderingContext2D->strokeText != nullptr,
            "Failed to execute strokeText(): dart method is nullptr.");
   instance->nativeCanvasRenderingContext2D->strokeText(instance->nativeCanvasRenderingContext2D, &text, x, y, maxWidth);
@@ -970,7 +970,7 @@ JSValueRef CanvasRenderingContext2D::save(JSContextRef ctx, JSObjectRef function
                                           JSValueRef *exception) {
   auto instance =
     reinterpret_cast<CanvasRenderingContext2D::CanvasRenderingContext2DInstance *>(JSObjectGetPrivate(thisObject));
-  getDartMethod()->flushUICommand();
+  getDartMethod(instance->context->getOwner())->flushUICommand();
   assert_m(instance->nativeCanvasRenderingContext2D->save != nullptr,
            "Failed to execute save(): dart method is nullptr.");
   instance->nativeCanvasRenderingContext2D->save(instance->nativeCanvasRenderingContext2D);
@@ -985,7 +985,7 @@ JSValueRef CanvasRenderingContext2D::stroke(JSContextRef ctx, JSObjectRef functi
   auto instance =
     reinterpret_cast<CanvasRenderingContext2D::CanvasRenderingContext2DInstance *>(JSObjectGetPrivate(thisObject));
 
-  getDartMethod()->flushUICommand();
+  getDartMethod(instance->context->getOwner())->flushUICommand();
   assert_m(instance->nativeCanvasRenderingContext2D->stroke != nullptr,
            "Failed to execute stroke(): dart method is nullptr.");
   instance->nativeCanvasRenderingContext2D->stroke(instance->nativeCanvasRenderingContext2D);
@@ -1012,7 +1012,7 @@ JSValueRef CanvasRenderingContext2D::scale(JSContextRef ctx, JSObjectRef functio
   auto instance =
     reinterpret_cast<CanvasRenderingContext2D::CanvasRenderingContext2DInstance *>(JSObjectGetPrivate(thisObject));
 
-  getDartMethod()->flushUICommand();
+  getDartMethod(instance->context->getOwner())->flushUICommand();
   assert_m(instance->nativeCanvasRenderingContext2D->scale != nullptr,
            "Failed to execute scale(): dart method is nullptr.");
   instance->nativeCanvasRenderingContext2D->scale(instance->nativeCanvasRenderingContext2D, x, y);
@@ -1027,7 +1027,7 @@ JSValueRef CanvasRenderingContext2D::restore(JSContextRef ctx, JSObjectRef funct
   auto instance =
     reinterpret_cast<CanvasRenderingContext2D::CanvasRenderingContext2DInstance *>(JSObjectGetPrivate(thisObject));
 
-  getDartMethod()->flushUICommand();
+  getDartMethod(instance->context->getOwner())->flushUICommand();
   assert_m(instance->nativeCanvasRenderingContext2D->restore != nullptr,
            "Failed to execute restore(): dart method is nullptr.");
   instance->nativeCanvasRenderingContext2D->restore(instance->nativeCanvasRenderingContext2D);
@@ -1042,7 +1042,7 @@ JSValueRef CanvasRenderingContext2D::resetTransform(JSContextRef ctx, JSObjectRe
   auto instance =
     reinterpret_cast<CanvasRenderingContext2D::CanvasRenderingContext2DInstance *>(JSObjectGetPrivate(thisObject));
 
-  getDartMethod()->flushUICommand();
+  getDartMethod(instance->context->getOwner())->flushUICommand();
   assert_m(instance->nativeCanvasRenderingContext2D->resetTransform != nullptr,
            "Failed to execute resetTransform(): dart method is nullptr.");
   instance->nativeCanvasRenderingContext2D->resetTransform(instance->nativeCanvasRenderingContext2D);
@@ -1072,7 +1072,7 @@ JSValueRef CanvasRenderingContext2D::setTransform(JSContextRef ctx, JSObjectRef 
   auto instance =
     reinterpret_cast<CanvasRenderingContext2D::CanvasRenderingContext2DInstance *>(JSObjectGetPrivate(thisObject));
 
-  getDartMethod()->flushUICommand();
+  getDartMethod(instance->context->getOwner())->flushUICommand();
   assert_m(instance->nativeCanvasRenderingContext2D->setTransform != nullptr,
            "Failed to execute setTransform(): dart method is nullptr.");
   instance->nativeCanvasRenderingContext2D->setTransform(instance->nativeCanvasRenderingContext2D, a, b, c, d, e, f);
@@ -1102,7 +1102,7 @@ JSValueRef CanvasRenderingContext2D::transform(JSContextRef ctx, JSObjectRef fun
   auto instance =
     reinterpret_cast<CanvasRenderingContext2D::CanvasRenderingContext2DInstance *>(JSObjectGetPrivate(thisObject));
 
-  getDartMethod()->flushUICommand();
+  getDartMethod(instance->context->getOwner())->flushUICommand();
   assert_m(instance->nativeCanvasRenderingContext2D->transform != nullptr,
            "Failed to execute transform(): dart method is nullptr.");
   instance->nativeCanvasRenderingContext2D->transform(instance->nativeCanvasRenderingContext2D, a, b, c, d, e, f);

--- a/bridge/bindings/jsc/DOM/elements/image_element.cc
+++ b/bridge/bindings/jsc/DOM/elements/image_element.cc
@@ -42,19 +42,19 @@ JSValueRef JSImageElement::ImageElementInstance::getProperty(std::string &name, 
     auto &&property = propertyMap[name];
     switch (property) {
     case ImageElementProperty::width: {
-      getDartMethod()->flushUICommand();
+      getDartMethod(context->getOwner())->flushUICommand();
       return JSValueMakeNumber(_hostClass->ctx, nativeImageElement->getImageWidth(nativeImageElement));
     }
     case ImageElementProperty::height: {
-      getDartMethod()->flushUICommand();
+      getDartMethod(context->getOwner())->flushUICommand();
       return JSValueMakeNumber(_hostClass->ctx, nativeImageElement->getImageHeight(nativeImageElement));
     }
     case ImageElementProperty::naturalWidth: {
-      getDartMethod()->flushUICommand();
+      getDartMethod(context->getOwner())->flushUICommand();
       return JSValueMakeNumber(_hostClass->ctx, nativeImageElement->getImageNaturalWidth(nativeImageElement));
     }
     case ImageElementProperty::naturalHeight: {
-      getDartMethod()->flushUICommand();
+      getDartMethod(context->getOwner())->flushUICommand();
       return JSValueMakeNumber(_hostClass->ctx, nativeImageElement->getImageNaturalHeight(nativeImageElement));
     }
     case ImageElementProperty::src: {

--- a/bridge/bindings/jsc/DOM/elements/input_element.cc
+++ b/bridge/bindings/jsc/DOM/elements/input_element.cc
@@ -36,9 +36,9 @@ JSValueRef JSInputElement::focus(JSContextRef ctx, JSObjectRef function, JSObjec
 
   auto elementInstance =
     static_cast<JSInputElement::InputElementInstance *>(JSObjectGetPrivate(thisObject));
-    getDartMethod(elementInstance->context->getOwner())->flushUICommand();
+  getDartMethod(elementInstance->context->getOwner())->flushUICommand();
 
-    assert_m(elementInstance->nativeInputElement->focus != nullptr,
+  assert_m(elementInstance->nativeInputElement->focus != nullptr,
            "Failed to call dart method: focus() is nullptr");
   elementInstance->nativeInputElement->focus(elementInstance->nativeInputElement);
   return nullptr;
@@ -49,7 +49,7 @@ JSValueRef JSInputElement::blur(JSContextRef ctx, JSObjectRef function, JSObject
 
   auto elementInstance =
     static_cast<JSInputElement::InputElementInstance *>(JSObjectGetPrivate(thisObject));
-    getDartMethod(elementInstance->context->getOwner())->flushUICommand();
+  getDartMethod(elementInstance->context->getOwner())->flushUICommand();
 
   assert_m(elementInstance->nativeInputElement->blur != nullptr,
            "Failed to call dart method: blur() is nullptr");

--- a/bridge/bindings/jsc/DOM/elements/input_element.cc
+++ b/bridge/bindings/jsc/DOM/elements/input_element.cc
@@ -33,11 +33,12 @@ JSObjectRef JSInputElement::instanceConstructor(JSContextRef ctx, JSObjectRef co
 
 JSValueRef JSInputElement::focus(JSContextRef ctx, JSObjectRef function, JSObjectRef thisObject, size_t argumentCount,
                                  const JSValueRef *arguments, JSValueRef *exception) {
-  getDartMethod()->flushUICommand();
 
   auto elementInstance =
     static_cast<JSInputElement::InputElementInstance *>(JSObjectGetPrivate(thisObject));
-  assert_m(elementInstance->nativeInputElement->focus != nullptr,
+    getDartMethod(elementInstance->context->getOwner())->flushUICommand();
+
+    assert_m(elementInstance->nativeInputElement->focus != nullptr,
            "Failed to call dart method: focus() is nullptr");
   elementInstance->nativeInputElement->focus(elementInstance->nativeInputElement);
   return nullptr;
@@ -45,10 +46,11 @@ JSValueRef JSInputElement::focus(JSContextRef ctx, JSObjectRef function, JSObjec
 
 JSValueRef JSInputElement::blur(JSContextRef ctx, JSObjectRef function, JSObjectRef thisObject, size_t argumentCount,
                                 const JSValueRef *arguments, JSValueRef *exception) {
-  getDartMethod()->flushUICommand();
 
   auto elementInstance =
     static_cast<JSInputElement::InputElementInstance *>(JSObjectGetPrivate(thisObject));
+    getDartMethod(elementInstance->context->getOwner())->flushUICommand();
+
   assert_m(elementInstance->nativeInputElement->blur != nullptr,
            "Failed to call dart method: blur() is nullptr");
   elementInstance->nativeInputElement->blur(elementInstance->nativeInputElement);
@@ -78,11 +80,11 @@ JSValueRef JSInputElement::InputElementInstance::getProperty(std::string &name, 
     auto &&property = propertyMap[name];
     switch (property) {
     case InputElementProperty::width: {
-      getDartMethod()->flushUICommand();
+      getDartMethod(context->getOwner())->flushUICommand();
       return JSValueMakeNumber(_hostClass->ctx, nativeInputElement->getInputWidth(nativeInputElement));
     }
     case InputElementProperty::height: {
-      getDartMethod()->flushUICommand();
+      getDartMethod(context->getOwner())->flushUICommand();
       return JSValueMakeNumber(_hostClass->ctx, nativeInputElement->getInputHeight(nativeInputElement));
     }
     default: {

--- a/bridge/bindings/jsc/DOM/event_target.cc
+++ b/bridge/bindings/jsc/DOM/event_target.cc
@@ -439,8 +439,8 @@ void NativeEventTarget::dispatchEventImpl(NativeEventTarget *nativeEventTarget, 
   std::u16string u16EventType = std::u16string(reinterpret_cast<const char16_t *>(nativeEventType->string),
                                                nativeEventType->length);
   std::string eventType = toUTF8(u16EventType);
-  if (std::getenv("ENABLE_KRAKEN_JS_LOG") != nullptr && strcmp(std::getenv("ENABLE_KRAKEN_JS_LOG"), "true") == 0) {
-    KRAKEN_LOG(VERBOSE) << "TYLOR dispatchEventImpl ::--> " << eventType << std::endl;
+  if (std::getenv("ENABLE_MULTI_RUNTIME_JS_LOG") != nullptr && strcmp(std::getenv("ENABLE_MULTI_RUNTIME_JS_LOG"), "true") == 0) {
+    KRAKEN_LOG(VERBOSE) << "dispatchEventImpl ::--> " << eventType << std::endl;
   }
 
   EventInstance *eventInstance = JSEvent::buildEventInstance(eventType, context, nativeEvent, isCustomEvent == 1);

--- a/bridge/bindings/jsc/DOM/event_target.cc
+++ b/bridge/bindings/jsc/DOM/event_target.cc
@@ -439,6 +439,10 @@ void NativeEventTarget::dispatchEventImpl(NativeEventTarget *nativeEventTarget, 
   std::u16string u16EventType = std::u16string(reinterpret_cast<const char16_t *>(nativeEventType->string),
                                                nativeEventType->length);
   std::string eventType = toUTF8(u16EventType);
+        if (std::getenv("ENABLE_KRAKEN_JS_LOG") != nullptr && strcmp(std::getenv("ENABLE_KRAKEN_JS_LOG"), "true") == 0) {
+            KRAKEN_LOG(VERBOSE) << "TYLOR dispatchEventImpl ::--> " << eventType << std::endl;
+        }
+
   EventInstance *eventInstance = JSEvent::buildEventInstance(eventType, context, nativeEvent, isCustomEvent == 1);
   eventInstance->nativeEvent->target = eventTargetInstance;
   eventTargetInstance->dispatchEvent(eventInstance);

--- a/bridge/bindings/jsc/DOM/event_target.cc
+++ b/bridge/bindings/jsc/DOM/event_target.cc
@@ -439,9 +439,9 @@ void NativeEventTarget::dispatchEventImpl(NativeEventTarget *nativeEventTarget, 
   std::u16string u16EventType = std::u16string(reinterpret_cast<const char16_t *>(nativeEventType->string),
                                                nativeEventType->length);
   std::string eventType = toUTF8(u16EventType);
-        if (std::getenv("ENABLE_KRAKEN_JS_LOG") != nullptr && strcmp(std::getenv("ENABLE_KRAKEN_JS_LOG"), "true") == 0) {
-            KRAKEN_LOG(VERBOSE) << "TYLOR dispatchEventImpl ::--> " << eventType << std::endl;
-        }
+  if (std::getenv("ENABLE_KRAKEN_JS_LOG") != nullptr && strcmp(std::getenv("ENABLE_KRAKEN_JS_LOG"), "true") == 0) {
+    KRAKEN_LOG(VERBOSE) << "TYLOR dispatchEventImpl ::--> " << eventType << std::endl;
+  }
 
   EventInstance *eventInstance = JSEvent::buildEventInstance(eventType, context, nativeEvent, isCustomEvent == 1);
   eventInstance->nativeEvent->target = eventTargetInstance;

--- a/bridge/bindings/jsc/DOM/style_declaration.cc
+++ b/bridge/bindings/jsc/DOM/style_declaration.cc
@@ -15,13 +15,13 @@ void bindCSSStyleDeclaration(std::unique_ptr<JSContext> &context) {
 }
 
 namespace {
-    std::recursive_mutex style_runtime_mutex_;
+std::recursive_mutex style_runtime_mutex_;
 static std::string parseJavaScriptCSSPropertyName(std::string &propertyName) {
   static std::unordered_map<std::string, std::string> propertyCache{};
 
-    std::lock_guard<std::recursive_mutex> guard(style_runtime_mutex_);
+  std::lock_guard<std::recursive_mutex> guard(style_runtime_mutex_);
 
-    if (propertyCache.count(propertyName) > 0) {
+  if (propertyCache.count(propertyName) > 0) {
     return propertyCache[propertyName];
   }
 
@@ -54,16 +54,16 @@ CSSStyleDeclaration::CSSStyleDeclaration(JSContext *context) : HostClass(context
 std::unordered_map<JSContext *, CSSStyleDeclaration *> CSSStyleDeclaration::instanceMap{};
 
 CSSStyleDeclaration *CSSStyleDeclaration::instance(JSContext *context) {
-    std::lock_guard<std::recursive_mutex> guard(style_runtime_mutex_);
-    if (instanceMap.count(context) == 0) {
+  std::lock_guard<std::recursive_mutex> guard(style_runtime_mutex_);
+  if (instanceMap.count(context) == 0) {
     instanceMap[context] = new CSSStyleDeclaration(context);
   }
   return instanceMap[context];
 }
 
 CSSStyleDeclaration::~CSSStyleDeclaration() {
-    std::lock_guard<std::recursive_mutex> guard(style_runtime_mutex_);
-    instanceMap.erase(context);
+  std::lock_guard<std::recursive_mutex> guard(style_runtime_mutex_);
+  instanceMap.erase(context);
 }
 
 JSObjectRef CSSStyleDeclaration::instanceConstructor(JSContextRef ctx, JSObjectRef constructor, size_t argumentCount,

--- a/bridge/bindings/jsc/DOM/style_declaration.cc
+++ b/bridge/bindings/jsc/DOM/style_declaration.cc
@@ -15,11 +15,13 @@ void bindCSSStyleDeclaration(std::unique_ptr<JSContext> &context) {
 }
 
 namespace {
-
+    std::recursive_mutex style_runtime_mutex_;
 static std::string parseJavaScriptCSSPropertyName(std::string &propertyName) {
   static std::unordered_map<std::string, std::string> propertyCache{};
 
-  if (propertyCache.count(propertyName) > 0) {
+    std::lock_guard<std::recursive_mutex> guard(style_runtime_mutex_);
+
+    if (propertyCache.count(propertyName) > 0) {
     return propertyCache[propertyName];
   }
 
@@ -52,14 +54,16 @@ CSSStyleDeclaration::CSSStyleDeclaration(JSContext *context) : HostClass(context
 std::unordered_map<JSContext *, CSSStyleDeclaration *> CSSStyleDeclaration::instanceMap{};
 
 CSSStyleDeclaration *CSSStyleDeclaration::instance(JSContext *context) {
-  if (instanceMap.count(context) == 0) {
+    std::lock_guard<std::recursive_mutex> guard(style_runtime_mutex_);
+    if (instanceMap.count(context) == 0) {
     instanceMap[context] = new CSSStyleDeclaration(context);
   }
   return instanceMap[context];
 }
 
 CSSStyleDeclaration::~CSSStyleDeclaration() {
-  instanceMap.erase(context);
+    std::lock_guard<std::recursive_mutex> guard(style_runtime_mutex_);
+    instanceMap.erase(context);
 }
 
 JSObjectRef CSSStyleDeclaration::instanceConstructor(JSContextRef ctx, JSObjectRef constructor, size_t argumentCount,

--- a/bridge/bindings/jsc/KOM/location.cc
+++ b/bridge/bindings/jsc/KOM/location.cc
@@ -33,13 +33,13 @@ JSValueRef JSLocation::reload(JSContextRef ctx, JSObjectRef function, JSObjectRe
                               const JSValueRef *arguments, JSValueRef *exception) {
   auto jsLocation = static_cast<JSLocation *>(JSObjectGetPrivate(function));
 
-  if (getDartMethod()->reloadApp == nullptr) {
+  if (getDartMethod(jsLocation->context->getOwner())->reloadApp == nullptr) {
     throwJSError(ctx, "Failed to execute 'reload': dart method (reloadApp) is not registered.", exception);
     return nullptr;
   }
 
-  getDartMethod()->flushUICommand();
-  getDartMethod()->reloadApp(jsLocation->context->getContextId());
+  getDartMethod(jsLocation->context->getOwner())->flushUICommand();
+  getDartMethod(jsLocation->context->getOwner())->reloadApp(jsLocation->context->getContextId());
 
   return nullptr;
 }

--- a/bridge/bindings/jsc/KOM/screen.cc
+++ b/bridge/bindings/jsc/KOM/screen.cc
@@ -9,12 +9,12 @@
 namespace kraken::binding::jsc {
 
 JSValueRef JSScreen::getProperty(std::string &name, JSValueRef *exception) {
-  if (getDartMethod()->getScreen == nullptr) {
+  if (getDartMethod(context->getOwner())->getScreen == nullptr) {
     throwJSError(context->context(), "Failed to read screen: dart method (getScreen) is not registered.", exception);
     return nullptr;
   }
 
-  Screen *screen = getDartMethod()->getScreen(context->getContextId());
+  Screen *screen = getDartMethod(context->getOwner())->getScreen(context->getContextId());
 
   if (name == "width" || name == "availWidth") {
     return JSValueMakeNumber(context->context(), screen->width);

--- a/bridge/bindings/jsc/KOM/timer.cc
+++ b/bridge/bindings/jsc/KOM/timer.cc
@@ -134,7 +134,7 @@ JSValueRef setTimeout(JSContextRef ctx, JSObjectRef function, JSObjectRef thisOb
     return nullptr;
   }
 
-  if (getDartMethod()->setTimeout == nullptr) {
+  if (getDartMethod(context->getOwner())->setTimeout == nullptr) {
     throwJSError(ctx, "Failed to execute 'setTimeout': dart method (setTimeout) is not registered.", exception);
     return nullptr;
   }
@@ -143,7 +143,7 @@ JSValueRef setTimeout(JSContextRef ctx, JSObjectRef function, JSObjectRef thisOb
   auto bridge = static_cast<JSBridge *>(context->getOwner());
   auto timerId = bridge->bridgeCallback->registerCallback<int32_t>(
     std::move(callbackContext), [&timeout](BridgeCallback::Context *callbackContext, int32_t contextId) {
-      return getDartMethod()->setTimeout(callbackContext, contextId, handleTransientCallback, timeout);
+      return getDartMethod(callbackContext->_context.getOwner())->setTimeout(callbackContext, contextId, handleTransientCallback, timeout);
     });
 
   // `-1` represents ffi error occurred.
@@ -191,7 +191,7 @@ JSValueRef setInterval(JSContextRef ctx, JSObjectRef function, JSObjectRef thisO
     return nullptr;
   }
 
-  if (getDartMethod()->setInterval == nullptr) {
+  if (getDartMethod(context->getOwner())->setInterval == nullptr) {
     throwJSError(ctx, "Failed to execute 'setInterval': dart method (setInterval) is not registered.", exception);
     return nullptr;
   }
@@ -201,7 +201,7 @@ JSValueRef setInterval(JSContextRef ctx, JSObjectRef function, JSObjectRef thisO
   auto bridge = static_cast<JSBridge *>(context->getOwner());
   auto timerId = bridge->bridgeCallback->registerCallback<int32_t>(
     std::move(callbackContext), [&timeout](BridgeCallback::Context *callbackContext, int32_t contextId) {
-      return getDartMethod()->setInterval(callbackContext, contextId, handlePersistentCallback, timeout);
+      return getDartMethod(callbackContext->_context.getOwner())->setInterval(callbackContext, contextId, handlePersistentCallback, timeout);
     });
 
   if (timerId == -1) {
@@ -228,12 +228,12 @@ JSValueRef clearTimeout(JSContextRef ctx, JSObjectRef function, JSObjectRef this
 
   auto id = static_cast<int32_t>(JSValueToNumber(ctx, timerIdValueRef, exception));
 
-  if (getDartMethod()->clearTimeout == nullptr) {
+  if (getDartMethod(context->getOwner())->clearTimeout == nullptr) {
     throwJSError(ctx, "Failed to execute 'clearTimeout': dart method (clearTimeout) is not registered.", exception);
     return nullptr;
   }
 
-  getDartMethod()->clearTimeout(context->getContextId(), id);
+  getDartMethod(context->getOwner())->clearTimeout(context->getContextId(), id);
   return nullptr;
 }
 
@@ -256,14 +256,14 @@ JSValueRef cancelAnimationFrame(JSContextRef ctx, JSObjectRef function, JSObject
 
   auto id = static_cast<int32_t>(JSValueToNumber(ctx, requestIdValueRef, exception));
 
-  if (getDartMethod()->cancelAnimationFrame == nullptr) {
+  if (getDartMethod(context->getOwner())->cancelAnimationFrame == nullptr) {
     throwJSError(ctx,
                     "Failed to execute 'cancelAnimationFrame': dart method (cancelAnimationFrame) is not registered.",
                     exception);
     return nullptr;
   }
 
-  getDartMethod()->cancelAnimationFrame(context->getContextId(), id);
+  getDartMethod(context->getOwner())->cancelAnimationFrame(context->getContextId(), id);
 
   return nullptr;
 }
@@ -296,16 +296,16 @@ JSValueRef requestAnimationFrame(JSContextRef ctx, JSObjectRef function, JSObjec
   // the context pointer which will be pass by pointer address to dart code.
   auto callbackContext = std::make_unique<BridgeCallback::Context>(*context, callbackObjectRef, exception);
 
-  if (getDartMethod()->flushUICommand == nullptr) {
+  if (getDartMethod(context->getOwner())->flushUICommand == nullptr) {
     throwJSError(ctx,
                     "Failed to execute '__kraken_flush_ui_command__': dart method (flushUICommand) is not registered.",
                     exception);
     return nullptr;
   }
   // Flush all pending ui messages.
-  getDartMethod()->flushUICommand();
+  getDartMethod(context->getOwner())->flushUICommand();
 
-  if (getDartMethod()->requestAnimationFrame == nullptr) {
+  if (getDartMethod(context->getOwner())->requestAnimationFrame == nullptr) {
     throwJSError(ctx,
                     "Failed to execute 'requestAnimationFrame': dart method (requestAnimationFrame) is not registered.",
                     exception);
@@ -315,7 +315,7 @@ JSValueRef requestAnimationFrame(JSContextRef ctx, JSObjectRef function, JSObjec
   auto bridge = static_cast<JSBridge *>(context->getOwner());
   int32_t requestId = bridge->bridgeCallback->registerCallback<int32_t>(
     std::move(callbackContext), [](BridgeCallback::Context *callbackContext, int32_t contextId) {
-      return getDartMethod()->requestAnimationFrame(callbackContext, contextId, handleRAFTransientCallback);
+      return getDartMethod(callbackContext->_context.getOwner())->requestAnimationFrame(callbackContext, contextId, handleRAFTransientCallback);
     });
 
   // `-1` represents some error occurred.

--- a/bridge/bindings/jsc/KOM/window.cc
+++ b/bridge/bindings/jsc/KOM/window.cc
@@ -140,8 +140,8 @@ JSValueRef JSWindow::scrollTo(JSContextRef ctx, JSObjectRef function, JSObjectRe
   }
 
   auto window = reinterpret_cast<WindowInstance *>(JSObjectGetPrivate(thisObject));
-    getDartMethod(window->context->getOwner())->flushUICommand();
-    window->nativeWindow->scrollTo(window->nativeWindow, x, y);
+  getDartMethod(window->context->getOwner())->flushUICommand();
+  window->nativeWindow->scrollTo(window->nativeWindow, x, y);
 
   return nullptr;
 }
@@ -163,8 +163,8 @@ JSValueRef JSWindow::scrollBy(JSContextRef ctx, JSObjectRef function, JSObjectRe
   }
 
   auto window = reinterpret_cast<WindowInstance *>(JSObjectGetPrivate(thisObject));
-    getDartMethod(window->context->getOwner())->flushUICommand();
-    window->nativeWindow->scrollBy(window->nativeWindow, x, y);
+  getDartMethod(window->context->getOwner())->flushUICommand();
+  window->nativeWindow->scrollBy(window->nativeWindow, x, y);
 
   return nullptr;
 }

--- a/bridge/bindings/jsc/KOM/window.cc
+++ b/bridge/bindings/jsc/KOM/window.cc
@@ -13,7 +13,7 @@ WindowInstance::WindowInstance(JSWindow *window)
   : EventTargetInstance(window, WINDOW_TARGET_ID), nativeWindow(new NativeWindow(nativeEventTarget)) {
   location_ = new JSLocation(context);
 
-  getDartMethod()->initWindow(window->contextId, nativeWindow);
+  getDartMethod(context->getOwner())->initWindow(window->contextId, nativeWindow);
 }
 
 WindowInstance::~WindowInstance() {
@@ -34,22 +34,22 @@ JSValueRef WindowInstance::getProperty(std::string &name, JSValueRef *exception)
 
     switch (property) {
     case WindowProperty::devicePixelRatio: {
-      if (getDartMethod()->devicePixelRatio == nullptr) {
+      if (getDartMethod(context->getOwner())->devicePixelRatio == nullptr) {
         throwJSError(context->context(),
                         "Failed to read devicePixelRatio: dart method (devicePixelRatio) is not register.", exception);
         return nullptr;
       }
 
-      double devicePixelRatio = getDartMethod()->devicePixelRatio(_hostClass->contextId);
+      double devicePixelRatio = getDartMethod(context->getOwner())->devicePixelRatio(_hostClass->contextId);
       return JSValueMakeNumber(context->context(), devicePixelRatio);
     }
     case WindowProperty::colorScheme: {
-      if (getDartMethod()->platformBrightness == nullptr) {
+      if (getDartMethod(context->getOwner())->platformBrightness == nullptr) {
         throwJSError(context->context(),
                         "Failed to read colorScheme: dart method (platformBrightness) not register.", exception);
         return nullptr;
       }
-      const NativeString *code = getDartMethod()->platformBrightness(_hostClass->contextId);
+      const NativeString *code = getDartMethod(context->getOwner())->platformBrightness(_hostClass->contextId);
       JSStringRef resultRef = JSStringCreateWithCharacters(code->string, code->length);
       return JSValueMakeString(context->context(), resultRef);
     }
@@ -65,11 +65,11 @@ JSValueRef WindowInstance::getProperty(std::string &name, JSValueRef *exception)
       return history;
     }
     case WindowProperty::scrollX: {
-      getDartMethod()->flushUICommand();
+      getDartMethod(context->getOwner())->flushUICommand();
       return JSValueMakeNumber(_hostClass->ctx, nativeWindow->scrollX(nativeWindow));
     }
     case WindowProperty::scrollY: {
-      getDartMethod()->flushUICommand();
+      getDartMethod(context->getOwner())->flushUICommand();
       return JSValueMakeNumber(_hostClass->ctx, nativeWindow->scrollY(nativeWindow));
     }
     }
@@ -139,9 +139,9 @@ JSValueRef JSWindow::scrollTo(JSContextRef ctx, JSObjectRef function, JSObjectRe
     y = JSValueToNumber(ctx, yValueRef, exception);
   }
 
-  getDartMethod()->flushUICommand();
   auto window = reinterpret_cast<WindowInstance *>(JSObjectGetPrivate(thisObject));
-  window->nativeWindow->scrollTo(window->nativeWindow, x, y);
+    getDartMethod(window->context->getOwner())->flushUICommand();
+    window->nativeWindow->scrollTo(window->nativeWindow, x, y);
 
   return nullptr;
 }
@@ -162,9 +162,9 @@ JSValueRef JSWindow::scrollBy(JSContextRef ctx, JSObjectRef function, JSObjectRe
     y = JSValueToNumber(ctx, yValueRef, exception);
   }
 
-  getDartMethod()->flushUICommand();
   auto window = reinterpret_cast<WindowInstance *>(JSObjectGetPrivate(thisObject));
-  window->nativeWindow->scrollBy(window->nativeWindow, x, y);
+    getDartMethod(window->context->getOwner())->flushUICommand();
+    window->nativeWindow->scrollBy(window->nativeWindow, x, y);
 
   return nullptr;
 }

--- a/bridge/bindings/jsc/ui_manager.cc
+++ b/bridge/bindings/jsc/ui_manager.cc
@@ -112,8 +112,8 @@ JSValueRef krakenInvokeModule(JSContextRef ctx, JSObjectRef function, JSObjectRe
     callbackValueRef = JSValueToObject(ctx, arguments[3], exception);
   }
 
-    std::unique_ptr<BridgeCallback::Context> callbackContext = nullptr;
-    auto context = static_cast<JSContext *>(JSObjectGetPrivate(function));
+  std::unique_ptr<BridgeCallback::Context> callbackContext = nullptr;
+  auto context = static_cast<JSContext *>(JSObjectGetPrivate(function));
 
   if (getDartMethod(context->getOwner())->invokeModule == nullptr) {
     throwJSError(ctx, "Failed to execute '__kraken_invoke_module__': dart method (invokeModule) is not registered.",
@@ -143,7 +143,7 @@ JSValueRef krakenInvokeModule(JSContextRef ctx, JSObjectRef function, JSObjectRe
     result = bridge->bridgeCallback->registerCallback<NativeString *>(
       std::move(callbackContext),
       [moduleName, method, params](BridgeCallback::Context *bridgeContext, int32_t contextId) {
-        NativeString *response = getDartMethod(bridgeContext->_context.getOwner())->invokeModule(bridgeContext, contextId, moduleName, method, params,
+        NativeString *response = getDartMethod(bridgeContext->_context.getOwner())->invokeModule(bridgeContext,contextId, moduleName, method, params,
                                                                handleInvokeModuleTransientCallback);
         return response;
       });
@@ -170,8 +170,8 @@ JSValueRef krakenInvokeModule(JSContextRef ctx, JSObjectRef function, JSObjectRe
 
 JSValueRef flushUICommand(JSContextRef ctx, JSObjectRef function, JSObjectRef thisObject, size_t argumentCount,
                           JSValueRef const *arguments, JSValueRef *exception) {
-    std::unique_ptr<BridgeCallback::Context> callbackContext = nullptr;
-    auto context = static_cast<JSContext *>(JSObjectGetPrivate(function));
+  std::unique_ptr<BridgeCallback::Context> callbackContext = nullptr;
+  auto context = static_cast<JSContext *>(JSObjectGetPrivate(function));
   if (getDartMethod(context->getOwner())->flushUICommand == nullptr) {
     throwJSError(ctx,
                  "Failed to execute '__kraken_flush_ui_command__': dart method (flushUICommand) is not registered.",

--- a/bridge/bindings/jsc/ui_manager.cc
+++ b/bridge/bindings/jsc/ui_manager.cc
@@ -112,14 +112,15 @@ JSValueRef krakenInvokeModule(JSContextRef ctx, JSObjectRef function, JSObjectRe
     callbackValueRef = JSValueToObject(ctx, arguments[3], exception);
   }
 
-  if (getDartMethod()->invokeModule == nullptr) {
+    std::unique_ptr<BridgeCallback::Context> callbackContext = nullptr;
+    auto context = static_cast<JSContext *>(JSObjectGetPrivate(function));
+
+  if (getDartMethod(context->getOwner())->invokeModule == nullptr) {
     throwJSError(ctx, "Failed to execute '__kraken_invoke_module__': dart method (invokeModule) is not registered.",
                  exception);
     return nullptr;
   }
 
-  std::unique_ptr<BridgeCallback::Context> callbackContext = nullptr;
-  auto context = static_cast<JSContext *>(JSObjectGetPrivate(function));
 
   NativeString *moduleName = stringRefToNativeString(moduleNameStringRef);
   NativeString *method = stringRefToNativeString(methodStringRef);
@@ -142,12 +143,12 @@ JSValueRef krakenInvokeModule(JSContextRef ctx, JSObjectRef function, JSObjectRe
     result = bridge->bridgeCallback->registerCallback<NativeString *>(
       std::move(callbackContext),
       [moduleName, method, params](BridgeCallback::Context *bridgeContext, int32_t contextId) {
-        NativeString *response = getDartMethod()->invokeModule(bridgeContext, contextId, moduleName, method, params,
+        NativeString *response = getDartMethod(bridgeContext->_context.getOwner())->invokeModule(bridgeContext, contextId, moduleName, method, params,
                                                                handleInvokeModuleTransientCallback);
         return response;
       });
   } else {
-    result = getDartMethod()->invokeModule(callbackContext.get(), context->getContextId(), moduleName, method, params,
+    result = getDartMethod(context->getOwner())->invokeModule(callbackContext.get(), context->getContextId(), moduleName, method, params,
                                            handleInvokeModuleUnexpectedCallback);
   }
 
@@ -169,13 +170,15 @@ JSValueRef krakenInvokeModule(JSContextRef ctx, JSObjectRef function, JSObjectRe
 
 JSValueRef flushUICommand(JSContextRef ctx, JSObjectRef function, JSObjectRef thisObject, size_t argumentCount,
                           JSValueRef const *arguments, JSValueRef *exception) {
-  if (getDartMethod()->flushUICommand == nullptr) {
+    std::unique_ptr<BridgeCallback::Context> callbackContext = nullptr;
+    auto context = static_cast<JSContext *>(JSObjectGetPrivate(function));
+  if (getDartMethod(context->getOwner())->flushUICommand == nullptr) {
     throwJSError(ctx,
                  "Failed to execute '__kraken_flush_ui_command__': dart method (flushUICommand) is not registered.",
                  exception);
     return nullptr;
   }
-  getDartMethod()->flushUICommand();
+  getDartMethod(context->getOwner())->flushUICommand();
   return nullptr;
 }
 

--- a/bridge/bridge_jsc.cc
+++ b/bridge/bridge_jsc.cc
@@ -58,8 +58,9 @@ ConsoleMessageHandler JSBridge::consoleMessageHandler {nullptr};
  * JSRuntime
  */
 JSBridge::JSBridge(int32_t isolateHash, int32_t contextId, const JSExceptionHandler &handler) : isolateHash(isolateHash), contextId(contextId) {
-        ::foundation::UICommandBuffer::instance(contextId)->isolateHash = isolateHash;
-        auto errorHandler = [handler, this](int32_t contextId, const char *errmsg) {
+  //@todo hack maybe add init method
+  ::foundation::UICommandBuffer::instance(contextId)->isolateHash = isolateHash;
+  auto errorHandler = [handler, this](int32_t contextId, const char *errmsg) {
     handler(contextId, errmsg);
     // trigger window.onerror handler.
     // TODO: trigger onerror event.

--- a/bridge/bridge_jsc.cc
+++ b/bridge/bridge_jsc.cc
@@ -57,8 +57,9 @@ ConsoleMessageHandler JSBridge::consoleMessageHandler {nullptr};
 /**
  * JSRuntime
  */
-JSBridge::JSBridge(int32_t contextId, const JSExceptionHandler &handler) : contextId(contextId) {
-  auto errorHandler = [handler, this](int32_t contextId, const char *errmsg) {
+JSBridge::JSBridge(int32_t isolateHash, int32_t contextId, const JSExceptionHandler &handler) : isolateHash(isolateHash), contextId(contextId) {
+        ::foundation::UICommandBuffer::instance(contextId)->isolateHash = isolateHash;
+        auto errorHandler = [handler, this](int32_t contextId, const char *errmsg) {
     handler(contextId, errmsg);
     // trigger window.onerror handler.
     // TODO: trigger onerror event.

--- a/bridge/bridge_jsc.h
+++ b/bridge/bridge_jsc.h
@@ -21,7 +21,7 @@ class JSBridge final {
 public:
   static ConsoleMessageHandler consoleMessageHandler;
   JSBridge() = delete;
-  JSBridge(int32_t jsContext, const JSExceptionHandler &handler);
+  JSBridge(int32_t isolateHash, int32_t jsContext, const JSExceptionHandler &handler);
   ~JSBridge();
 
   static std::unordered_map<std::string, NativeString> pluginSourceCode;
@@ -29,6 +29,7 @@ public:
   std::deque<JSObjectRef> krakenModuleListenerList;
 
   int32_t contextId;
+  int32_t isolateHash;
   foundation::BridgeCallback *bridgeCallback;
   // the owner pointer which take JSBridge as property.
   void *owner;

--- a/bridge/bridge_test_jsc.cc
+++ b/bridge/bridge_test_jsc.cc
@@ -88,7 +88,7 @@ JSValueRef matchImageSnapshot(JSContextRef ctx, JSObjectRef function, JSObjectRe
     return nullptr;
   }
 
-  if (getDartMethod()->matchImageSnapshot == nullptr) {
+  if (getDartMethod(context->getOwner())->matchImageSnapshot == nullptr) {
     binding::jsc::throwJSError(
       ctx, "Failed to execute '__kraken_match_image_snapshot__': dart method (matchImageSnapshot) is not registered.",
       exception);
@@ -122,7 +122,8 @@ JSValueRef matchImageSnapshot(JSContextRef ctx, JSObjectRef function, JSObjectRe
   bridge->bridgeCallback->registerCallback<void>(
     std::move(callbackContext),
     [&blob, &nativeString, &fn](BridgeCallback::Context *callbackContext, int32_t contextId) {
-      getDartMethod()->matchImageSnapshot(callbackContext, contextId, blob->bytes(), blob->size(), &nativeString, fn);
+        auto &_context = callbackContext->_context;
+        getDartMethod(_context.getOwner())->matchImageSnapshot(callbackContext, contextId, blob->bytes(), blob->size(), &nativeString, fn);
     });
 
   return nullptr;
@@ -130,26 +131,26 @@ JSValueRef matchImageSnapshot(JSContextRef ctx, JSObjectRef function, JSObjectRe
 
 JSValueRef environment(JSContextRef ctx, JSObjectRef function, JSObjectRef thisObject, size_t argumentCount,
                        const JSValueRef *arguments, JSValueRef *exception) {
-  if (getDartMethod()->environment == nullptr) {
+    auto context = static_cast<binding::jsc::JSContext *>(JSObjectGetPrivate(function));
+    if (getDartMethod(context->getOwner())->environment == nullptr) {
     binding::jsc::throwJSError(ctx, "Failed to execute '__kraken_environment__': dart method (environment) is not registered.",
                     exception);
     return nullptr;
   }
-  const char *env = getDartMethod()->environment();
+  const char *env = getDartMethod(context->getOwner())->environment();
   JSStringRef envStringRef = JSStringCreateWithUTF8CString(env);
   return JSValueMakeFromJSONString(ctx, envStringRef);
 }
 
 JSValueRef simulatePointer(JSContextRef ctx, JSObjectRef function, JSObjectRef thisObject, size_t argumentCount,
                            const JSValueRef *arguments, JSValueRef *exception) {
-  if (getDartMethod()->simulatePointer == nullptr) {
+    auto context = static_cast<binding::jsc::JSContext *>(JSObjectGetPrivate(function));
+    if (getDartMethod(context->getOwner())->simulatePointer == nullptr) {
     binding::jsc::throwJSError(ctx,
                     "Failed to execute '__kraken_simulate_pointer__': dart method(simulatePointer) is not registered.",
                     exception);
     return nullptr;
   }
-
-  auto context = static_cast<binding::jsc::JSContext *>(JSObjectGetPrivate(function));
 
   const JSValueRef &firstArgsValueRef = arguments[0];
   if (!JSValueIsObject(ctx, firstArgsValueRef)) {
@@ -191,7 +192,7 @@ JSValueRef simulatePointer(JSContextRef ctx, JSObjectRef function, JSObjectRef t
 
   int32_t pointer = JSValueToNumber(ctx, secondArgsValueRef, exception);
 
-  getDartMethod()->simulatePointer(mousePointerList, length, pointer);
+  getDartMethod(context->getOwner())->simulatePointer(mousePointerList, length, pointer);
 
   delete[] mousePointerList;
 
@@ -200,7 +201,9 @@ JSValueRef simulatePointer(JSContextRef ctx, JSObjectRef function, JSObjectRef t
 
 JSValueRef simulateInputText(JSContextRef ctx, JSObjectRef function, JSObjectRef thisObject, size_t argumentCount,
                             const JSValueRef *arguments, JSValueRef *exception) {
-  if (getDartMethod()->simulateInputText == nullptr) {
+    auto context = static_cast<binding::jsc::JSContext *>(JSObjectGetPrivate(function));
+
+    if (getDartMethod(context->getOwner())->simulateInputText == nullptr) {
     binding::jsc::throwJSError(ctx,
                     "Failed to execute '__kraken_simulate_inputtext__': dart method(simulateInputText) is not registered.",
                     exception);
@@ -218,7 +221,7 @@ JSValueRef simulateInputText(JSContextRef ctx, JSObjectRef function, JSObjectRef
   NativeString nativeString{};
   nativeString.length = JSStringGetLength(charsStringRef);
   nativeString.string = JSStringGetCharactersPtr(charsStringRef);
-  getDartMethod()->simulateInputText(&nativeString);
+  getDartMethod(context->getOwner())->simulateInputText(&nativeString);
   JSStringRelease(charsStringRef);
   return nullptr;
 }

--- a/bridge/bridge_test_jsc.cc
+++ b/bridge/bridge_test_jsc.cc
@@ -122,8 +122,8 @@ JSValueRef matchImageSnapshot(JSContextRef ctx, JSObjectRef function, JSObjectRe
   bridge->bridgeCallback->registerCallback<void>(
     std::move(callbackContext),
     [&blob, &nativeString, &fn](BridgeCallback::Context *callbackContext, int32_t contextId) {
-        auto &_context = callbackContext->_context;
-        getDartMethod(_context.getOwner())->matchImageSnapshot(callbackContext, contextId, blob->bytes(), blob->size(), &nativeString, fn);
+      auto &_context = callbackContext->_context;
+      getDartMethod(_context.getOwner())->matchImageSnapshot(callbackContext, contextId, blob->bytes(), blob->size(),&nativeString, fn);
     });
 
   return nullptr;
@@ -131,8 +131,8 @@ JSValueRef matchImageSnapshot(JSContextRef ctx, JSObjectRef function, JSObjectRe
 
 JSValueRef environment(JSContextRef ctx, JSObjectRef function, JSObjectRef thisObject, size_t argumentCount,
                        const JSValueRef *arguments, JSValueRef *exception) {
-    auto context = static_cast<binding::jsc::JSContext *>(JSObjectGetPrivate(function));
-    if (getDartMethod(context->getOwner())->environment == nullptr) {
+  auto context = static_cast<binding::jsc::JSContext *>(JSObjectGetPrivate(function));
+  if (getDartMethod(context->getOwner())->environment == nullptr) {
     binding::jsc::throwJSError(ctx, "Failed to execute '__kraken_environment__': dart method (environment) is not registered.",
                     exception);
     return nullptr;
@@ -144,8 +144,8 @@ JSValueRef environment(JSContextRef ctx, JSObjectRef function, JSObjectRef thisO
 
 JSValueRef simulatePointer(JSContextRef ctx, JSObjectRef function, JSObjectRef thisObject, size_t argumentCount,
                            const JSValueRef *arguments, JSValueRef *exception) {
-    auto context = static_cast<binding::jsc::JSContext *>(JSObjectGetPrivate(function));
-    if (getDartMethod(context->getOwner())->simulatePointer == nullptr) {
+  auto context = static_cast<binding::jsc::JSContext *>(JSObjectGetPrivate(function));
+  if (getDartMethod(context->getOwner())->simulatePointer == nullptr) {
     binding::jsc::throwJSError(ctx,
                     "Failed to execute '__kraken_simulate_pointer__': dart method(simulatePointer) is not registered.",
                     exception);
@@ -201,9 +201,9 @@ JSValueRef simulatePointer(JSContextRef ctx, JSObjectRef function, JSObjectRef t
 
 JSValueRef simulateInputText(JSContextRef ctx, JSObjectRef function, JSObjectRef thisObject, size_t argumentCount,
                             const JSValueRef *arguments, JSValueRef *exception) {
-    auto context = static_cast<binding::jsc::JSContext *>(JSObjectGetPrivate(function));
+  auto context = static_cast<binding::jsc::JSContext *>(JSObjectGetPrivate(function));
 
-    if (getDartMethod(context->getOwner())->simulateInputText == nullptr) {
+  if (getDartMethod(context->getOwner())->simulateInputText == nullptr) {
     binding::jsc::throwJSError(ctx,
                     "Failed to execute '__kraken_simulate_inputtext__': dart method(simulateInputText) is not registered.",
                     exception);

--- a/bridge/dart_methods.cc
+++ b/bridge/dart_methods.cc
@@ -14,7 +14,7 @@ namespace kraken {
 std::shared_ptr<DartMethodPointer> getDartMethod(void* owner) {
     auto bridge = static_cast<kraken::JSBridge*>(owner);
     int32_t isolateHash = bridge->isolateHash;
-    if (std::getenv("ENABLE_KRAKEN_JS_LOG") != nullptr && strcmp(std::getenv("ENABLE_KRAKEN_JS_LOG"), "true") == 0) {
+    if (std::getenv("ENABLE_MULTI_RUNTIME_JS_LOG") != nullptr && strcmp(std::getenv("ENABLE_MULTI_RUNTIME_JS_LOG"), "true") == 0) {
         KRAKEN_LOG(VERBOSE) << "getDartMethod(void* owner)  bridge::--> " << bridge << std::endl;
         KRAKEN_LOG(VERBOSE) << "getDartMethod(void* owner)  bridge::-->isolateHash " << bridge->isolateHash << std::endl;
     }
@@ -26,11 +26,11 @@ std::shared_ptr<DartMethodPointer> getDartMethod(int32_t isolateHash) {
   std::__thread_id currentThread = std::this_thread::get_id();
     std::shared_ptr<DartMethodPointer> methodPointer;
     if(methodPointerMap[isolateHash] == NULL){
-        if (std::getenv("ENABLE_KRAKEN_JS_LOG") != nullptr && strcmp(std::getenv("ENABLE_KRAKEN_JS_LOG"), "true") == 0) {
+        if (std::getenv("ENABLE_MULTI_RUNTIME_JS_LOG") != nullptr && strcmp(std::getenv("ENABLE_MULTI_RUNTIME_JS_LOG"), "true") == 0) {
             KRAKEN_LOG(VERBOSE) << "getDartMethod create isolateHash::--> " << isolateHash << std::endl;
         }
         std::shared_ptr<DartMethodPointer> sharedPtr = std::make_shared<DartMethodPointer>();
-        if (std::getenv("ENABLE_KRAKEN_JS_LOG") != nullptr && strcmp(std::getenv("ENABLE_KRAKEN_JS_LOG"), "true") == 0) {
+        if (std::getenv("ENABLE_MULTI_RUNTIME_JS_LOG") != nullptr && strcmp(std::getenv("ENABLE_MULTI_RUNTIME_JS_LOG"), "true") == 0) {
             KRAKEN_LOG(VERBOSE)<< "getDartMethod create std::shared_ptr<DartMethodPointer> sharedPtr:: " << sharedPtr << std::endl;
         }
         methodPointerMap[isolateHash] = sharedPtr;
@@ -45,7 +45,7 @@ std::shared_ptr<DartMethodPointer> getDartMethod(int32_t isolateHash) {
   // @TODO: implement task loops for async method call.
   if (currentThread != getUIThreadId()) {
     // return empty struct to stop further behavior.
-      if (std::getenv("ENABLE_KRAKEN_JS_LOG") != nullptr && strcmp(std::getenv("ENABLE_KRAKEN_JS_LOG"), "true") == 0) {
+      if (std::getenv("ENABLE_MULTI_RUNTIME_JS_LOG") != nullptr && strcmp(std::getenv("ENABLE_MULTI_RUNTIME_JS_LOG"), "true") == 0) {
           KRAKEN_LOG(VERBOSE)<< "getDartMethod(int32_t isolateHash) getUIThreadId():: " << getUIThreadId() << std::endl;
           KRAKEN_LOG(VERBOSE)<< "getDartMethod(int32_t isolateHash) currentThread != getUIThreadId() true:: methodPointer" << methodPointer<< std::endl;
       }
@@ -59,7 +59,7 @@ std::shared_ptr<DartMethodPointer> getDartMethod(int32_t isolateHash) {
 
 void registerDartMethods(int32_t isolateHash, uint64_t *methodBytes, int32_t length) {
     std::shared_ptr<DartMethodPointer> methodPointer = getDartMethod(isolateHash);
-    if (std::getenv("ENABLE_KRAKEN_JS_LOG") != nullptr && strcmp(std::getenv("ENABLE_KRAKEN_JS_LOG"), "true") == 0) {
+    if (std::getenv("ENABLE_MULTI_RUNTIME_JS_LOG") != nullptr && strcmp(std::getenv("ENABLE_MULTI_RUNTIME_JS_LOG"), "true") == 0) {
         KRAKEN_LOG(VERBOSE) << "registerDartMethods: isolateHash---->>> : " << isolateHash << std::endl;
         KRAKEN_LOG(VERBOSE) << "registerDartMethods: methodPointer: " << methodPointer << std::endl;
         KRAKEN_LOG(VERBOSE) << "registerDartMethods: methodBytes:" << methodBytes << std::endl;

--- a/bridge/foundation/ui_command_buffer.cc
+++ b/bridge/foundation/ui_command_buffer.cc
@@ -8,7 +8,7 @@
 
 namespace foundation {
 
-UICommandBuffer::UICommandBuffer(int32_t contextId) : isolateHash(isolateHash), contextId(contextId) {}
+UICommandBuffer::UICommandBuffer(int32_t contextId) : contextId(contextId) {}
 
 void UICommandBuffer::addCommand(int32_t id, int32_t type, void *nativePtr, bool batchedUpdate) {
   if (batchedUpdate) {
@@ -32,16 +32,16 @@ void UICommandBuffer::addCommand(int32_t id, int32_t type, void *nativePtr) {
 
 void UICommandBuffer::addCommand(int32_t id, int32_t type, NativeString &args_01, void *nativePtr) {
   if (!update_batched) {
-      void * bridge = getJSContext(contextId);
-      std::shared_ptr<kraken::DartMethodPointer> methodPointer = kraken::getDartMethod(isolateHash);
-      if (std::getenv("ENABLE_KRAKEN_JS_LOG") != nullptr && strcmp(std::getenv("ENABLE_KRAKEN_JS_LOG"), "true") == 0) {
-          KRAKEN_LOG(VERBOSE)
-          << " addCommand(int32_t id, int32_t type, NativeString &args_01, void *nativePtr)  bridge::--> " << bridge
-          << std::endl;
-          KRAKEN_LOG(VERBOSE)
-          << " addCommand(int32_t id, int32_t type, NativeString &args_01, void *nativePtr)  methodPointer::--> "
-          << methodPointer << std::endl;
-      }
+    void *bridge = getJSContext(contextId);
+    std::shared_ptr<kraken::DartMethodPointer> methodPointer = kraken::getDartMethod(isolateHash);
+    if (std::getenv("ENABLE_KRAKEN_JS_LOG") != nullptr && strcmp(std::getenv("ENABLE_KRAKEN_JS_LOG"), "true") == 0) {
+      KRAKEN_LOG(VERBOSE)
+      << " addCommand(int32_t id, int32_t type, NativeString &args_01, void *nativePtr)  bridge::--> " << bridge
+      << std::endl;
+      KRAKEN_LOG(VERBOSE)
+      << " addCommand(int32_t id, int32_t type, NativeString &args_01, void *nativePtr)  methodPointer::--> "
+      << methodPointer << std::endl;
+    }
 
     methodPointer->requestBatchUpdate(contextId);
     update_batched = true;

--- a/bridge/foundation/ui_command_buffer.cc
+++ b/bridge/foundation/ui_command_buffer.cc
@@ -8,11 +8,11 @@
 
 namespace foundation {
 
-UICommandBuffer::UICommandBuffer(int32_t contextId) : contextId(contextId) {}
+UICommandBuffer::UICommandBuffer(int32_t contextId) : isolateHash(isolateHash), contextId(contextId) {}
 
 void UICommandBuffer::addCommand(int32_t id, int32_t type, void *nativePtr, bool batchedUpdate) {
   if (batchedUpdate) {
-    kraken::getDartMethod()->requestBatchUpdate(contextId);
+    kraken::getDartMethod(isolateHash)->requestBatchUpdate(contextId);
     update_batched = true;
   }
 
@@ -22,7 +22,7 @@ void UICommandBuffer::addCommand(int32_t id, int32_t type, void *nativePtr, bool
 
 void UICommandBuffer::addCommand(int32_t id, int32_t type, void *nativePtr) {
   if (!update_batched) {
-    kraken::getDartMethod()->requestBatchUpdate(contextId);
+    kraken::getDartMethod(isolateHash)->requestBatchUpdate(contextId);
     update_batched = true;
   }
 
@@ -32,7 +32,18 @@ void UICommandBuffer::addCommand(int32_t id, int32_t type, void *nativePtr) {
 
 void UICommandBuffer::addCommand(int32_t id, int32_t type, NativeString &args_01, void *nativePtr) {
   if (!update_batched) {
-    kraken::getDartMethod()->requestBatchUpdate(contextId);
+      void * bridge = getJSContext(contextId);
+      std::shared_ptr<kraken::DartMethodPointer> methodPointer = kraken::getDartMethod(isolateHash);
+      if (std::getenv("ENABLE_KRAKEN_JS_LOG") != nullptr && strcmp(std::getenv("ENABLE_KRAKEN_JS_LOG"), "true") == 0) {
+          KRAKEN_LOG(VERBOSE)
+          << " addCommand(int32_t id, int32_t type, NativeString &args_01, void *nativePtr)  bridge::--> " << bridge
+          << std::endl;
+          KRAKEN_LOG(VERBOSE)
+          << " addCommand(int32_t id, int32_t type, NativeString &args_01, void *nativePtr)  methodPointer::--> "
+          << methodPointer << std::endl;
+      }
+
+    methodPointer->requestBatchUpdate(contextId);
     update_batched = true;
   }
 
@@ -43,7 +54,7 @@ void UICommandBuffer::addCommand(int32_t id, int32_t type, NativeString &args_01
 void UICommandBuffer::addCommand(int32_t id, int32_t type, NativeString &args_01, NativeString &args_02,
                                                 void *nativePtr) {
   if (!update_batched) {
-    kraken::getDartMethod()->requestBatchUpdate(contextId);
+    kraken::getDartMethod(getJSContext(contextId))->requestBatchUpdate(contextId);
     update_batched = true;
   }
   UICommandItem item{id, type, args_01, args_02, nativePtr};

--- a/bridge/foundation/ui_command_buffer.cc
+++ b/bridge/foundation/ui_command_buffer.cc
@@ -34,7 +34,7 @@ void UICommandBuffer::addCommand(int32_t id, int32_t type, NativeString &args_01
   if (!update_batched) {
     void *bridge = getJSContext(contextId);
     std::shared_ptr<kraken::DartMethodPointer> methodPointer = kraken::getDartMethod(isolateHash);
-    if (std::getenv("ENABLE_KRAKEN_JS_LOG") != nullptr && strcmp(std::getenv("ENABLE_KRAKEN_JS_LOG"), "true") == 0) {
+    if (std::getenv("ENABLE_MULTI_RUNTIME_JS_LOG") != nullptr && strcmp(std::getenv("ENABLE_MULTI_RUNTIME_JS_LOG"), "true") == 0) {
       KRAKEN_LOG(VERBOSE)
       << " addCommand(int32_t id, int32_t type, NativeString &args_01, void *nativePtr)  bridge::--> " << bridge
       << std::endl;

--- a/bridge/include/dart_methods.h
+++ b/bridge/include/dart_methods.h
@@ -7,6 +7,7 @@
 #define KRAKEN_DART_METHODS_H_
 
 #include "kraken_bridge.h"
+#include "kraken_bridge_jsc.h"
 
 #ifdef ENABLE_TEST
 #include "kraken_bridge_test.h"
@@ -94,7 +95,7 @@ struct DartMethodPointer {
   InitDocument initDocument{nullptr};
 };
 
-void registerDartMethods(uint64_t *methodBytes, int32_t length);
+void registerDartMethods(int32_t isolateHash, uint64_t *methodBytes, int32_t length);
 
 #ifdef IS_TEST
 KRAKEN_EXPORT
@@ -102,7 +103,10 @@ void registerTestEnvDartMethods(uint64_t *methodBytes, int32_t length);
 #endif
 
 KRAKEN_EXPORT
-std::shared_ptr<DartMethodPointer> getDartMethod();
+std::shared_ptr<DartMethodPointer> getDartMethod(void* owner);
+
+KRAKEN_EXPORT
+std::shared_ptr<DartMethodPointer> getDartMethod(int32_t keyHash);
 
 } // namespace kraken
 

--- a/bridge/include/kraken_bridge.h
+++ b/bridge/include/kraken_bridge.h
@@ -84,11 +84,11 @@ typedef void (*Task)(void *);
 typedef void (*ConsoleMessageHandler)(void* ctx, const std::string &message, int logLevel);
 
 KRAKEN_EXPORT_C
-void initJSContextPool(int poolSize);
+int32_t initJSContextPool(int32_t isolateHash, int poolSize);
 KRAKEN_EXPORT_C
 void disposeContext(int32_t contextId);
 KRAKEN_EXPORT_C
-int32_t allocateNewContext(int32_t targetContextId);
+int32_t allocateNewContext(int32_t isolateHash, int32_t targetContextId);
 KRAKEN_EXPORT_C
 void *getJSContext(int32_t contextId);
 bool checkContext(int32_t contextId);
@@ -101,7 +101,7 @@ KRAKEN_EXPORT_C
 void invokeModuleEvent(int32_t contextId, NativeString *module, const char *eventType, void *event,
                        NativeString *extra);
 KRAKEN_EXPORT_C
-void registerDartMethods(uint64_t *methodBytes, int32_t length);
+void registerDartMethods(int32_t isolateHash, uint64_t *methodBytes, int32_t length);
 KRAKEN_EXPORT_C
 Screen *createScreen(double width, double height);
 KRAKEN_EXPORT_C

--- a/bridge/include/kraken_foundation.h
+++ b/bridge/include/kraken_foundation.h
@@ -75,7 +75,7 @@ public:
   KRAKEN_EXPORT UICommandItem *data();
   KRAKEN_EXPORT int64_t size();
   KRAKEN_EXPORT void clear();
-    int32_t isolateHash;
+  int32_t isolateHash;
 
 private:
   int32_t contextId;

--- a/bridge/include/kraken_foundation.h
+++ b/bridge/include/kraken_foundation.h
@@ -75,6 +75,7 @@ public:
   KRAKEN_EXPORT UICommandItem *data();
   KRAKEN_EXPORT int64_t size();
   KRAKEN_EXPORT void clear();
+    int32_t isolateHash;
 
 private:
   int32_t contextId;

--- a/bridge/kraken_bridge.cc
+++ b/bridge/kraken_bridge.cc
@@ -56,8 +56,8 @@ std::__thread_id getUIThreadId() {
   return uiThreadId;
 }
 
-void printError(int32_t contextId, const char* errmsg) {
-    kraken::JSBridge* bridge = static_cast<kraken::JSBridge* >(getJSContext(contextId));
+void printError(int32_t contextId, const char *errmsg) {
+  kraken::JSBridge *bridge = static_cast<kraken::JSBridge * >(getJSContext(contextId));
   if (kraken::getDartMethod(bridge)->onJsError != nullptr) {
     kraken::getDartMethod(bridge)->onJsError(contextId, errmsg);
   }
@@ -67,12 +67,12 @@ void printError(int32_t contextId, const char* errmsg) {
 namespace {
 
 void disposeAllBridge() {
-    if (std::getenv("ENABLE_KRAKEN_JS_LOG") != nullptr && strcmp(std::getenv("ENABLE_KRAKEN_JS_LOG"), "true") == 0) {
-        KRAKEN_LOG(VERBOSE) << "disposeAllBridge" << std::endl;
-    }
-    for (int i = 0; i <= poolIndex && i < maxPoolSize; i++) {
-        disposeContext(i);
-    }
+  if (std::getenv("ENABLE_KRAKEN_JS_LOG") != nullptr && strcmp(std::getenv("ENABLE_KRAKEN_JS_LOG"), "true") == 0) {
+    KRAKEN_LOG(VERBOSE) << "disposeAllBridge" << std::endl;
+  }
+  for (int i = 0; i <= poolIndex && i < maxPoolSize; i++) {
+    disposeContext(i);
+  }
   poolIndex = 0;
   inited = false;
 }
@@ -89,40 +89,40 @@ int32_t searchForAvailableContextId() {
 } // namespace
 
 int32_t initJSContextPool(int32_t isolateHash, int poolSize) {
-    std::lock_guard<std::recursive_mutex> guard(bridge_runtime_mutex_);
-    uiThreadId = std::this_thread::get_id();
-    if (std::getenv("ENABLE_KRAKEN_JS_LOG") != nullptr && strcmp(std::getenv("ENABLE_KRAKEN_JS_LOG"), "true") == 0) {
-        KRAKEN_LOG(VERBOSE) << "initJSContextPool" << inited << std::endl;
-        KRAKEN_LOG(VERBOSE) << "initJSContextPool isolateHash::--> " << isolateHash << std::endl;
-        KRAKEN_LOG(VERBOSE) << "initJSContextPool uiThreadId::--> " << uiThreadId << std::endl;
-    }
-    // When dart hot restarted, should dispose previous bridge and clear task message queue.
-    if (!inited) {
+  std::lock_guard<std::recursive_mutex> guard(bridge_runtime_mutex_);
+  uiThreadId = std::this_thread::get_id();
+  if (std::getenv("ENABLE_KRAKEN_JS_LOG") != nullptr && strcmp(std::getenv("ENABLE_KRAKEN_JS_LOG"), "true") == 0) {
+    KRAKEN_LOG(VERBOSE) << "initJSContextPool" << inited << std::endl;
+    KRAKEN_LOG(VERBOSE) << "initJSContextPool isolateHash::--> " << isolateHash << std::endl;
+    KRAKEN_LOG(VERBOSE) << "initJSContextPool uiThreadId::--> " << uiThreadId << std::endl;
+  }
+  // When dart hot restarted, should dispose previous bridge and clear task message queue.
+  if (!inited) {
 //        if (inited) {
 //            disposeAllBridge();
-//            foundation::UICommandBuffer::instance(0)->isolateHash = isolateHash;
+//            ::foundation::UICommandBuffer::instance(0)->isolateHash = isolateHash;
 //            foundation::UICommandBuffer::instance(0)->clear();
 //        };
-        contextPool = new kraken::JSBridge *[poolSize];
-        for (int i = 1; i < poolSize; i++) {
-            contextPool[i] = nullptr;
-        }
-
-        inited = true;
-        maxPoolSize = poolSize;
+    contextPool = new kraken::JSBridge *[poolSize];
+    for (int i = 1; i < poolSize; i++) {
+      contextPool[i] = nullptr;
     }
 
-    poolIndex++;
-      contextPool[poolIndex] = new kraken::JSBridge(isolateHash, poolIndex, printError);
-    return poolIndex;
+    inited = true;
+    maxPoolSize = poolSize;
+  }
+
+  poolIndex++;
+  contextPool[poolIndex] = new kraken::JSBridge(isolateHash, poolIndex, printError);
+  return poolIndex;
 }
 
 void disposeContext(int32_t contextId) {
-    std::lock_guard<std::recursive_mutex> guard(bridge_runtime_mutex_);
-    if (std::getenv("ENABLE_KRAKEN_JS_LOG") != nullptr && strcmp(std::getenv("ENABLE_KRAKEN_JS_LOG"), "true") == 0) {
-        KRAKEN_LOG(VERBOSE) << "disposeContext" << contextId << std::endl;
-    }
-    assert(contextId < maxPoolSize);
+  std::lock_guard<std::recursive_mutex> guard(bridge_runtime_mutex_);
+  if (std::getenv("ENABLE_KRAKEN_JS_LOG") != nullptr && strcmp(std::getenv("ENABLE_KRAKEN_JS_LOG"), "true") == 0) {
+    KRAKEN_LOG(VERBOSE) << "disposeContext" << contextId << std::endl;
+  }
+  assert(contextId < maxPoolSize);
   if (contextPool[contextId] == nullptr) return;
   auto context = static_cast<kraken::JSBridge *>(contextPool[contextId]);
   delete context;
@@ -147,8 +147,8 @@ int32_t allocateNewContext(int32_t isolateHash, int32_t targetContextId) {
                                                 .c_str());
 
   auto context = new kraken::JSBridge(isolateHash, targetContextId, printError);
-    foundation::UICommandBuffer::instance(targetContextId)->isolateHash = isolateHash;
-    contextPool[targetContextId] = context;
+  foundation::UICommandBuffer::instance(targetContextId)->isolateHash = isolateHash;
+  contextPool[targetContextId] = context;
   return targetContextId;
 }
 
@@ -165,13 +165,13 @@ void *getJSContext(int32_t contextId) {
 }
 
 bool checkContext(int32_t contextId) {
-    std::lock_guard<std::recursive_mutex> guard(bridge_runtime_mutex_);
-    return inited && contextId < maxPoolSize && contextPool[contextId] != nullptr;
+  std::lock_guard<std::recursive_mutex> guard(bridge_runtime_mutex_);
+  return inited && contextId < maxPoolSize && contextPool[contextId] != nullptr;
 }
 
 bool checkContext(int32_t contextId, void *context) {
-    std::lock_guard<std::recursive_mutex> guard(bridge_runtime_mutex_);
-    if (contextPool[contextId] == nullptr) return false;
+  std::lock_guard<std::recursive_mutex> guard(bridge_runtime_mutex_);
+  if (contextPool[contextId] == nullptr) return false;
   auto bridge = static_cast<kraken::JSBridge *>(getJSContext(contextId));
   return bridge->getContext().get() == context;
 }
@@ -183,8 +183,8 @@ void evaluateScripts(int32_t contextId, NativeString *code, const char *bundleFi
 }
 
 void reloadJsContext(int32_t contextId) {
-    std::lock_guard<std::recursive_mutex> guard(bridge_runtime_mutex_);
-    assert(checkContext(contextId) && "reloadJSContext: contextId is not valid");
+  std::lock_guard<std::recursive_mutex> guard(bridge_runtime_mutex_);
+  assert(checkContext(contextId) && "reloadJSContext: contextId is not valid");
   auto bridgePtr = getJSContext(contextId);
   auto context = static_cast<kraken::JSBridge *>(bridgePtr);
   auto newContext = new kraken::JSBridge(context->isolateHash, contextId, printError);

--- a/bridge/kraken_bridge.cc
+++ b/bridge/kraken_bridge.cc
@@ -67,7 +67,7 @@ void printError(int32_t contextId, const char *errmsg) {
 namespace {
 
 void disposeAllBridge() {
-  if (std::getenv("ENABLE_KRAKEN_JS_LOG") != nullptr && strcmp(std::getenv("ENABLE_KRAKEN_JS_LOG"), "true") == 0) {
+  if (std::getenv("ENABLE_MULTI_RUNTIME_JS_LOG") != nullptr && strcmp(std::getenv("ENABLE_MULTI_RUNTIME_JS_LOG"), "true") == 0) {
     KRAKEN_LOG(VERBOSE) << "disposeAllBridge" << std::endl;
   }
   for (int i = 0; i <= poolIndex && i < maxPoolSize; i++) {
@@ -91,7 +91,7 @@ int32_t searchForAvailableContextId() {
 int32_t initJSContextPool(int32_t isolateHash, int poolSize) {
   std::lock_guard<std::recursive_mutex> guard(bridge_runtime_mutex_);
   uiThreadId = std::this_thread::get_id();
-  if (std::getenv("ENABLE_KRAKEN_JS_LOG") != nullptr && strcmp(std::getenv("ENABLE_KRAKEN_JS_LOG"), "true") == 0) {
+  if (std::getenv("ENABLE_MULTI_RUNTIME_JS_LOG") != nullptr && strcmp(std::getenv("ENABLE_MULTI_RUNTIME_JS_LOG"), "true") == 0) {
     KRAKEN_LOG(VERBOSE) << "initJSContextPool" << inited << std::endl;
     KRAKEN_LOG(VERBOSE) << "initJSContextPool isolateHash::--> " << isolateHash << std::endl;
     KRAKEN_LOG(VERBOSE) << "initJSContextPool uiThreadId::--> " << uiThreadId << std::endl;
@@ -119,7 +119,7 @@ int32_t initJSContextPool(int32_t isolateHash, int poolSize) {
 
 void disposeContext(int32_t contextId) {
   std::lock_guard<std::recursive_mutex> guard(bridge_runtime_mutex_);
-  if (std::getenv("ENABLE_KRAKEN_JS_LOG") != nullptr && strcmp(std::getenv("ENABLE_KRAKEN_JS_LOG"), "true") == 0) {
+  if (std::getenv("ENABLE_MULTI_RUNTIME_JS_LOG") != nullptr && strcmp(std::getenv("ENABLE_MULTI_RUNTIME_JS_LOG"), "true") == 0) {
     KRAKEN_LOG(VERBOSE) << "disposeContext" << contextId << std::endl;
   }
   assert(contextId < maxPoolSize);
@@ -154,7 +154,7 @@ int32_t allocateNewContext(int32_t isolateHash, int32_t targetContextId) {
 
 void *getJSContext(int32_t contextId) {
     std::lock_guard<std::recursive_mutex> guard(bridge_runtime_mutex_);
-    if (std::getenv("ENABLE_KRAKEN_JS_LOG") != nullptr && strcmp(std::getenv("ENABLE_KRAKEN_JS_LOG"), "true") == 0) {
+    if (std::getenv("ENABLE_MULTI_RUNTIME_JS_LOG") != nullptr && strcmp(std::getenv("ENABLE_MULTI_RUNTIME_JS_LOG"), "true") == 0) {
         KRAKEN_LOG(VERBOSE) << "getJSContext:: contextId " << contextId << std::endl;
         KRAKEN_LOG(VERBOSE) << "getJSContext:: contextPool[contextId] " << contextPool[contextId] << std::endl;
     }

--- a/bridge/kraken_bridge.cc
+++ b/bridge/kraken_bridge.cc
@@ -44,10 +44,11 @@
 
 // this is not thread safe
 std::atomic<bool> inited{false};
-std::atomic<int32_t> poolIndex{0};
+std::atomic<int32_t> poolIndex{-1};
 int maxPoolSize = 0;
 kraken::JSBridge **contextPool;
 Screen screen;
+std::recursive_mutex bridge_runtime_mutex_;
 
 std::__thread_id uiThreadId;
 
@@ -56,8 +57,9 @@ std::__thread_id getUIThreadId() {
 }
 
 void printError(int32_t contextId, const char* errmsg) {
-  if (kraken::getDartMethod()->onJsError != nullptr) {
-    kraken::getDartMethod()->onJsError(contextId, errmsg);
+    kraken::JSBridge* bridge = static_cast<kraken::JSBridge* >(getJSContext(contextId));
+  if (kraken::getDartMethod(bridge)->onJsError != nullptr) {
+    kraken::getDartMethod(bridge)->onJsError(contextId, errmsg);
   }
   KRAKEN_LOG(ERROR) << errmsg << std::endl;
 }
@@ -65,9 +67,12 @@ void printError(int32_t contextId, const char* errmsg) {
 namespace {
 
 void disposeAllBridge() {
-  for (int i = 0; i <= poolIndex && i < maxPoolSize; i++) {
-    disposeContext(i);
-  }
+    if (std::getenv("ENABLE_KRAKEN_JS_LOG") != nullptr && strcmp(std::getenv("ENABLE_KRAKEN_JS_LOG"), "true") == 0) {
+        KRAKEN_LOG(VERBOSE) << "disposeAllBridge" << std::endl;
+    }
+    for (int i = 0; i <= poolIndex && i < maxPoolSize; i++) {
+        disposeContext(i);
+    }
   poolIndex = 0;
   inited = false;
 }
@@ -83,25 +88,41 @@ int32_t searchForAvailableContextId() {
 
 } // namespace
 
-void initJSContextPool(int poolSize) {
-  uiThreadId = std::this_thread::get_id();
-  // When dart hot restarted, should dispose previous bridge and clear task message queue.
-  if (inited) {
-    disposeAllBridge();
-    foundation::UICommandBuffer::instance(0)->clear();
-  };
-  contextPool = new kraken::JSBridge *[poolSize];
-  for (int i = 1; i < poolSize; i++) {
-    contextPool[i] = nullptr;
-  }
+int32_t initJSContextPool(int32_t isolateHash, int poolSize) {
+    std::lock_guard<std::recursive_mutex> guard(bridge_runtime_mutex_);
+    uiThreadId = std::this_thread::get_id();
+    if (std::getenv("ENABLE_KRAKEN_JS_LOG") != nullptr && strcmp(std::getenv("ENABLE_KRAKEN_JS_LOG"), "true") == 0) {
+        KRAKEN_LOG(VERBOSE) << "initJSContextPool" << inited << std::endl;
+        KRAKEN_LOG(VERBOSE) << "initJSContextPool isolateHash::--> " << isolateHash << std::endl;
+        KRAKEN_LOG(VERBOSE) << "initJSContextPool uiThreadId::--> " << uiThreadId << std::endl;
+    }
+    // When dart hot restarted, should dispose previous bridge and clear task message queue.
+    if (!inited) {
+//        if (inited) {
+//            disposeAllBridge();
+//            foundation::UICommandBuffer::instance(0)->isolateHash = isolateHash;
+//            foundation::UICommandBuffer::instance(0)->clear();
+//        };
+        contextPool = new kraken::JSBridge *[poolSize];
+        for (int i = 1; i < poolSize; i++) {
+            contextPool[i] = nullptr;
+        }
 
-  contextPool[0] = new kraken::JSBridge(0, printError);
-  inited = true;
-  maxPoolSize = poolSize;
+        inited = true;
+        maxPoolSize = poolSize;
+    }
+
+    poolIndex++;
+      contextPool[poolIndex] = new kraken::JSBridge(isolateHash, poolIndex, printError);
+    return poolIndex;
 }
 
 void disposeContext(int32_t contextId) {
-  assert(contextId < maxPoolSize);
+    std::lock_guard<std::recursive_mutex> guard(bridge_runtime_mutex_);
+    if (std::getenv("ENABLE_KRAKEN_JS_LOG") != nullptr && strcmp(std::getenv("ENABLE_KRAKEN_JS_LOG"), "true") == 0) {
+        KRAKEN_LOG(VERBOSE) << "disposeContext" << contextId << std::endl;
+    }
+    assert(contextId < maxPoolSize);
   if (contextPool[contextId] == nullptr) return;
   auto context = static_cast<kraken::JSBridge *>(contextPool[contextId]);
   delete context;
@@ -112,7 +133,7 @@ void disposeContext(int32_t contextId) {
 #endif
 }
 
-int32_t allocateNewContext(int32_t targetContextId) {
+int32_t allocateNewContext(int32_t isolateHash, int32_t targetContextId) {
   if (targetContextId == -1) {
     targetContextId = ++poolIndex;
   }
@@ -124,22 +145,33 @@ int32_t allocateNewContext(int32_t targetContextId) {
   assert(contextPool[targetContextId] == nullptr && (std::string("can not allocate JSBridge at index") +
                                                std::to_string(targetContextId) + std::string(": bridge have already exist."))
                                                 .c_str());
-  auto context = new kraken::JSBridge(targetContextId, printError);
-  contextPool[targetContextId] = context;
+
+  auto context = new kraken::JSBridge(isolateHash, targetContextId, printError);
+    foundation::UICommandBuffer::instance(targetContextId)->isolateHash = isolateHash;
+    contextPool[targetContextId] = context;
   return targetContextId;
 }
 
 void *getJSContext(int32_t contextId) {
-  assert(checkContext(contextId) && "getJSContext: contextId is not valid.");
+    std::lock_guard<std::recursive_mutex> guard(bridge_runtime_mutex_);
+    if (std::getenv("ENABLE_KRAKEN_JS_LOG") != nullptr && strcmp(std::getenv("ENABLE_KRAKEN_JS_LOG"), "true") == 0) {
+        KRAKEN_LOG(VERBOSE) << "getJSContext:: contextId " << contextId << std::endl;
+        KRAKEN_LOG(VERBOSE) << "getJSContext:: contextPool[contextId] " << contextPool[contextId] << std::endl;
+    }
+    kraken::JSBridge* bridge = static_cast<kraken::JSBridge* >(contextPool[contextId]);
+
+//    assert(checkContext(contextId) && "getJSContext: contextId is not valid.");
   return contextPool[contextId];
 }
 
 bool checkContext(int32_t contextId) {
-  return inited && contextId < maxPoolSize && contextPool[contextId] != nullptr;
+    std::lock_guard<std::recursive_mutex> guard(bridge_runtime_mutex_);
+    return inited && contextId < maxPoolSize && contextPool[contextId] != nullptr;
 }
 
 bool checkContext(int32_t contextId, void *context) {
-  if (contextPool[contextId] == nullptr) return false;
+    std::lock_guard<std::recursive_mutex> guard(bridge_runtime_mutex_);
+    if (contextPool[contextId] == nullptr) return false;
   auto bridge = static_cast<kraken::JSBridge *>(getJSContext(contextId));
   return bridge->getContext().get() == context;
 }
@@ -151,10 +183,11 @@ void evaluateScripts(int32_t contextId, NativeString *code, const char *bundleFi
 }
 
 void reloadJsContext(int32_t contextId) {
-  assert(checkContext(contextId) && "reloadJSContext: contextId is not valid");
+    std::lock_guard<std::recursive_mutex> guard(bridge_runtime_mutex_);
+    assert(checkContext(contextId) && "reloadJSContext: contextId is not valid");
   auto bridgePtr = getJSContext(contextId);
   auto context = static_cast<kraken::JSBridge *>(bridgePtr);
-  auto newContext = new kraken::JSBridge(contextId, printError);
+  auto newContext = new kraken::JSBridge(context->isolateHash, contextId, printError);
   delete context;
   contextPool[contextId] = newContext;
 }
@@ -165,8 +198,8 @@ void invokeModuleEvent(int32_t contextId, NativeString *moduleName, const char *
   context->invokeModuleEvent(moduleName, eventType, event, extra);
 }
 
-void registerDartMethods(uint64_t *methodBytes, int32_t length) {
-  kraken::registerDartMethods(methodBytes, length);
+void registerDartMethods(int32_t isolateHash, uint64_t *methodBytes, int32_t length) {
+  kraken::registerDartMethods(isolateHash, methodBytes, length);
 }
 
 Screen *createScreen(double width, double height) {

--- a/kraken/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/kraken/example/ios/Runner.xcodeproj/project.pbxproj
@@ -203,39 +203,12 @@
 			buildActionMask = 2147483647;
 			files = (
 			);
-			inputPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks.sh",
-				"${PODS_ROOT}/../Flutter/Flutter.framework",
-				"${BUILT_PRODUCTS_DIR}/Reachability/Reachability.framework",
-				"${BUILT_PRODUCTS_DIR}/audioplayers/audioplayers.framework",
-				"${BUILT_PRODUCTS_DIR}/connectivity/connectivity.framework",
-				"${BUILT_PRODUCTS_DIR}/device_info/device_info.framework",
-				"${PODS_ROOT}/../.symlinks/plugins/kraken/ios/kraken_bridge.framework",
-				"${BUILT_PRODUCTS_DIR}/kraken/kraken.framework",
-				"${BUILT_PRODUCTS_DIR}/kraken_camera/kraken_camera.framework",
-				"${BUILT_PRODUCTS_DIR}/kraken_geolocation/kraken_geolocation.framework",
-				"${BUILT_PRODUCTS_DIR}/kraken_video_player/kraken_video_player.framework",
-				"${BUILT_PRODUCTS_DIR}/kraken_webview/kraken_webview.framework",
-				"${BUILT_PRODUCTS_DIR}/path_provider/path_provider.framework",
-				"${BUILT_PRODUCTS_DIR}/shared_preferences/shared_preferences.framework",
-				"${BUILT_PRODUCTS_DIR}/vibration/vibration.framework",
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-input-files.xcfilelist",
 			);
 			name = "[CP] Embed Pods Frameworks";
-			outputPaths = (
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Flutter.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Reachability.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/audioplayers.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/connectivity.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/device_info.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/kraken_bridge.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/kraken.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/kraken_camera.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/kraken_geolocation.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/kraken_video_player.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/kraken_webview.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/path_provider.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/shared_preferences.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/vibration.framework",
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-output-files.xcfilelist",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;

--- a/kraken/example/ios/Runner.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/kraken/example/ios/Runner.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -2,6 +2,6 @@
 <Workspace
    version = "1.0">
    <FileRef
-      location = "group:Runner.xcodeproj">
+      location = "self:">
    </FileRef>
 </Workspace>

--- a/kraken/ios/kraken_bridge.framework
+++ b/kraken/ios/kraken_bridge.framework
@@ -1,1 +1,1 @@
-../../bridge/build/ios/framework/kraken_bridge.framework
+/Users/tylorvan/youku_kraken/arranged/openkraken/kraken/kraken/ios/../../bridge/build/ios/framework/kraken_bridge.framework

--- a/kraken/lib/src/bridge/bridge.dart
+++ b/kraken/lib/src/bridge/bridge.dart
@@ -44,9 +44,8 @@ int initBridge() {
   }
 
   if (_firstView) {
-    initJSContextPool(kKrakenJSBridgePoolSize);
+    contextId =  initJSContextPool(kKrakenJSBridgePoolSize);
     _firstView = false;
-    contextId = 0;
   } else {
     contextId = allocateNewContext();
     if (contextId == -1) {

--- a/kraken/lib/src/bridge/from_native.dart
+++ b/kraken/lib/src/bridge/from_native.dart
@@ -1,5 +1,6 @@
 import 'dart:convert';
 import 'dart:ffi';
+import 'dart:isolate';
 import 'dart:typed_data';
 import 'dart:ui';
 
@@ -374,8 +375,8 @@ final List<int> _dartNativeMethods = [
   _nativeOnJsError.address,
 ];
 
-typedef NativeRegisterDartMethods = Void Function(Pointer<Uint64> methodBytes, Int32 length);
-typedef DartRegisterDartMethods = void Function(Pointer<Uint64> methodBytes, int length);
+typedef NativeRegisterDartMethods = Void Function(Int32 isolateHash, Pointer<Uint64> methodBytes, Int32 length);
+typedef DartRegisterDartMethods = void Function(int isolateHash,Pointer<Uint64> methodBytes, int length);
 
 final DartRegisterDartMethods _registerDartMethods =
     nativeDynamicLibrary.lookup<NativeFunction<NativeRegisterDartMethods>>('registerDartMethods').asFunction();
@@ -384,5 +385,9 @@ void registerDartMethodsToCpp() {
   Pointer<Uint64> bytes = malloc.allocate<Uint64>(sizeOf<Uint64>() * _dartNativeMethods.length);
   Uint64List nativeMethodList = bytes.asTypedList(_dartNativeMethods.length);
   nativeMethodList.setAll(0, _dartNativeMethods);
-  _registerDartMethods(bytes, _dartNativeMethods.length);
+  //todo tobe remove
+  print('nativeMethodList[0]' + nativeMethodList[0].toString());
+  print('_dartNativeMethods[0]' + _dartNativeMethods[0].toString());
+  print('_nativeInvokeModule.address' + _nativeInvokeModule.address.toString());
+  _registerDartMethods(Isolate.current.hashCode, bytes, _dartNativeMethods.length);
 }

--- a/kraken/lib/src/bridge/to_native.dart
+++ b/kraken/lib/src/bridge/to_native.dart
@@ -137,7 +137,7 @@ final DartInitJSContextPool _initJSContextPool =
     nativeDynamicLibrary.lookup<NativeFunction<NativeInitJSContextPool>>('initJSContextPool').asFunction();
 
 int initJSContextPool(int poolSize) {
-  if(kDebugMode) {
+  if (kDebugMode) {
     print("KrakenTy initJSContextPool poolSize[$poolSize]");
   }
   int isolateHash = Isolate.current.hashCode;
@@ -162,7 +162,7 @@ final DartAllocateNewContext _allocateNewContext =
 
 int allocateNewContext([int targetContextId = -1]) {
   int ret = _allocateNewContext(Isolate.current.hashCode, targetContextId);
-  if(kDebugMode) {
+  if (kDebugMode) {
     print("KrakenTy allocateNewContext[$ret]");
   }
   return ret;

--- a/kraken/lib/src/launcher/controller.dart
+++ b/kraken/lib/src/launcher/controller.dart
@@ -172,6 +172,9 @@ class KrakenViewController {
 
   void evaluateJavaScripts(String code, [String source = 'kraken://']) {
     assert(!_disposed, "Kraken have already disposed");
+    if (kDebugMode) {
+      print("KrakenTy evaluateScripts evaluateJavaScripts contextId[$contextId] url[$code]");
+    }
     evaluateScripts(_contextId, code, source, 0);
   }
 


### PR DESCRIPTION
功能：
1. Bridge 支持 Flutter 多 Engine 实例
2. Flutter 2.x 版本添加了 Flutter 多 Engine 支持，现在 Bridge 还不支持同时面向多 Dart Isolate 的情况。

修改点:
1. 新增isolateHash 概念标记Bridge 归属，并进行多引擎派发，并解决多线程资源抢占问题
2. jscontext 默认值 -1
2. getDartMethod 新增isolateHash