### PR TITLE
Refactor/define custom element

### DIFF
--- a/integration_tests/lib/custom/custom_element.dart
+++ b/integration_tests/lib/custom/custom_element.dart
@@ -39,7 +39,7 @@ void defineKrakenCustomElements() {
 
 class SampleElement extends Element {
   SampleElement(int targetId, Pointer<NativeEventTarget> nativeEventTarget, ElementManager elementManager)
-      : super(targetId, nativeEventTarget, elementManager, tagName: 'sample-element');
+      : super(targetId, nativeEventTarget, elementManager);
 
   @override
   getProperty(String key) {

--- a/integration_tests/lib/custom/custom_element.dart
+++ b/integration_tests/lib/custom/custom_element.dart
@@ -5,33 +5,36 @@ import 'package:kraken/dom.dart';
 import 'package:kraken/widget.dart';
 import 'package:flutter/material.dart' show TextDirection, TextStyle, Color, Image, Text, AssetImage, Widget, BuildContext hide Element;
 
-class TextCreator extends BaseWidgetCreator {
+class TextWidgetElement extends WidgetElement {
+  TextWidgetElement(int targetId, Pointer<NativeEventTarget> nativeEventTarget, ElementManager elementManager) :
+        super(targetId, nativeEventTarget, elementManager);
+
   @override
   Widget build(BuildContext context, Map<String, dynamic> properties) {
     return Text(properties['value'] ?? '', textDirection: TextDirection.ltr, style: TextStyle(color: Color.fromARGB(255, 100, 100, 100)));
   }
 }
 
-class ImageCreator extends BaseWidgetCreator {
+class ImageWidgetElement extends WidgetElement {
+  ImageWidgetElement(int targetId, Pointer<NativeEventTarget> nativeEventTarget, ElementManager elementManager) :
+        super(targetId, nativeEventTarget, elementManager);
+
   @override
   Widget build(BuildContext context, Map<String, dynamic> properties) {
     return Image(image: AssetImage(properties['src']));
   }
 }
 
-class SampleElementCreator extends BaseCustomElementCreator {
-  SampleElementCreator() : super('sample-element');
-
-  @override
-  Element build(int targetId, Pointer<NativeEventTarget> nativeEventTarget, ElementManager elementManager) {
-    return SampleElement(targetId, nativeEventTarget, elementManager);
-  }
-}
-
 void defineKrakenCustomElements() {
-  Kraken.defineCustomElement(WidgetElementCreator('flutter-text', TextCreator()));
-  Kraken.defineCustomElement(WidgetElementCreator('flutter-asset-image', ImageCreator()));
-  Kraken.defineCustomElement(SampleElementCreator());
+  Kraken.defineCustomElement('sample-element', (int targetId, Pointer<NativeEventTarget> nativeEventTarget, ElementManager elementManager) {
+    return SampleElement(targetId, nativeEventTarget, elementManager);
+  });
+  Kraken.defineCustomElement('flutter-text', (targetId, nativeEventTarget, elementManager) {
+    return TextWidgetElement(targetId, nativeEventTarget, elementManager);
+  });
+  Kraken.defineCustomElement('flutter-asset-image', (targetId, nativeEventTarget, elementManager) {
+    return ImageWidgetElement(targetId, nativeEventTarget, elementManager);
+  });
 }
 
 class SampleElement extends Element {

--- a/integration_tests/lib/custom/custom_element.dart
+++ b/integration_tests/lib/custom/custom_element.dart
@@ -3,20 +3,35 @@ import 'dart:async';
 import 'package:kraken/bridge.dart';
 import 'package:kraken/dom.dart';
 import 'package:kraken/widget.dart';
-import 'package:flutter/material.dart' show TextDirection, TextStyle, Color, Image, Text, AssetImage;
+import 'package:flutter/material.dart' show TextDirection, TextStyle, Color, Image, Text, AssetImage, Widget, BuildContext hide Element;
+
+class TextCreator extends BaseWidgetCreator {
+  @override
+  Widget build(BuildContext context, Map<String, dynamic> properties) {
+    return Text(properties['value'] ?? '', textDirection: TextDirection.ltr, style: TextStyle(color: Color.fromARGB(255, 100, 100, 100)));
+  }
+}
+
+class ImageCreator extends BaseWidgetCreator {
+  @override
+  Widget build(BuildContext context, Map<String, dynamic> properties) {
+    return Image(image: AssetImage(properties['src']));
+  }
+}
+
+class SampleElementCreator extends BaseCustomElementCreator {
+  SampleElementCreator() : super('sample-element');
+
+  @override
+  Element build(int targetId, Pointer<NativeEventTarget> nativeEventTarget, ElementManager elementManager) {
+    return SampleElement(targetId, nativeEventTarget, elementManager);
+  }
+}
 
 void defineKrakenCustomElements() {
-  Kraken.defineCustomElement<WidgetCreator>('flutter-text', (Map<String, dynamic> properties) {
-    return Text(properties['value'] ?? '', textDirection: TextDirection.ltr, style: TextStyle(color: Color.fromARGB(255, 100, 100, 100)));
-  });
-
-  Kraken.defineCustomElement<WidgetCreator>('flutter-asset-image', (Map<String, dynamic> properties) {
-    return Image(image: AssetImage(properties['src']));
-  });
-
-  Kraken.defineCustomElement<ElementCreator>('sample-element', (int targetId, Pointer<NativeEventTarget> nativeEventTarget, ElementManager elementManager) {
-    return SampleElement(targetId, nativeEventTarget, elementManager);
-  });
+  Kraken.defineCustomElement(WidgetElementCreator('flutter-text', TextCreator()));
+  Kraken.defineCustomElement(WidgetElementCreator('flutter-asset-image', ImageCreator()));
+  Kraken.defineCustomElement(SampleElementCreator());
 }
 
 class SampleElement extends Element {

--- a/integration_tests/pubspec.yaml
+++ b/integration_tests/pubspec.yaml
@@ -27,7 +27,7 @@ dependencies:
     sdk: flutter
   kraken: 0.8.0-dev.1
   image: ^3.0.2
-  kraken_video_player: 1.0.0-dev.2
+  kraken_video_player: 1.0.0-dev.3
   kraken_websocket: 1.0.0-dev.1
   kraken_animation_player: 1.0.0-dev.2
   kraken_webview: 1.0.0-dev.2

--- a/integration_tests/pubspec.yaml
+++ b/integration_tests/pubspec.yaml
@@ -27,10 +27,10 @@ dependencies:
     sdk: flutter
   kraken: 0.8.0-dev.1
   image: ^3.0.2
-  kraken_video_player: 1.0.0-dev.1
+  kraken_video_player: 1.0.0-dev.2
   kraken_websocket: 1.0.0-dev.1
-  kraken_animation_player: 1.0.0-dev.1
-  kraken_webview: 1.0.0-dev.1
+  kraken_animation_player: 1.0.0-dev.2
+  kraken_webview: 1.0.0-dev.2
 
 dev_dependencies:
   flutter_test:

--- a/kraken/lib/src/dom/document.dart
+++ b/kraken/lib/src/dom/document.dart
@@ -13,11 +13,14 @@ class Document extends Node {
   final HTMLElement documentElement;
 
   Document(int targetId, Pointer<NativeEventTarget> nativeEventTarget, ElementManager elementManager, this.documentElement)
-      : super(NodeType.DOCUMENT_NODE, targetId, nativeEventTarget, elementManager, '#document');
+      : super(NodeType.DOCUMENT_NODE, targetId, nativeEventTarget, elementManager);
 
   void _handleEvent(Event event) {
     emitUIEvent(elementManager.controller.view.contextId, nativeEventTargetPtr, event);
   }
+
+  @override
+  String get nodeName => '#document';
 
   @override
   void addEvent(String eventType) {

--- a/kraken/lib/src/dom/document_fragment.dart
+++ b/kraken/lib/src/dom/document_fragment.dart
@@ -10,7 +10,10 @@ const String DOCUMENT_FRAGMENT = 'DOCUMENTFRAGMENT';
 
 class DocumentFragment extends Node {
   DocumentFragment(int targetId, nativeNodePtr, ElementManager elementManager)
-      : super(NodeType.COMMENT_NODE, targetId, nativeNodePtr, elementManager, '#documentfragment');
+      : super(NodeType.COMMENT_NODE, targetId, nativeNodePtr, elementManager);
+
+  @override
+  String get nodeName => '#documentfragment';
 
   @override
   RenderObject? get renderer => null;

--- a/kraken/lib/src/dom/element.dart
+++ b/kraken/lib/src/dom/element.dart
@@ -465,7 +465,7 @@ class Element extends Node
       RenderBox? prev = (_renderer.parentData as ContainerParentDataMixin<RenderBox>).previousSibling;
       // It needs to find the previous sibling of the previous sibling if the placeholder of
       // positioned element exists and follows renderObject at the same time, eg.
-      // <div style="position: relative"><div style="postion: absolute" /></div>
+      // <div style="position: relative"><div style="position: absolute" /></div>
       if (prev == _renderBoxModel) {
         prev = (_renderBoxModel.parentData as ContainerParentDataMixin<RenderBox>).previousSibling;
       }
@@ -601,8 +601,8 @@ class Element extends Node
       _afterRendererAttach();
     }
 
-    // CSS Transition works after dom has layouted, so it needs to mark
-    // the renderBoxModel as layouted on the next frame.
+    // CSS Transition works after dom has layout, so it needs to mark
+    // the renderBoxModel as layout on the next frame.
     SchedulerBinding.instance!.addPostFrameCallback((timestamp) {
       renderBoxModel?.firstLayouted = true;
     });

--- a/kraken/lib/src/dom/element.dart
+++ b/kraken/lib/src/dom/element.dart
@@ -142,7 +142,8 @@ class Element extends Node
   /// Should create repaintBoundary for this element to repaint separately from parent.
   bool repaintSelf;
 
-  final String tagName;
+  // Default to unknown, assign by [createElement], used by inspector.
+  String tagName = UNKNOWN;
 
   final Map<String, dynamic> _defaultStyle;
 
@@ -173,16 +174,14 @@ class Element extends Node
   }
 
   Element(int targetId, Pointer<NativeEventTarget> nativeEventTarget, ElementManager elementManager,
-      {required String tagName,
-        Map<String, dynamic> defaultStyle = const {},
+      { Map<String, dynamic> defaultStyle = const {},
         // Whether element allows children.
         bool isIntrinsicBox = false,
         this.repaintSelf = false})
       : _defaultStyle = defaultStyle,
-        tagName = tagName.toUpperCase(),
         _isIntrinsicBox = isIntrinsicBox,
         defaultDisplay = defaultStyle.containsKey(DISPLAY) ? defaultStyle[DISPLAY] : INLINE,
-        super(NodeType.ELEMENT_NODE, targetId, nativeEventTarget, elementManager, tagName) {
+        super(NodeType.ELEMENT_NODE, targetId, nativeEventTarget, elementManager) {
     style = CSSStyleDeclaration(this);
     _setDefaultStyle();
   }
@@ -252,6 +251,9 @@ class Element extends Node
     RenderBoxModel rootBoxModel = rootElement.renderBoxModel!;
     return rootBoxModel.renderStyle.fontSize;
   }
+
+  @override
+  String get nodeName => tagName;
 
   @override
   RenderObject? get renderer => renderBoxModel?.renderPositionHolder ?? renderBoxModel;
@@ -359,7 +361,7 @@ class Element extends Node
   void paintFixedChildren(double scrollOffset, AxisDirection axisDirection) {
     RenderLayoutBox? _scrollingContentLayoutBox = scrollingContentLayoutBox;
     // Only root element has fixed children
-    if (tagName == 'HTML' && _scrollingContentLayoutBox != null) {
+    if (targetId == HTML_ID && _scrollingContentLayoutBox != null) {
       for (RenderBoxModel child in _scrollingContentLayoutBox.fixedChildren) {
         // Save scrolling offset for paint
         if (axisDirection == AxisDirection.down) {

--- a/kraken/lib/src/dom/element_registry.dart
+++ b/kraken/lib/src/dom/element_registry.dart
@@ -21,10 +21,12 @@ Element createElement(int id, Pointer<NativeEventTarget> nativePtr, String name,
   ElementCreator? creator = _elementRegistry[name];
   if (creator == null) {
     print('ERROR: unexpected element type "$name"');
-    return Element(id, nativePtr, elementManager, tagName: UNKNOWN);
+    return Element(id, nativePtr, elementManager);
   }
 
   Element element = creator(id, nativePtr, elementManager);
+  // Assign tagName, used by inspector.
+  element.tagName = name;
   return element;
 }
 

--- a/kraken/lib/src/dom/elements/a.dart
+++ b/kraken/lib/src/dom/elements/a.dart
@@ -18,7 +18,7 @@ class AnchorElement extends Element {
   String? _target;
 
   AnchorElement(int targetId, Pointer<NativeEventTarget> nativeEventTargetPtr, ElementManager elementManager)
-      : super(targetId, nativeEventTargetPtr, elementManager, tagName: ANCHOR) {
+      : super(targetId, nativeEventTargetPtr, elementManager) {
     addEvent(EVENT_CLICK);
   }
 

--- a/kraken/lib/src/dom/elements/body.dart
+++ b/kraken/lib/src/dom/elements/body.dart
@@ -17,7 +17,7 @@ const Map<String, dynamic> _defaultStyle = {
 
 class BodyElement extends Element {
   BodyElement(int targetId, Pointer<NativeEventTarget> nativePtr, ElementManager elementManager)
-      : super( targetId, nativePtr, elementManager, tagName: BODY, defaultStyle: _defaultStyle);
+      : super( targetId, nativePtr, elementManager, defaultStyle: _defaultStyle);
 
   @override
   void willAttachRenderer() {

--- a/kraken/lib/src/dom/elements/canvas/canvas.dart
+++ b/kraken/lib/src/dom/elements/canvas/canvas.dart
@@ -60,7 +60,6 @@ class CanvasElement extends Element {
           isIntrinsicBox: true,
           repaintSelf: true,
           defaultStyle: _defaultStyle,
-          tagName: CANVAS,
         ) {
     painter = CanvasPainter(repaint: repaintNotifier);
   }

--- a/kraken/lib/src/dom/elements/edits.dart
+++ b/kraken/lib/src/dom/elements/edits.dart
@@ -23,10 +23,10 @@ const Map<String, dynamic> _delDefaultStyle = {
 
 class DelElement extends Element {
   DelElement(int targetId, Pointer<NativeEventTarget> nativePtr, ElementManager elementManager)
-      : super(targetId, nativePtr, elementManager, tagName: DEL, defaultStyle: _delDefaultStyle);
+      : super(targetId, nativePtr, elementManager, defaultStyle: _delDefaultStyle);
 }
 
 class InsElement extends Element {
   InsElement(int targetId, Pointer<NativeEventTarget> nativePtr, ElementManager elementManager)
-      : super(targetId, nativePtr, elementManager, tagName: INS, defaultStyle: _insDefaultStyle);
+      : super(targetId, nativePtr, elementManager, defaultStyle: _insDefaultStyle);
 }

--- a/kraken/lib/src/dom/elements/forms.dart
+++ b/kraken/lib/src/dom/elements/forms.dart
@@ -18,10 +18,10 @@ const Map<String, dynamic> _defaultStyle = {
 
 class LabelElement extends Element {
   LabelElement(int targetId, Pointer<NativeEventTarget> nativePtr, ElementManager elementManager)
-      : super(targetId, nativePtr, elementManager, tagName: LABEL);
+      : super(targetId, nativePtr, elementManager);
 }
 
 class ButtonElement extends Element {
   ButtonElement(int targetId, Pointer<NativeEventTarget> nativePtr, ElementManager elementManager)
-      : super(targetId, nativePtr, elementManager, tagName: BUTTON, defaultStyle: _defaultStyle);
+      : super(targetId, nativePtr, elementManager, defaultStyle: _defaultStyle);
 }

--- a/kraken/lib/src/dom/elements/grouping_content.dart
+++ b/kraken/lib/src/dom/elements/grouping_content.dart
@@ -53,67 +53,67 @@ const Map<String, dynamic> _pDefaultStyle = {
 
 class DivElement extends Element {
   DivElement(int targetId, Pointer<NativeEventTarget> nativePtr, ElementManager elementManager)
-      : super(targetId, nativePtr, elementManager, tagName: DIV, defaultStyle: _defaultStyle);
+      : super(targetId, nativePtr, elementManager, defaultStyle: _defaultStyle);
 }
 
 class FigureElement extends Element {
   FigureElement(int targetId, Pointer<NativeEventTarget> nativePtr, ElementManager elementManager)
-      : super(targetId, nativePtr, elementManager, tagName: FIGURE, defaultStyle: _bDefaultStyle);
+      : super(targetId, nativePtr, elementManager, defaultStyle: _bDefaultStyle);
 }
 
 class FigureCaptionElement extends Element {
   FigureCaptionElement(int targetId, Pointer<NativeEventTarget> nativePtr, ElementManager elementManager)
-      : super(targetId, nativePtr, elementManager, tagName: FIGCAPTION, defaultStyle: _defaultStyle);
+      : super(targetId, nativePtr, elementManager, defaultStyle: _defaultStyle);
 }
 
 class BlockQuotationElement extends Element {
   BlockQuotationElement(int targetId, Pointer<NativeEventTarget> nativePtr, ElementManager elementManager)
-      : super(targetId, nativePtr, elementManager, tagName: BLOCKQUOTE, defaultStyle: _bDefaultStyle);
+      : super(targetId, nativePtr, elementManager, defaultStyle: _bDefaultStyle);
 }
 
 // https://html.spec.whatwg.org/multipage/grouping-content.html#htmlparagraphelement
 class ParagraphElement extends Element {
   static Map<String, dynamic> defaultStyle = _defaultStyle;
   ParagraphElement(int targetId, Pointer<NativeEventTarget> nativePtr, ElementManager elementManager)
-      : super(targetId, nativePtr, elementManager, tagName: PARAGRAPH, defaultStyle: defaultStyle);
+      : super(targetId, nativePtr, elementManager, defaultStyle: defaultStyle);
 }
 
 // https://html.spec.whatwg.org/multipage/grouping-content.html#htmlulistelement
 class UListElement extends Element {
   UListElement(int targetId, Pointer<NativeEventTarget> nativePtr, ElementManager elementManager)
-      : super(targetId, nativePtr, elementManager, tagName: UL, defaultStyle: _pDefaultStyle);
+      : super(targetId, nativePtr, elementManager, defaultStyle: _pDefaultStyle);
 }
 
 // https://html.spec.whatwg.org/multipage/grouping-content.html#htmlolistelement
 class OListElement extends Element {
   OListElement(int targetId, Pointer<NativeEventTarget> nativePtr, ElementManager elementManager)
-      : super(targetId, nativePtr, elementManager, tagName: OL, defaultStyle: _pDefaultStyle);
+      : super(targetId, nativePtr, elementManager, defaultStyle: _pDefaultStyle);
 }
 
 class LIElement extends Element {
   LIElement(int targetId, Pointer<NativeEventTarget> nativePtr, ElementManager elementManager)
-      : super(targetId, nativePtr, elementManager, tagName: LI, defaultStyle: _defaultStyle);
+      : super(targetId, nativePtr, elementManager, defaultStyle: _defaultStyle);
 }
 
 // https://html.spec.whatwg.org/multipage/grouping-content.html#htmlpreelement
 class PreElement extends Element {
   PreElement(int targetId, Pointer<NativeEventTarget> nativePtr, ElementManager elementManager)
-      : super(targetId, nativePtr, elementManager, tagName: PRE, defaultStyle: _preDefaultStyle);
+      : super(targetId, nativePtr, elementManager, defaultStyle: _preDefaultStyle);
 }
 
 // https://developer.mozilla.org/en-US/docs/Web/HTML/Element/dd
 class DDElement extends Element {
   DDElement(int targetId, Pointer<NativeEventTarget> nativePtr, ElementManager elementManager)
-      : super(targetId, nativePtr, elementManager, tagName: DD, defaultStyle: _ddDefaultStyle);
+      : super(targetId, nativePtr, elementManager, defaultStyle: _ddDefaultStyle);
 }
 
 class DTElement extends Element {
   DTElement(int targetId, Pointer<NativeEventTarget> nativePtr, ElementManager elementManager)
-      : super(targetId, nativePtr, elementManager, tagName: DT, defaultStyle: _defaultStyle);
+      : super(targetId, nativePtr, elementManager, defaultStyle: _defaultStyle);
 }
 
 // https://html.spec.whatwg.org/multipage/grouping-content.html#htmldlistelement
 class DListElement extends Element {
   DListElement(int targetId, Pointer<NativeEventTarget> nativePtr, ElementManager elementManager)
-      : super(targetId, nativePtr, elementManager, tagName: DL, defaultStyle: _pDefaultStyle);
+      : super(targetId, nativePtr, elementManager, defaultStyle: _pDefaultStyle);
 }

--- a/kraken/lib/src/dom/elements/head.dart
+++ b/kraken/lib/src/dom/elements/head.dart
@@ -26,32 +26,32 @@ const String SCRIPT = 'SCRIPT';
 
 class HeadElement extends Element {
   HeadElement(int targetId, Pointer<NativeEventTarget>   nativePtr, ElementManager elementManager)
-      : super(targetId, nativePtr, elementManager, tagName: HEAD, defaultStyle: _defaultStyle);
+      : super(targetId, nativePtr, elementManager, defaultStyle: _defaultStyle);
 }
 
 class LinkElement extends Element {
   LinkElement(int targetId, Pointer<NativeEventTarget> nativePtr, ElementManager elementManager)
-      : super(targetId, nativePtr, elementManager, tagName: LINK, defaultStyle: _defaultStyle);
+      : super(targetId, nativePtr, elementManager, defaultStyle: _defaultStyle);
 }
 
 class MetaElement extends Element {
   MetaElement(int targetId, Pointer<NativeEventTarget> nativePtr, ElementManager elementManager)
-      : super(targetId, nativePtr, elementManager, tagName: META, defaultStyle: _defaultStyle);
+      : super(targetId, nativePtr, elementManager, defaultStyle: _defaultStyle);
 }
 
 class TitleElement extends Element {
   TitleElement(int targetId, Pointer<NativeEventTarget> nativePtr, ElementManager elementManager)
-      : super(targetId, nativePtr, elementManager, tagName: TITLE, defaultStyle: _defaultStyle);
+      : super(targetId, nativePtr, elementManager, defaultStyle: _defaultStyle);
 }
 
 class NoScriptElement extends Element {
   NoScriptElement(int targetId, Pointer<NativeEventTarget> nativePtr, ElementManager elementManager)
-      : super(targetId, nativePtr, elementManager, tagName: NOSCRIPT, defaultStyle: _defaultStyle);
+      : super(targetId, nativePtr, elementManager, defaultStyle: _defaultStyle);
 }
 
 class ScriptElement extends Element {
   ScriptElement(int targetId, Pointer<NativeEventTarget> nativePtr, ElementManager elementManager)
-      : super(targetId, nativePtr, elementManager, tagName: SCRIPT, defaultStyle: _defaultStyle) {
+      : super(targetId, nativePtr, elementManager, defaultStyle: _defaultStyle) {
   }
 
   @override
@@ -94,5 +94,5 @@ class ScriptElement extends Element {
 // TODO
 class StyleElement extends Element {
   StyleElement(int targetId, Pointer<NativeEventTarget> nativePtr, ElementManager elementManager)
-      : super(targetId, nativePtr, elementManager, tagName: STYLE, defaultStyle: _defaultStyle);
+      : super(targetId, nativePtr, elementManager, defaultStyle: _defaultStyle);
 }

--- a/kraken/lib/src/dom/elements/headings.dart
+++ b/kraken/lib/src/dom/elements/headings.dart
@@ -65,30 +65,30 @@ const Map<String, dynamic> _h6DefaultStyle = {
 
 class H1Element extends Element {
   H1Element(int targetId, Pointer<NativeEventTarget> nativePtr, ElementManager elementManager)
-      : super(targetId, nativePtr, elementManager, tagName: H1, defaultStyle: _h1DefaultStyle);
+      : super(targetId, nativePtr, elementManager, defaultStyle: _h1DefaultStyle);
 }
 
 class H2Element extends Element {
   H2Element(int targetId, Pointer<NativeEventTarget> nativePtr, ElementManager elementManager)
-      : super(targetId, nativePtr, elementManager, tagName: H2, defaultStyle: _h2DefaultStyle);
+      : super(targetId, nativePtr, elementManager, defaultStyle: _h2DefaultStyle);
 }
 
 class H3Element extends Element {
   H3Element(int targetId, Pointer<NativeEventTarget> nativePtr, ElementManager elementManager)
-      : super(targetId, nativePtr, elementManager, tagName: H3, defaultStyle: _h3DefaultStyle);
+      : super(targetId, nativePtr, elementManager, defaultStyle: _h3DefaultStyle);
 }
 
 class H4Element extends Element {
   H4Element(int targetId, Pointer<NativeEventTarget> nativePtr, ElementManager elementManager)
-      : super(targetId, nativePtr, elementManager, tagName: H4, defaultStyle: _h4DefaultStyle);
+      : super(targetId, nativePtr, elementManager, defaultStyle: _h4DefaultStyle);
 }
 
 class H5Element extends Element {
   H5Element(int targetId, Pointer<NativeEventTarget> nativePtr, ElementManager elementManager)
-      : super(targetId, nativePtr, elementManager, tagName: H5, defaultStyle: _h5DefaultStyle);
+      : super(targetId, nativePtr, elementManager, defaultStyle: _h5DefaultStyle);
 }
 
 class H6Element extends Element {
   H6Element(int targetId, Pointer<NativeEventTarget> nativePtr, ElementManager elementManager)
-      : super(targetId, nativePtr, elementManager, tagName: H6, defaultStyle: _h6DefaultStyle);
+      : super(targetId, nativePtr, elementManager, defaultStyle: _h6DefaultStyle);
 }

--- a/kraken/lib/src/dom/elements/html.dart
+++ b/kraken/lib/src/dom/elements/html.dart
@@ -24,7 +24,6 @@ class HTMLElement extends Element {
       targetId,
       nativePtr,
       elementManager,
-      tagName: HTML,
       defaultStyle: defaultStyle
   ) {
     if (kProfileMode) {

--- a/kraken/lib/src/dom/elements/img.dart
+++ b/kraken/lib/src/dom/elements/img.dart
@@ -57,7 +57,6 @@ class ImageElement extends Element {
       nativeEventTarget,
       elementManager,
       isIntrinsicBox: true,
-      tagName: IMAGE,
       defaultStyle: _defaultStyle) {
     _renderStreamListener = ImageStreamListener(_renderImageStream, onError: _onImageError);
   }

--- a/kraken/lib/src/dom/elements/input.dart
+++ b/kraken/lib/src/dom/elements/input.dart
@@ -238,7 +238,7 @@ class InputElement extends Element implements TextInputClient, TickerProvider {
     this.textDirection = TextDirection.ltr,
     this.minLines = 1,
     this.maxLines = 1,
-  }) : super(targetId, nativeEventTarget, elementManager, tagName: INPUT, defaultStyle: _defaultStyle, isIntrinsicBox: true) {
+  }) : super(targetId, nativeEventTarget, elementManager, defaultStyle: _defaultStyle, isIntrinsicBox: true) {
     _textSelectionDelegate = EditableTextDelegate(this);
     scrollOffsetX = _scrollableX.position;
   }

--- a/kraken/lib/src/dom/elements/object.dart
+++ b/kraken/lib/src/dom/elements/object.dart
@@ -26,7 +26,7 @@ const Map<String, dynamic> _paramStyle = {
 // https://developer.mozilla.org/en-US/docs/Web/HTML/Element/param
 class ParamElement extends Element {
   ParamElement(int targetId, Pointer<NativeEventTarget> nativePtr, ElementManager elementManager)
-      : super(targetId, nativePtr, elementManager, tagName: PARAM, defaultStyle: _paramStyle);
+      : super(targetId, nativePtr, elementManager, defaultStyle: _paramStyle);
 }
 
 _DefaultObjectElementClient _DefaultObjectElementClientFactory(ObjectElementHost objectElementHost) {
@@ -40,7 +40,7 @@ class ObjectElement extends Element implements ObjectElementHost {
   late ObjectElementClient _objectElementClient;
 
   ObjectElement(int targetId, Pointer<NativeEventTarget> nativePtr, ElementManager elementManager)
-      : super(targetId, nativePtr, elementManager, tagName: OBJECT, defaultStyle: _objectStyle, isIntrinsicBox: true) {
+      : super(targetId, nativePtr, elementManager, defaultStyle: _objectStyle, isIntrinsicBox: true) {
     initObjectClient();
     initElementClient();
     initDetachCallback(elementManager);

--- a/kraken/lib/src/dom/elements/sections.dart
+++ b/kraken/lib/src/dom/elements/sections.dart
@@ -31,40 +31,40 @@ const Map<String, dynamic> _addressDefaultStyle = {
 
 class AddressElement extends Element {
   AddressElement(int targetId, Pointer<NativeEventTarget> nativePtr, ElementManager elementManager)
-      : super(targetId, nativePtr, elementManager, tagName: ADDRESS, defaultStyle: _addressDefaultStyle);
+      : super(targetId, nativePtr, elementManager, defaultStyle: _addressDefaultStyle);
 }
 
 class ArticleElement extends Element {
   ArticleElement(int targetId, Pointer<NativeEventTarget> nativePtr, ElementManager elementManager)
-      : super(targetId, nativePtr, elementManager, tagName: ARTICLE, defaultStyle: _defaultStyle);
+      : super(targetId, nativePtr, elementManager, defaultStyle: _defaultStyle);
 }
 
 class AsideElement extends Element {
   AsideElement(int targetId, Pointer<NativeEventTarget> nativePtr, ElementManager elementManager)
-      : super(targetId, nativePtr, elementManager, tagName: ASIDE, defaultStyle: _defaultStyle);
+      : super(targetId, nativePtr, elementManager, defaultStyle: _defaultStyle);
 }
 
 class FooterElement extends Element {
   FooterElement(int targetId, Pointer<NativeEventTarget> nativePtr, ElementManager elementManager)
-      : super(targetId, nativePtr, elementManager, tagName: FOOTER, defaultStyle: _defaultStyle);
+      : super(targetId, nativePtr, elementManager, defaultStyle: _defaultStyle);
 }
 
 class HeaderElement extends Element {
   HeaderElement(int targetId, Pointer<NativeEventTarget> nativePtr, ElementManager elementManager)
-      : super(targetId, nativePtr, elementManager, tagName: HEADER, defaultStyle: _defaultStyle);
+      : super(targetId, nativePtr, elementManager, defaultStyle: _defaultStyle);
 }
 
 class MainElement extends Element {
   MainElement(int targetId, Pointer<NativeEventTarget> nativePtr, ElementManager elementManager)
-      : super(targetId, nativePtr, elementManager, tagName: MAIN, defaultStyle: _defaultStyle);
+      : super(targetId, nativePtr, elementManager, defaultStyle: _defaultStyle);
 }
 
 class NavElement extends Element {
   NavElement(int targetId, Pointer<NativeEventTarget> nativePtr, ElementManager elementManager)
-      : super(targetId, nativePtr, elementManager, tagName: NAV, defaultStyle: _defaultStyle);
+      : super(targetId, nativePtr, elementManager, defaultStyle: _defaultStyle);
 }
 
 class SectionElement extends Element {
   SectionElement(int targetId, Pointer<NativeEventTarget> nativePtr, ElementManager elementManager)
-      : super(targetId, nativePtr, elementManager, tagName: SECTION, defaultStyle: _defaultStyle);
+      : super(targetId, nativePtr, elementManager, defaultStyle: _defaultStyle);
 }

--- a/kraken/lib/src/dom/elements/semantics_text.dart
+++ b/kraken/lib/src/dom/elements/semantics_text.dart
@@ -75,7 +75,6 @@ class BRElement extends Element {
   BRElement(int targetId, Pointer<NativeEventTarget> nativePtr, ElementManager elementManager)
       : super(
         targetId, nativePtr, elementManager,
-        tagName: BR,
         defaultStyle: _breakDefaultStyle,
         isIntrinsicBox: true,
       );
@@ -83,98 +82,98 @@ class BRElement extends Element {
 
 class BringElement extends Element {
   BringElement(int targetId, Pointer<NativeEventTarget> nativePtr, ElementManager elementManager)
-      : super(targetId, nativePtr, elementManager, tagName: B, defaultStyle: _boldDefaultStyle);
+      : super(targetId, nativePtr, elementManager, defaultStyle: _boldDefaultStyle);
 }
 
 class AbbreviationElement extends Element {
   AbbreviationElement(int targetId, Pointer<NativeEventTarget> nativePtr, ElementManager elementManager)
-      : super(targetId, nativePtr, elementManager, tagName: ABBR, defaultStyle: _abbrDefaultStyle);
+      : super(targetId, nativePtr, elementManager, defaultStyle: _abbrDefaultStyle);
 }
 
 class EmphasisElement extends Element {
   EmphasisElement(int targetId, Pointer<NativeEventTarget> nativePtr, ElementManager elementManager)
-      : super(targetId, nativePtr, elementManager, tagName: EM, defaultStyle: _defaultStyle);
+      : super(targetId, nativePtr, elementManager, defaultStyle: _defaultStyle);
 }
 
 class CitationElement extends Element {
   CitationElement(int targetId, Pointer<NativeEventTarget> nativePtr, ElementManager elementManager)
-      : super(targetId, nativePtr, elementManager, tagName: CITE, defaultStyle: _defaultStyle);
+      : super(targetId, nativePtr, elementManager, defaultStyle: _defaultStyle);
 }
 
 class DefinitionElement extends Element {
   DefinitionElement(int targetId, Pointer<NativeEventTarget> nativePtr, ElementManager elementManager)
-      : super(targetId, nativePtr, elementManager, tagName: DFN, defaultStyle: _defaultStyle);
+      : super(targetId, nativePtr, elementManager, defaultStyle: _defaultStyle);
 }
 
 // https://developer.mozilla.org/en-US/docs/Web/HTML/Element/i
 class IdiomaticElement extends Element {
   IdiomaticElement(int targetId, Pointer<NativeEventTarget> nativePtr, ElementManager elementManager)
-      : super(targetId, nativePtr, elementManager, tagName: I, defaultStyle: _defaultStyle);
+      : super(targetId, nativePtr, elementManager, defaultStyle: _defaultStyle);
 }
 
 class CodeElement extends Element {
   CodeElement(int targetId, Pointer<NativeEventTarget> nativePtr, ElementManager elementManager)
-      : super(targetId, nativePtr, elementManager, tagName: CODE, defaultStyle: _codeDefaultStyle);
+      : super(targetId, nativePtr, elementManager, defaultStyle: _codeDefaultStyle);
 }
 
 class SampleElement extends Element {
   SampleElement(int targetId, Pointer<NativeEventTarget> nativePtr, ElementManager elementManager)
-      : super(targetId, nativePtr, elementManager, tagName: SAMP, defaultStyle: _codeDefaultStyle);
+      : super(targetId, nativePtr, elementManager, defaultStyle: _codeDefaultStyle);
 }
 
 class KeyboardElement extends Element {
   KeyboardElement(int targetId, Pointer<NativeEventTarget> nativePtr, ElementManager elementManager)
-      : super(targetId, nativePtr, elementManager, tagName: KBD, defaultStyle: _codeDefaultStyle);
+      : super(targetId, nativePtr, elementManager, defaultStyle: _codeDefaultStyle);
 }
 
 class SpanElement extends Element {
   SpanElement(int targetId, Pointer<NativeEventTarget> nativePtr, ElementManager elementManager)
-      : super(targetId, nativePtr, elementManager, tagName: SPAN);
+      : super(targetId, nativePtr, elementManager);
 }
 
 class DataElement extends Element {
   DataElement(int targetId, Pointer<NativeEventTarget> nativePtr, ElementManager elementManager)
-      : super(targetId, nativePtr, elementManager, tagName: DATA);
+      : super(targetId, nativePtr, elementManager);
 }
 
 // TODO: enclosed text is a short inline quotation
 class QuoteElement extends Element {
   QuoteElement(int targetId, Pointer<NativeEventTarget> nativePtr, ElementManager elementManager)
-      : super(targetId, nativePtr, elementManager, tagName: Q);
+      : super(targetId, nativePtr, elementManager);
 }
 
 class StrongElement extends Element {
   StrongElement(int targetId, Pointer<NativeEventTarget> nativePtr, ElementManager elementManager)
-      : super(targetId, nativePtr, elementManager, tagName: STRONG, defaultStyle: _boldDefaultStyle);
+      : super(targetId, nativePtr, elementManager, defaultStyle: _boldDefaultStyle);
 }
 
 class TimeElement extends Element {
   TimeElement(int targetId, Pointer<NativeEventTarget> nativePtr, ElementManager elementManager)
-      : super(targetId, nativePtr, elementManager, tagName: TIME, defaultStyle: _boldDefaultStyle);
+      : super(targetId, nativePtr, elementManager, defaultStyle: _boldDefaultStyle);
 }
 
 class SmallElement extends Element {
   SmallElement(int targetId, Pointer<NativeEventTarget> nativePtr, ElementManager elementManager)
-      : super(targetId, nativePtr, elementManager, tagName: SMALL, defaultStyle: _smallDefaultStyle);
+      : super(targetId, nativePtr, elementManager, defaultStyle: _smallDefaultStyle);
 }
 
 class StrikethroughElement extends Element {
   StrikethroughElement(int targetId, Pointer<NativeEventTarget> nativePtr, ElementManager elementManager)
-      : super(targetId, nativePtr, elementManager, tagName: S, defaultStyle: _sDefaultStyle);
+      : super(targetId, nativePtr, elementManager, defaultStyle: _sDefaultStyle);
 }
 
 // https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-u-element
 class UnarticulatedElement extends Element {
   UnarticulatedElement(int targetId, Pointer<NativeEventTarget> nativePtr, ElementManager elementManager)
-      : super(targetId, nativePtr, elementManager, tagName: U, defaultStyle: _uDefaultStyle);
+      : super(targetId, nativePtr, elementManager, defaultStyle: _uDefaultStyle);
 }
 
 class VariableElement extends Element {
   VariableElement(int targetId, Pointer<NativeEventTarget> nativePtr, ElementManager elementManager)
-      : super(targetId, nativePtr, elementManager, tagName: VAR, defaultStyle: _defaultStyle);
+      : super(targetId, nativePtr, elementManager, defaultStyle: _defaultStyle);
 }
 
 class MarkElement extends Element {
   MarkElement(int targetId, Pointer<NativeEventTarget> nativePtr, ElementManager elementManager)
-      : super(targetId, nativePtr, elementManager, tagName: MARK, defaultStyle: _markDefaultStyle);
+      : super(targetId, nativePtr, elementManager, defaultStyle: _markDefaultStyle);
 }

--- a/kraken/lib/src/dom/elements/template.dart
+++ b/kraken/lib/src/dom/elements/template.dart
@@ -17,5 +17,5 @@ const Map<String, dynamic> _defaultStyle = {
 
 class TemplateElement extends Element {
   TemplateElement(int targetId, Pointer<NativeEventTarget> nativePtr, ElementManager elementManager)
-      : super( targetId, nativePtr, elementManager, tagName: TEMPLATE, defaultStyle: _defaultStyle);
+      : super( targetId, nativePtr, elementManager, defaultStyle: _defaultStyle);
 }

--- a/kraken/lib/src/dom/node.dart
+++ b/kraken/lib/src/dom/node.dart
@@ -19,7 +19,10 @@ enum NodeType {
 
 class Comment extends Node {
   Comment(int targetId, Pointer<NativeEventTarget> nativeEventTarget, ElementManager elementManager)
-      : super(NodeType.COMMENT_NODE, targetId, nativeEventTarget, elementManager, '#comment');
+      : super(NodeType.COMMENT_NODE, targetId, nativeEventTarget, elementManager);
+
+  @override
+  String get nodeName => '#comment';
 
   @override
   RenderObject? get renderer => null;
@@ -87,7 +90,7 @@ abstract class Node extends EventTarget implements RenderObjectNode, LifecycleCa
   List<Node> childNodes = [];
   Node? parentNode;
   NodeType nodeType;
-  String nodeName;
+  String get nodeName;
 
   /// The Node.parentNode read-only property returns the parent of the specified node in the DOM tree.
   Node? get parent => parentNode;
@@ -109,7 +112,7 @@ abstract class Node extends EventTarget implements RenderObjectNode, LifecycleCa
     return _children;
   }
 
-  Node(this.nodeType, int targetId, Pointer<NativeEventTarget> nativeEventTarget, ElementManager elementManager, this.nodeName)
+  Node(this.nodeType, int targetId, Pointer<NativeEventTarget> nativeEventTarget, ElementManager elementManager)
       : super(targetId, nativeEventTarget, elementManager);
 
   // If node is on the tree, the root parent is body.

--- a/kraken/lib/src/dom/text_node.dart
+++ b/kraken/lib/src/dom/text_node.dart
@@ -19,7 +19,7 @@ const String TAB_CHAR = '\t';
 
 class TextNode extends Node {
   TextNode(int targetId, Pointer<NativeEventTarget> nativeEventTarget, this._data, ElementManager elementManager)
-      : super(NodeType.TEXT_NODE, targetId, nativeEventTarget, elementManager, '#text');
+      : super(NodeType.TEXT_NODE, targetId, nativeEventTarget, elementManager);
 
   RenderTextBox? _renderTextBox;
 
@@ -75,6 +75,9 @@ class TextNode extends Node {
   }
 
   @override
+  String get nodeName => '#text';
+
+  @override
   RenderObject? get renderer => _renderTextBox;
 
   void updateTextStyle() {
@@ -84,8 +87,7 @@ class TextNode extends Node {
   }
 
   @override
-  handleJSCall(String method, List argv) {
-  }
+  handleJSCall(String method, List argv) {}
 
   void _setTextSizeType(BoxSizeType width, BoxSizeType height) {
     RenderTextBox? renderTextBox = _renderTextBox;

--- a/kraken/lib/widget.dart
+++ b/kraken/lib/widget.dart
@@ -63,14 +63,34 @@ const Map<String, dynamic> _defaultStyle = {
   DISPLAY: INLINE_BLOCK,
 };
 
-typedef WidgetCreator = Widget Function(Map<String, dynamic>);
+abstract class BaseCustomElementCreator {
+  final String tagName;
+  BaseCustomElementCreator(this.tagName);
+  dom.Element build(int targetId, Pointer<NativeEventTarget> nativeEventTarget, ElementManager elementManager);
+}
+
+abstract class BaseWidgetCreator {
+  Widget build(BuildContext context, Map<String, dynamic> properties);
+}
+
+class WidgetElementCreator extends BaseCustomElementCreator {
+  final BaseWidgetCreator creator;
+  WidgetElementCreator(String tagName, this.creator): super(tagName);
+
+  @override
+  dom.Element build(int targetId, Pointer<NativeEventTarget> nativeEventTarget, dom.ElementManager elementManager) {
+    return _WidgetCustomElement(targetId, nativeEventTarget, elementManager, tagName, creator);
+  }
+}
+
+// typedef WidgetCreator = Widget Function(Map<String, dynamic>);
 class _WidgetCustomElement extends dom.Element {
-  late WidgetCreator _widgetCreator;
+  late BaseWidgetCreator _widgetCreator;
   late Element _renderViewElement;
   late BuildOwner _buildOwner;
   late Widget _widget;
   _KrakenAdapterWidgetPropertiesState? _propertiesState;
-  _WidgetCustomElement(int targetId, Pointer<NativeEventTarget> nativePtr, dom.ElementManager elementManager, String tagName, WidgetCreator creator)
+  _WidgetCustomElement(int targetId, Pointer<NativeEventTarget> nativePtr, dom.ElementManager elementManager, String tagName, BaseWidgetCreator creator)
       : super(
       targetId,
       nativePtr,
@@ -142,7 +162,7 @@ class _KrakenAdapterWidget extends StatefulWidget {
 
 class _KrakenAdapterWidgetPropertiesState extends State<_KrakenAdapterWidget> {
   Map<String, dynamic> _properties;
-  final WidgetCreator _widgetCreator;
+  final BaseWidgetCreator _widgetCreator;
   _KrakenAdapterWidgetPropertiesState(this._widgetCreator, this._properties);
 
   void onAttributeChanged(Map<String, dynamic> properties) {
@@ -153,7 +173,7 @@ class _KrakenAdapterWidgetPropertiesState extends State<_KrakenAdapterWidget> {
 
   @override
   Widget build(BuildContext context) {
-    return _widgetCreator(_properties);
+    return _widgetCreator.build(context, _properties);
   }
 }
 
@@ -222,20 +242,11 @@ class Kraken extends StatefulWidget {
     return RegExp(r'^[a-z][.0-9_a-z]*-[\-.0-9_a-z]*$').hasMatch(localName);
   }
 
-  static void defineCustomElement<T extends Function>(String localName, T creator) {
-    if (!_isValidCustomElementName(localName)) {
-      throw ArgumentError('The element name "$localName" is not valid.');
+  static void defineCustomElement<T extends BaseCustomElementCreator>(T creator) {
+    if (!_isValidCustomElementName(creator.tagName)) {
+      throw ArgumentError('The element name "${creator.tagName}" is not valid.');
     }
-
-    String tagName = localName.toUpperCase();
-
-    if (T == ElementCreator) {
-      defineElement(tagName, creator as ElementCreator);
-    } else if (T == WidgetCreator) {
-      defineElement(tagName, (id, nativePtr, elementManager) {
-        return _WidgetCustomElement(id, nativePtr.cast<NativeEventTarget>(), elementManager, tagName, creator as WidgetCreator);
-      });
-    }
+    defineElement(creator.tagName.toUpperCase(), creator.build);
   }
 
   loadContent(String bundleContent) async {

--- a/kraken/lib/widget.dart
+++ b/kraken/lib/widget.dart
@@ -73,7 +73,6 @@ abstract class WidgetElement extends dom.Element {
       targetId,
       nativeEventTarget,
       elementManager,
-      tagName: '',
       isIntrinsicBox: true,
       defaultStyle: _defaultStyle
   );


### PR DESCRIPTION
Fixed #758

重新设计 `Kraken.defineCustomElement` API，支持通过此 API 扩展自定义 Element。

**1. 将一个 Widget 扩展成一个 Element**

```dart
class TextWidgetElement extends WidgetElement {
  TextWidgetElement(int targetId, Pointer<NativeEventTarget> nativeEventTarget, ElementManager elementManager) :
        super(targetId, nativeEventTarget, elementManager);

  @override
  Widget build(BuildContext context, Map<String, dynamic> properties) {
    return Text(properties['value'] ?? '', textDirection: TextDirection.ltr, style: TextStyle(color: Color.fromARGB(255, 100, 100, 100)));
  }
}
Kraken.defineCustomElement('flutter-text', (targetId, nativeEventTarget, elementManager) {
  return TextWidgetElement(targetId, nativeEventTarget, elementManager);
});
```

**自定义一个 Element**

```dart
class SampleElement extends Element { 
  // ..
}

Kraken.defineCustomElement('sample-element', (int targetId, Pointer<NativeEventTarget> nativeEventTarget, ElementManager elementManager) {
  return SampleElement(targetId, nativeEventTarget, elementManager);
});

```
