### PR TITLE
fix: input can not focus when hitting enter key

### DIFF
--- a/kraken/lib/src/dom/elements/input.dart
+++ b/kraken/lib/src/dom/elements/input.dart
@@ -449,7 +449,7 @@ class InputElement extends Element implements TextInputClient, TickerProvider {
     switch (action) {
       case TextInputAction.done:
         _triggerChangeEvent();
-        blur();
+        InputElement.clearFocus();
         break;
       case TextInputAction.none:
         // TODO: Handle this case.


### PR DESCRIPTION
Closes https://github.com/openkraken/kraken/issues/594

原因：键盘 enter key 按下时会触发 input 的 blur 操作，由于多 input 的存在，在 InputElement 中以静态变量形式保存了当前 focus 的 element，原逻辑 blur 时未将 focusElement 清空，导致下次选中 input 时 focusElement 与上一次相等，从而无法选中。