### PR TITLE
fix: relative path of xhr.

### DIFF
--- a/bridge/polyfill/src/xhr.ts
+++ b/bridge/polyfill/src/xhr.ts
@@ -184,7 +184,7 @@ export class XMLHttpRequest extends EventTarget {
     }
 
     let ssl = false;
-    let url = new URL(this.settings.url);
+    let url = new URL(this.settings.url, location.href);
     let host;
     // Determine the server
     switch (url.protocol) {


### PR DESCRIPTION
xhr 去掉了相对路径判断的话，需要在 new URL 时候加入第二个参数，否则会抛异常。

close #642 