### PR TITLE
:recycle: refactor: bridge macos min target to 10.11

### DIFF
--- a/bridge/CMakeLists.txt
+++ b/bridge/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.10.0)
-set(CMAKE_OSX_DEPLOYMENT_TARGET 10.14)
+set(CMAKE_OSX_DEPLOYMENT_TARGET 10.11)
 project(KrakenBridge)
 
 set(CMAKE_CXX_STANDARD 17)


### PR DESCRIPTION
- Remove building complain about:  
![image](https://user-images.githubusercontent.com/3922719/138650160-b21d5930-5220-456b-8ffc-7950b19b133c.png)

Not really dependent with >= 10.14.