### PR TITLE
[WIP] :bug: fix: not to remove image stream listener

### DIFF
--- a/kraken/lib/src/dom/elements/img.dart
+++ b/kraken/lib/src/dom/elements/img.dart
@@ -150,7 +150,6 @@ class ImageElement extends Element {
     _imageProvider?.evict();
     _imageProvider = null;
 
-    _removeStreamListener();
     _renderImage?.image = null;
   }
 
@@ -161,7 +160,8 @@ class ImageElement extends Element {
     _imageProvider?.evict();
     _imageProvider = null;
 
-    _removeStreamListener();
+    _imageStream?.removeListener(_renderStreamListener);
+    _imageStream = null;
 
     _renderImage = null;
 
@@ -340,11 +340,6 @@ class ImageElement extends Element {
     }
   }
 
-  void _removeStreamListener() {
-    _imageStream?.removeListener(_renderStreamListener);
-    _imageStream = null;
-  }
-
   RenderImage createRenderImageBox() {
     RenderStyle renderStyle = renderBoxModel!.renderStyle;
     BoxFit objectFit = renderStyle.objectFit;
@@ -419,8 +414,6 @@ class ImageElement extends Element {
     _resetImage();
 
     if (_source != null) {
-      _removeStreamListener();
-
       Uri base = Uri.parse(elementManager.controller.href);
       Uri resolvedUri = elementManager.controller.uriParser!.resolve(base, Uri.parse(_source!));
 


### PR DESCRIPTION
修复调试复用同一个 img 标签更新 src 以更换图片时候被捕获的异步异常  

![image](https://user-images.githubusercontent.com/3922719/137136591-6ff3ba11-4896-4b2e-9041-5d760bce1537.png)

此异常不影响表现, 但可能会对运行时性能造成影响  

因为此异常并不会尝试日志或者抛出来中断执行, 需要进一步想一下如何持续集成, 如果 Element 解耦 targetId 和 NativePoiner, 可以尝试在单元测试里直接执行? 先跑一下 CI 看看有无其它影响.