### PR TITLE
:bug: fix: using http-date(RFC-1123) to parse last-modified.

### DIFF
--- a/kraken/lib/src/foundation/http_cache_object.dart
+++ b/kraken/lib/src/foundation/http_cache_object.dart
@@ -10,6 +10,7 @@ import 'dart:typed_data';
 
 import 'package:path/path.dart' as path;
 
+import 'http_client.dart';
 import 'http_client_response.dart';
 
 class HttpCacheObject {
@@ -70,7 +71,7 @@ class HttpCacheObject {
     int contentLength = response.headers.contentLength;
     String? lastModifiedValue = response.headers.value(HttpHeaders.lastModifiedHeader);
     DateTime? lastModified = lastModifiedValue != null
-        ? DateTime.tryParse(lastModifiedValue)
+        ? tryParseHttpDate(lastModifiedValue)
         : null;
 
     return HttpCacheObject(url, cacheDirectory,
@@ -320,7 +321,7 @@ class HttpCacheObject {
     // Update lastModified
     String? remoteLastModifiedString = response.headers.value(HttpHeaders.lastModifiedHeader);
     if (remoteLastModifiedString != null) {
-      DateTime? remoteLastModified = DateTime.tryParse(remoteLastModifiedString);
+      DateTime? remoteLastModified = tryParseHttpDate(remoteLastModifiedString);
       if (remoteLastModified != null
           && (lastModified == null || !remoteLastModified.isAtSameMomentAs(lastModified!))) {
         lastModified = remoteLastModified;

--- a/kraken/lib/src/foundation/http_client.dart
+++ b/kraken/lib/src/foundation/http_client.dart
@@ -248,7 +248,7 @@ class _HttpHeaders implements HttpHeaders {
   }
 
   @override
-  DateTime? get expires => DateTime.tryParse(_headers[HttpHeaders.expiresHeader] ?? '');
+  DateTime? get expires => tryParseHttpDate(_headers[HttpHeaders.expiresHeader] ?? '');
 
   @override
   set expires(DateTime? _expires) {
@@ -357,5 +357,14 @@ class _HttpHeaders implements HttpHeaders {
         ..write('\n');
     });
     return sb.toString();
+  }
+}
+
+DateTime? tryParseHttpDate(String input) {
+  try {
+    return HttpDate.parse(input);
+  } catch (ignored) {
+    // Ignore all exceptions.
+    return null;
   }
 }

--- a/kraken/test/fixtures/GET_plain_text_with_current_time_last_modified
+++ b/kraken/test/fixtures/GET_plain_text_with_current_time_last_modified
@@ -1,0 +1,6 @@
+HTTP/1.1 200 OK
+Content-Type: text/plain
+Last-Modified: CURRENT_TIME
+Content-Length: 10
+
+CachedData

--- a/kraken/test/src/foundation/http_cache.dart
+++ b/kraken/test/src/foundation/http_cache.dart
@@ -57,6 +57,36 @@ void main() {
       assert(cacheObject.valid);
     });
 
+    // The second request that last-modified has updated, then controller should update local
+    // expire time and save new response.
+    test('Update cache last-modified', () async {
+      // First request to save cache.
+      var req = await httpClient.openUrl('GET',
+          server.getUri('plain_text_with_current_time_last_modified'));
+      KrakenHttpOverrides.setContextHeader(req.headers, contextId);
+      req.headers.ifModifiedSince = HttpDate.parse('Sun, 15 Mar 2020 11:32:20 GMT');
+      var res = await req.close();
+      expect(String.fromCharCodes(await consolidateHttpClientResponseBytes(res)), 'CachedData');
+
+      // Second request and updating cache.
+      var req2 = await httpClient.openUrl('GET',
+          server.getUri('plain_text_with_current_time_last_modified'));
+      KrakenHttpOverrides.setContextHeader(req2.headers, contextId);
+      var res2 = await req2.close();
+
+      // Must miss cache, and update cache.
+      String httpDateNow = HttpDate.format(DateTime.now());
+      expect(res2.headers.value('cache-hits'), null);
+      expect(res2.headers.value(HttpHeaders.lastModifiedHeader), httpDateNow);
+
+      // Check cache object updated.
+      HttpCacheController cacheController = HttpCacheController.instance(req.headers.value('origin')!);
+      var cacheObject = await cacheController.getCacheObject(req.uri);
+      assert(cacheObject.lastModified != null);
+      // Difference <= 1ms.
+      assert(DateTime.now().compareTo(cacheObject.lastModified!) <= 1);
+    });
+
     test('Negotiation cache eTag', () async {
       // First request to save cache.
       var req = await httpClient.openUrl('GET',


### PR DESCRIPTION
Fix #781 

- 应当使用 HttpDate 格式来解析 last-modified, 参考 RFC1123 的格式, 并且增加了单元测试用例