### PR TITLE
fix: kraken widget size

### DIFF
--- a/kraken/lib/src/rendering/viewport.dart
+++ b/kraken/lib/src/rendering/viewport.dart
@@ -64,16 +64,15 @@ class RenderViewportBox extends RenderProxyBox
 
   @override
   void performLayout() {
-    double maxWidth = window.physicalSize.width / window.devicePixelRatio;
-    double maxHeight = window.physicalSize.height / window.devicePixelRatio;
-    size = constraints.constrain(Size(maxWidth, maxHeight));
+    double width = _viewportSize.width;
+    double height = _viewportSize.height - _bottomInset;
+    if (height.isNegative || height.isNaN) {
+      height = _viewportSize.height;
+    }
+    size = constraints.constrain(Size(width, height));
     if (child != null) {
-      double height = _viewportSize.height - _bottomInset;
-      if (height.isNegative || height.isNaN) {
-        height = _viewportSize.height;
-      }
       child!.layout(BoxConstraints.tightFor(
-        width: _viewportSize.width,
+        width: width,
         height: height,
       ));
     }


### PR DESCRIPTION
Closes https://github.com/openkraken/kraken/issues/556

* 修复 Kraken widget size 不对，不应该使用屏幕宽高，而应该使用 widget 上设置的 viewportWidth/viewportHeight。