### PR TITLE
:fire: test: remove test of startTime.

### DIFF
--- a/integration_tests/specs/performance/performance.ts
+++ b/integration_tests/specs/performance/performance.ts
@@ -15,10 +15,6 @@ describe('Performance', () => {
     }, 300);
   });
 
-  it('init startTime should less than 2000', () => {
-    expect(startTime).toBeLessThan(2000);
-  });
-
   it('clearMarks', () => {
     performance.mark('abc');
     performance.mark('efg');


### PR DESCRIPTION
依赖测试机性能，时间有点拍脑袋不科学，经常不通过影响测试效率。