### PR TITLE
Fix/flush at close

### DIFF
--- a/kraken/ios/Classes/KrakenPlugin.m
+++ b/kraken/ios/Classes/KrakenPlugin.m
@@ -49,7 +49,7 @@ static FlutterMethodChannel *methodChannel = nil;
 
 - (NSString*) getTemporaryDirectory {
   NSArray<NSString *>* paths = NSSearchPathForDirectoriesInDomains(NSCachesDirectory, NSUserDomainMask, YES);
-  return paths.firstObject;
+  return [paths.firstObject stringByAppendingString: @"/Kraken"];
 }
 
 @end

--- a/kraken/lib/src/foundation/http_cache_object.dart
+++ b/kraken/lib/src/foundation/http_cache_object.dart
@@ -229,7 +229,7 @@ class HttpCacheObject {
 
     // The index file will not be TOO LARGE,
     // so take bytes at one time.
-    await _file.writeAsBytes(bytesBuilder.takeBytes());
+    await _file.writeAsBytes(bytesBuilder.takeBytes(), flush: true);
 
     _valid = true;
   }
@@ -364,8 +364,10 @@ class HttpCacheObjectBlob extends EventSink<List<int>> {
   }
 
   @override
-  void close() {
-    _writer?.close();
+  void close() async {
+    // Ensure buffer has been written.
+    await _writer?.flush();
+    await _writer?.close();
   }
 
   Future<bool> exists() {

--- a/kraken/lib/src/foundation/http_cache_object.dart
+++ b/kraken/lib/src/foundation/http_cache_object.dart
@@ -193,6 +193,9 @@ class HttpCacheObject {
       print('Error while reading cache object for $url');
       print('\n$message');
       print('\n$stackTrace');
+
+      // Remove index file while invalid.
+      await remove();
     }
   }
 
@@ -239,10 +242,9 @@ class HttpCacheObject {
   }
 
   // Remove all the cached files.
-  void remove() async {
-    final File indexFile = File(path.join(cacheDirectory, '$hash'));
+  Future<void> remove() async {
     await Future.wait([
-      indexFile.delete(),
+      _file.delete(),
       _blob.remove(),
     ]);
     _valid = false;

--- a/kraken/lib/src/foundation/http_client_request.dart
+++ b/kraken/lib/src/foundation/http_client_request.dart
@@ -129,7 +129,6 @@ class ProxyHttpClientRequest extends HttpClientRequest {
           }
         }
 
-
         // Step 3: Handle negotiate cache request header.
         if (request.headers.ifModifiedSince == null
             && request.headers.value(HttpHeaders.ifNoneMatchHeader) == null) {

--- a/kraken/macos/Classes/KrakenPlugin.m
+++ b/kraken/macos/Classes/KrakenPlugin.m
@@ -47,7 +47,7 @@ static FlutterMethodChannel *methodChannel = nil;
 
 - (NSString*) getTemporaryDirectory {
   NSArray<NSString *>* paths = NSSearchPathForDirectoriesInDomains(NSCachesDirectory, NSUserDomainMask, YES);
-  return paths.firstObject;
+  return [paths.firstObject stringByAppendingString: @"/Kraken"];
 }
 
 @end


### PR DESCRIPTION
1. Close #643 当索引文件不完整时移除索引文件, 这里是边缘场景无法进行单元测试或者集成测试
2. 造成索引文件不完整的原因可能是文件写入时被中断操作, 我在这个 PR 里加入了 writeAsBytes 的可选参数 flush: true 使得 async 操作返回前必须完成 io 操作, 以避免前述问题的发生 (直接 kill -9 进程或者拔电源之类极端情况依然无解)
2. 修复 iOS 和 macOS 下 `getTemporaryDirectory` 没有带 `/Kraken` 路径的问题, 为之前遗漏问题, 与 Android 保持一致 (平台相关无法使用单元测试)