### PR TITLE
:recycle: refactor: gesture scroll physics and auto determine.

### DIFF
--- a/kraken/lib/src/css/overflow.dart
+++ b/kraken/lib/src/css/overflow.dart
@@ -333,7 +333,7 @@ mixin CSSOverflowMixin on ElementBase {
     KrakenScrollable? scrollable = _getScrollable(Axis.vertical);
     if (scrollable?.position?.maxScrollExtent != null) {
       // Viewport height + maxScrollExtent
-      return renderBoxModel!.clientHeight + scrollable!.position!.maxScrollExtent!;
+      return renderBoxModel!.clientHeight + scrollable!.position!.maxScrollExtent;
     }
 
     Size scrollContainerSize = renderBoxModel!.scrollableSize;
@@ -343,7 +343,7 @@ mixin CSSOverflowMixin on ElementBase {
   double get scrollWidth {
     KrakenScrollable? scrollable = _getScrollable(Axis.horizontal);
     if (scrollable?.position?.maxScrollExtent != null) {
-      return renderBoxModel!.clientWidth + scrollable!.position!.maxScrollExtent!;
+      return renderBoxModel!.clientWidth + scrollable!.position!.maxScrollExtent;
     }
     Size scrollContainerSize = renderBoxModel!.scrollableSize;
     return scrollContainerSize.width;

--- a/kraken/lib/src/dom/elements/input.dart
+++ b/kraken/lib/src/dom/elements/input.dart
@@ -1110,8 +1110,8 @@ class InputElement extends Element implements TextInputClient, TickerProvider {
     // the ascent.
     final double targetOffset = (additionalOffset + _scrollableX.position!.pixels)
       .clamp(
-      _scrollableX.position!.minScrollExtent!,
-      _scrollableX.position!.maxScrollExtent!,
+      _scrollableX.position!.minScrollExtent,
+      _scrollableX.position!.maxScrollExtent,
     );
 
     final double offsetDelta = _scrollableX.position!.pixels - targetOffset;

--- a/kraken/lib/src/gesture/scroll_context.dart
+++ b/kraken/lib/src/gesture/scroll_context.dart
@@ -19,7 +19,7 @@ abstract class ScrollContext {
   TickerProvider get vsync;
 
   /// The direction in which the widget scrolls.
-  AxisDirection? get axisDirection;
+  AxisDirection get axisDirection;
 
   /// Whether the user can drag the widget, for example to initiate a scroll.
   void setCanDrag(bool value);

--- a/kraken/lib/src/gesture/scroll_metrics.dart
+++ b/kraken/lib/src/gesture/scroll_metrics.dart
@@ -46,10 +46,10 @@ abstract class ScrollMetrics {
     AxisDirection? axisDirection,
   }) {
     return FixedScrollMetrics(
-      minScrollExtent: minScrollExtent ?? this.minScrollExtent,
-      maxScrollExtent: maxScrollExtent ?? this.maxScrollExtent,
-      pixels: pixels ?? this.pixels,
-      viewportDimension: viewportDimension ?? this.viewportDimension,
+      minScrollExtent: minScrollExtent ?? (hasContentDimensions ? this.minScrollExtent : null),
+      maxScrollExtent: maxScrollExtent ?? (hasContentDimensions ? this.maxScrollExtent : null),
+      pixels: pixels ?? (hasPixels ? this.pixels : null),
+      viewportDimension: viewportDimension ?? (hasViewportDimension ? this.viewportDimension : null),
       axisDirection: axisDirection ?? this.axisDirection,
     );
   }
@@ -60,7 +60,7 @@ abstract class ScrollMetrics {
   ///
   /// This value should typically be non-null and less than or equal to
   /// [maxScrollExtent]. It can be negative infinity, if the scroll is unbounded.
-  double? get minScrollExtent;
+  double get minScrollExtent;
 
   /// The maximum in-range value for [pixels].
   ///
@@ -68,23 +68,32 @@ abstract class ScrollMetrics {
   ///
   /// This value should typically be non-null and greater than or equal to
   /// [minScrollExtent]. It can be infinity, if the scroll is unbounded.
-  double? get maxScrollExtent;
+  double get maxScrollExtent;
+
+  /// Whether the [minScrollExtent] and the [maxScrollExtent] properties are available.
+  bool get hasContentDimensions;
 
   /// The current scroll position, in logical pixels along the [axisDirection].
   double get pixels;
 
+  /// Whether the [pixels] property is available.
+  bool get hasPixels;
+
   /// The extent of the viewport along the [axisDirection].
-  double? get viewportDimension;
+  double get viewportDimension;
+
+  /// Whether the [viewportDimension] property is available.
+  bool get hasViewportDimension;
 
   /// The direction in which the scroll view scrolls.
-  AxisDirection? get axisDirection;
+  AxisDirection get axisDirection;
 
   /// The axis in which the scroll view scrolls.
-  Axis get axis => axisDirectionToAxis(axisDirection!);
+  Axis get axis => axisDirectionToAxis(axisDirection);
 
   /// Whether the [pixels] value is outside the [minScrollExtent] and
   /// [maxScrollExtent].
-  bool get outOfRange => pixels < minScrollExtent! || pixels > maxScrollExtent!;
+  bool get outOfRange => pixels < minScrollExtent || pixels > maxScrollExtent;
 
   /// Whether the [pixels] value is exactly at the [minScrollExtent] or the
   /// [maxScrollExtent].
@@ -92,7 +101,7 @@ abstract class ScrollMetrics {
 
   /// The quantity of content conceptually "above" the viewport in the scrollable.
   /// This is the content above the content described by [extentInside].
-  double get extentBefore => math.max(pixels - minScrollExtent!, 0.0);
+  double get extentBefore => math.max(pixels - minScrollExtent, 0.0);
 
   /// The quantity of content conceptually "inside" the viewport in the scrollable.
   ///
@@ -102,48 +111,62 @@ abstract class ScrollMetrics {
   ///
   /// The value is always non-negative, and less than or equal to [viewportDimension].
   double get extentInside {
-    assert(minScrollExtent! <= maxScrollExtent!);
-    return viewportDimension!
+    assert(minScrollExtent <= maxScrollExtent);
+    return viewportDimension
         // "above" overscroll value
-        -
-        (minScrollExtent! - pixels).clamp(0, viewportDimension!)
+        - (minScrollExtent - pixels).clamp(0, viewportDimension)
         // "below" overscroll value
-        -
-        (pixels - maxScrollExtent!).clamp(0, viewportDimension!);
+        - (pixels - maxScrollExtent).clamp(0, viewportDimension);
   }
 
   /// The quantity of content conceptually "below" the viewport in the scrollable.
   /// This is the content below the content described by [extentInside].
-  double get extentAfter => math.max(maxScrollExtent! - pixels, 0.0);
+  double get extentAfter => math.max(maxScrollExtent - pixels, 0.0);
 }
 
 /// An immutable snapshot of values associated with a [Scrollable] viewport.
 ///
 /// For details, see [ScrollMetrics], which defines this object's interfaces.
-class FixedScrollMetrics extends ScrollMetrics {
+class FixedScrollMetrics with ScrollMetrics {
   /// Creates an immutable snapshot of values associated with a [Scrollable] viewport.
   FixedScrollMetrics({
-    required this.minScrollExtent,
-    required this.maxScrollExtent,
-    required this.pixels,
-    required this.viewportDimension,
+    required double? minScrollExtent,
+    required double? maxScrollExtent,
+    required double? pixels,
+    required double? viewportDimension,
     required this.axisDirection,
-  });
+  }) : _minScrollExtent = minScrollExtent,
+        _maxScrollExtent = maxScrollExtent,
+        _pixels = pixels,
+        _viewportDimension = viewportDimension;
 
   @override
-  final double? minScrollExtent;
+  double get minScrollExtent => _minScrollExtent!;
+  final double? _minScrollExtent;
 
   @override
-  final double? maxScrollExtent;
+  double get maxScrollExtent => _maxScrollExtent!;
+  final double? _maxScrollExtent;
 
   @override
-  final double pixels;
+  bool get hasContentDimensions => _minScrollExtent != null && _maxScrollExtent != null;
 
   @override
-  final double? viewportDimension;
+  double get pixels => _pixels!;
+  final double? _pixels;
 
   @override
-  final AxisDirection? axisDirection;
+  bool get hasPixels => _pixels != null;
+
+  @override
+  double get viewportDimension => _viewportDimension!;
+  final double? _viewportDimension;
+
+  @override
+  bool get hasViewportDimension => _viewportDimension != null;
+
+  @override
+  final AxisDirection axisDirection;
 
   @override
   String toString() {

--- a/kraken/lib/src/gesture/scroll_position.dart
+++ b/kraken/lib/src/gesture/scroll_position.dart
@@ -126,19 +126,28 @@ abstract class ScrollPosition extends ViewportOffset with ScrollMetrics {
   final String? debugLabel;
 
   @override
-  double? get minScrollExtent => _minScrollExtent;
+  bool get hasContentDimensions => _minScrollExtent != null && _maxScrollExtent != null;
+
+  @override
+  double get minScrollExtent => _minScrollExtent!;
   double? _minScrollExtent;
 
   @override
-  double? get maxScrollExtent => _maxScrollExtent;
+  double get maxScrollExtent => _maxScrollExtent!;
   double? _maxScrollExtent;
+
+  @override
+  bool get hasPixels => _pixels != null;
 
   @override
   double get pixels => _pixels!;
   double? _pixels;
 
   @override
-  double? get viewportDimension => _viewportDimension;
+  bool get hasViewportDimension => _viewportDimension != null;
+
+  @override
+  double get viewportDimension => _viewportDimension!;
   double? _viewportDimension;
 
   /// Whether [viewportDimension], [minScrollExtent], [maxScrollExtent],
@@ -180,10 +189,16 @@ abstract class ScrollPosition extends ViewportOffset with ScrollMetrics {
   void absorb(ScrollPosition other) {
     assert(other.context == context);
     assert(_pixels == null);
-    _minScrollExtent = other.minScrollExtent;
-    _maxScrollExtent = other.maxScrollExtent;
-    _pixels = other._pixels;
-    _viewportDimension = other.viewportDimension;
+    if (other.hasContentDimensions) {
+      _minScrollExtent = other.minScrollExtent;
+      _maxScrollExtent = other.maxScrollExtent;
+    }
+    if (other.hasPixels) {
+      _pixels = other.pixels;
+    }
+    if (other.hasViewportDimension) {
+      _viewportDimension = other.viewportDimension;
+    }
 
     assert(activity == null);
     assert(other.activity != null);
@@ -404,8 +419,8 @@ abstract class ScrollPosition extends ViewportOffset with ScrollMetrics {
     }
 
     final Set<SemanticsAction?> actions = <SemanticsAction?>{};
-    if (pixels > minScrollExtent!) actions.add(backward);
-    if (pixels < maxScrollExtent!) actions.add(forward);
+    if (pixels > minScrollExtent) actions.add(backward);
+    if (pixels < maxScrollExtent) actions.add(forward);
 
     if (setEquals<SemanticsAction?>(actions, _semanticActions)) return;
 
@@ -474,16 +489,16 @@ abstract class ScrollPosition extends ViewportOffset with ScrollMetrics {
     double? target;
     switch (alignmentPolicy) {
       case ScrollPositionAlignmentPolicy.explicit:
-        target = viewport.getOffsetToReveal(object, alignment).offset.clamp(minScrollExtent!, maxScrollExtent!);
+        target = viewport.getOffsetToReveal(object, alignment).offset.clamp(minScrollExtent, maxScrollExtent);
         break;
       case ScrollPositionAlignmentPolicy.keepVisibleAtEnd:
-        target = viewport.getOffsetToReveal(object, 1.0).offset.clamp(minScrollExtent!, maxScrollExtent!);
+        target = viewport.getOffsetToReveal(object, 1.0).offset.clamp(minScrollExtent, maxScrollExtent);
         if (target < pixels) {
           target = pixels;
         }
         break;
       case ScrollPositionAlignmentPolicy.keepVisibleAtStart:
-        target = viewport.getOffsetToReveal(object, 0.0).offset.clamp(minScrollExtent!, maxScrollExtent!);
+        target = viewport.getOffsetToReveal(object, 0.0).offset.clamp(minScrollExtent, maxScrollExtent);
         if (target > pixels) {
           target = pixels;
         }
@@ -569,7 +584,7 @@ abstract class ScrollPosition extends ViewportOffset with ScrollMetrics {
   }) {
     assert(clamp != null);
 
-    if (clamp!) to = to.clamp(minScrollExtent!, maxScrollExtent!);
+    if (clamp!) to = to.clamp(minScrollExtent, maxScrollExtent);
 
     return super.moveTo(to, duration: duration, curve: curve);
   }
@@ -636,7 +651,7 @@ abstract class ScrollPosition extends ViewportOffset with ScrollMetrics {
   void debugFillDescription(List<String?> description) {
     if (debugLabel != null) description.add(debugLabel);
     super.debugFillDescription(description as List<String>);
-    description.add('range: ${minScrollExtent?.toStringAsFixed(1)}..${maxScrollExtent?.toStringAsFixed(1)}');
-    description.add('viewport: ${viewportDimension?.toStringAsFixed(1)}');
+    description.add('range: ${minScrollExtent.toStringAsFixed(1)}..${maxScrollExtent.toStringAsFixed(1)}');
+    description.add('viewport: ${viewportDimension.toStringAsFixed(1)}');
   }
 }

--- a/kraken/lib/src/gesture/scroll_position_with_single_context.dart
+++ b/kraken/lib/src/gesture/scroll_position_with_single_context.dart
@@ -71,7 +71,7 @@ class ScrollPositionWithSingleContext extends ScrollPosition implements ScrollAc
   double _heldPreviousVelocity = 0.0;
 
   @override
-  AxisDirection? get axisDirection => context.axisDirection;
+  AxisDirection get axisDirection => context.axisDirection;
 
   @override
   double setPixels(double newPixels) {

--- a/kraken/lib/src/gesture/scrollable.dart
+++ b/kraken/lib/src/gesture/scrollable.dart
@@ -53,9 +53,9 @@ class _CustomTicker extends Ticker {
 }
 
 class KrakenScrollable with _CustomTickerProviderStateMixin implements ScrollContext {
-  AxisDirection? _axisDirection;
+  late AxisDirection _axisDirection;
   ScrollPosition? position;
-  final ScrollPhysics _physics = BouncingScrollPhysics();
+  final ScrollPhysics _physics = ScrollPhysics.createScrollPhysics();
   DragStartBehavior dragStartBehavior;
   ScrollListener? scrollListener;
 
@@ -71,7 +71,7 @@ class KrakenScrollable with _CustomTickerProviderStateMixin implements ScrollCon
   /// The axis along which the scroll view scrolls.
   ///
   /// Determined by the [axisDirection].
-  Axis get axis => axisDirectionToAxis(_axisDirection!);
+  Axis get axis => axisDirectionToAxis(_axisDirection);
 
   void handlePointerDown(PointerDownEvent event) {
     for (GestureRecognizer? recognizer in _recognizers.values) {
@@ -80,7 +80,7 @@ class KrakenScrollable with _CustomTickerProviderStateMixin implements ScrollCon
   }
 
   @override
-  AxisDirection? get axisDirection => _axisDirection;
+  AxisDirection get axisDirection => _axisDirection;
 
   // This field is set during layout, and then reused until the next time it is set.
   Map<Type, GestureRecognizerFactory> _gestureRecognizers = const <Type, GestureRecognizerFactory>{};

--- a/kraken/lib/src/rendering/recycler.dart
+++ b/kraken/lib/src/rendering/recycler.dart
@@ -51,7 +51,7 @@ class RenderRecyclerLayout extends RenderLayoutBox {
     _renderSliverList = _buildRenderSliverList();
     _renderViewport = RenderViewport(
       offset: scrollable.position!,
-      axisDirection: scrollable.axisDirection!,
+      axisDirection: scrollable.axisDirection,
       crossAxisDirection: getCrossAxisDirection(axis),
       children: [_renderSliverList],
     );

--- a/kraken/test/gesture.dart
+++ b/kraken/test/gesture.dart
@@ -1,0 +1,9 @@
+import 'package:test/test.dart';
+
+import 'src/gesture/scroll_physics.dart' as scroll_physics;
+
+void main() {
+  group('gesture', () {
+    scroll_physics.main();
+  });
+}

--- a/kraken/test/kraken_test.dart
+++ b/kraken/test/kraken_test.dart
@@ -7,6 +7,7 @@ import 'package:kraken/foundation.dart';
 
 import 'foundation.dart' as foundation;
 import 'module.dart' as module;
+import 'gesture.dart' as gesture;
 import 'local_http_server.dart';
 
 // The main entry for kraken unit test.
@@ -32,6 +33,7 @@ void main() {
   // Start tests.
   foundation.main();
   module.main();
+  gesture.main();
 
   tearDownAll(() {
     if (tempDirectory.existsSync()) {

--- a/kraken/test/src/gesture/scroll_physics.dart
+++ b/kraken/test/src/gesture/scroll_physics.dart
@@ -1,0 +1,29 @@
+import 'dart:io' show Platform;
+import 'package:kraken/src/gesture/scroll_physics.dart';
+import 'package:test/test.dart';
+
+// Only for test.
+class TestScrollPhysics extends ScrollPhysics {}
+
+void main() {
+  group('ScrollPhysics', () {
+    test('createScrollPhysics', () {
+      ScrollPhysics scrollPhysics = ScrollPhysics.createScrollPhysics();
+      // In test env, that should be macos env.
+      expect(Platform.operatingSystem, 'macos');
+      expect(scrollPhysics.runtimeType.toString(), 'BouncingScrollPhysics');
+    });
+
+    test('ScrollPhysics Factory', () {
+      // ScrollPhysics
+      ScrollPhysics.scrollPhysicsFactory = (ScrollPhysics? parent) {
+        return TestScrollPhysics();
+      };
+
+      ScrollPhysics scrollPhysics = ScrollPhysics.createScrollPhysics();
+      expect(scrollPhysics.runtimeType.toString(), 'TestScrollPhysics');
+
+      ScrollPhysics.scrollPhysicsFactory = null;
+    });
+  });
+}


### PR DESCRIPTION
1. 重构了 scroll_physics, 删除大量不必要的 non-null casting (!)
2. 支持在不同类型设备下自动判断 ScrollPhysics 类型, iOS 使用 BouncingScrollPhysics, Android 以及其它设备使用 ClampingScrollPhysics
3. 支持覆盖默认的 ScrollPhysics 其 API 为
```dart
ScrollPhysics.scrollPhysicsFactory = (ScrollPhysics? parent) {
  // ...
  return CustomScrollPhysics();
};
```