### PR TITLE
feat: disable http cache for windows and linux

### DIFF
--- a/bridge/bindings/qjs/js_context.h
+++ b/bridge/bindings/qjs/js_context.h
@@ -8,18 +8,17 @@
 
 #include <quickjs/list.h>
 #include <quickjs/quickjs.h>
+#include <atomic>
+#include <cassert>
+#include <cmath>
+#include <cstring>
+#include <locale>
 #include <memory>
+#include <mutex>
 #include <unordered_map>
 #include "js_context_macros.h"
 #include "kraken_foundation.h"
 #include "qjs_patch.h"
-#include <cmath>
-#include <cstring>
-#include <cassert>
-#include <cstring>
-#include <atomic>
-#include <locale>
-#include <mutex>
 using QjsContext = JSContext;
 using JSExceptionHandler = std::function<void(int32_t contextId, const char* message)>;
 

--- a/bridge/include/kraken_foundation.h
+++ b/bridge/include/kraken_foundation.h
@@ -6,16 +6,16 @@
 #ifndef KRAKENBRIDGE_FOUNDATION_H
 #define KRAKENBRIDGE_FOUNDATION_H
 
+#include <atomic>
+#include <cassert>
 #include <codecvt>
 #include <cstdint>
-#include <unordered_map>
-#include <vector>
-#include <cassert>
+#include <functional>
+#include <locale>
 #include <sstream>
 #include <string>
-#include <atomic>
-#include <locale>
-#include <functional>
+#include <unordered_map>
+#include <vector>
 #define HTML_TARGET_ID -1
 #define WINDOW_TARGET_ID -2
 #define DOCUMENT_TARGET_ID -3

--- a/bridge/kraken_bridge.cc
+++ b/bridge/kraken_bridge.cc
@@ -4,11 +4,11 @@
  */
 
 #include "kraken_bridge.h"
+#include <cassert>
 #include "dart_methods.h"
 #include "foundation/inspector_task_queue.h"
 #include "foundation/logging.h"
 #include "foundation/ui_task_queue.h"
-#include <cassert>
 #if KRAKEN_JSC_ENGINE
 #include "bindings/jsc/KOM/performance.h"
 #elif KRAKEN_QUICK_JS_ENGINE

--- a/kraken/lib/src/foundation/http_cache.dart
+++ b/kraken/lib/src/foundation/http_cache.dart
@@ -27,7 +27,8 @@ enum HttpCacheMode {
 }
 
 class HttpCacheController {
-  static HttpCacheMode mode = HttpCacheMode.DEFAULT;
+  // Disable HTTP Cache for Windows and Linux
+  static HttpCacheMode mode = Platform.isLinux && Platform.isWindows ? HttpCacheMode.NO_CACHE : HttpCacheMode.DEFAULT;
 
   static final Map<String, HttpCacheController> _controllers = HashMap();
 

--- a/kraken/lib/src/foundation/http_cache.dart
+++ b/kraken/lib/src/foundation/http_cache.dart
@@ -27,8 +27,8 @@ enum HttpCacheMode {
 }
 
 class HttpCacheController {
-  // Disable HTTP Cache for Windows and Linux
-  static HttpCacheMode mode = Platform.isLinux && Platform.isWindows ? HttpCacheMode.NO_CACHE : HttpCacheMode.DEFAULT;
+  // TODO: Add HTTP Cache for Windows and Linux
+  static HttpCacheMode mode = Platform.isLinux || Platform.isWindows ? HttpCacheMode.NO_CACHE : HttpCacheMode.DEFAULT;
 
   static final Map<String, HttpCacheController> _controllers = HashMap();
 


### PR DESCRIPTION
We don't have native implementation of temporary directory on Windows and Linux platform.
So we temporary disable it.