### PR TITLE
feat: add checks for quickjs gc mark.

### DIFF
--- a/bridge/bindings/qjs/bom/window.cc
+++ b/bridge/bindings/qjs/bom/window.cc
@@ -191,8 +191,9 @@ WindowInstance::WindowInstance(Window *window) : EventTargetInstance(window, Win
 void WindowInstance::gcMark(JSRuntime *rt, JSValue val, JS_MarkFunc *mark_func) {
   EventTargetInstance::gcMark(rt, val, mark_func);
 
-  JS_MarkValue(rt, m_location->jsObject, mark_func);
-  JS_MarkValue(rt, onerror, mark_func);
+  // Should check object is already inited before gc mark.
+  if (JS_IsObject(m_location->jsObject)) JS_MarkValue(rt, m_location->jsObject, mark_func);
+  if (JS_IsObject(onerror)) JS_MarkValue(rt, onerror, mark_func);
 }
 
 }

--- a/bridge/bindings/qjs/dom/elements/template_element.cc
+++ b/bridge/bindings/qjs/dom/elements/template_element.cc
@@ -69,7 +69,8 @@ TemplateElementInstance::~TemplateElementInstance() {
 
 void TemplateElementInstance::gcMark(JSRuntime *rt, JSValue val, JS_MarkFunc *mark_func) {
   NodeInstance::gcMark(rt, val, mark_func);
-  JS_MarkValue(rt, m_content->instanceObject, mark_func);
+  // Should check object is already inited before gc mark.
+  if (JS_IsObject(m_content->instanceObject)) JS_MarkValue(rt, m_content->instanceObject, mark_func);
 }
 
 }

--- a/bridge/bindings/qjs/dom/event_target.cc
+++ b/bridge/bindings/qjs/dom/event_target.cc
@@ -496,9 +496,10 @@ JSValue EventTargetInstance::getNativeProperty(const char *prop) {
 
 void EventTargetInstance::gcMark(JSRuntime *rt, JSValue val, JS_MarkFunc *mark_func) {
   // Tell gc eventTargetInstance have these properties.
-  JS_MarkValue(rt, m_eventHandlers, mark_func);
-  JS_MarkValue(rt, m_propertyEventHandler, mark_func);
-  JS_MarkValue(rt, m_properties, mark_func);
+  // Should check object is already inited before gc mark.
+  if (JS_IsObject(m_eventHandlers)) JS_MarkValue(rt, m_eventHandlers, mark_func);
+  if (JS_IsObject(m_propertyEventHandler)) JS_MarkValue(rt, m_propertyEventHandler, mark_func);
+  if (JS_IsObject(m_properties)) JS_MarkValue(rt, m_properties, mark_func);
 }
 
 void NativeEventTarget::dispatchEventImpl(NativeEventTarget *nativeEventTarget, NativeString *nativeEventType,

--- a/bridge/bindings/qjs/dom/node.cc
+++ b/bridge/bindings/qjs/dom/node.cc
@@ -608,8 +608,9 @@ void NodeInstance::ensureDetached(NodeInstance *node) {
 void NodeInstance::gcMark(JSRuntime *rt, JSValue val, JS_MarkFunc *mark_func) {
   EventTargetInstance::gcMark(rt, val, mark_func);
 
-  JS_MarkValue(rt, childNodes, mark_func);
-  JS_MarkValue(rt, parentNode, mark_func);
+  // Should check object is already inited before gc mark.
+  if (JS_IsObject(childNodes)) JS_MarkValue(rt, childNodes, mark_func);
+  if (JS_IsObject(parentNode)) JS_MarkValue(rt, parentNode, mark_func);
 }
 
 } // namespace kraken::binding::qjs


### PR DESCRIPTION
Fixed #799

JS_NewObject 的过程中有可能会触发 GC，进而调用 gcMark 函数。因此需要添加一定的检测，防止首个属性初始化过程中触发 GC，从而去 mark 一个还没有初始化的对象。