### PR TITLE
fix: keyboard not shown when keyboard dismissed and input gets focused again

### DIFF
--- a/kraken/lib/src/dom/elements/input.dart
+++ b/kraken/lib/src/dom/elements/input.dart
@@ -597,6 +597,9 @@ class InputElement extends Element implements TextInputClient, TickerProvider {
   }
 
   void _handleSelectionChanged(TextSelection selection, SelectionChangedCause? cause) {
+    // Show keyboard for selection change or user gestures.
+    requestKeyboard();
+
     // TODO: show selection layer and emit selection changed event
 
     // To keep the cursor from blinking while it moves, restart the timer here.


### PR DESCRIPTION
Closes https://github.com/openkraken/kraken/issues/625

* 修复当使用键盘上右上角的收起按钮收起键盘后，再次点击 input，键盘未调出。原因是收起键盘时 input 仍然处于 focus 状态（关于这点 android 与 ios 表现不同，android 上收起键盘 input 仍处于 focus 状态而 ios 上 input 会失焦），原逻辑只有当 input 获取焦点时才会调起键盘，应改成 input 每次状态变化（如光标位置变化）时均调起键盘。