### PR TITLE
fix: fix crash when reportError.

### DIFF
--- a/bridge/bindings/qjs/js_context.cc
+++ b/bridge/bindings/qjs/js_context.cc
@@ -327,7 +327,7 @@ void JSContext::dispatchGlobalPromiseRejectionEvent(JSValueConst promise, JSValu
 }
 
 void JSContext::promiseRejectTracker(QjsContext* ctx, JSValue promise, JSValue reason, int is_handled, void* opaque) {
-  auto *context = static_cast<JSContext *>(JS_GetContextOpaque(ctx));
+  auto* context = static_cast<JSContext*>(JS_GetContextOpaque(ctx));
   context->reportError(reason);
   context->dispatchGlobalPromiseRejectionEvent(promise, reason);
 }

--- a/bridge/bindings/qjs/js_context.cc
+++ b/bridge/bindings/qjs/js_context.cc
@@ -65,7 +65,7 @@ JSContext::JSContext(int32_t contextId, const JSExceptionHandler& handler, void*
   JS_DefinePropertyGetSet(m_ctx, globalObject, windowKey, windowGetter, JS_UNDEFINED, JS_PROP_HAS_GET | JS_PROP_ENUMERABLE);
   JS_FreeAtom(m_ctx, windowKey);
   JS_SetContextOpaque(m_ctx, this);
-  JS_SetHostPromiseRejectionTracker(m_runtime, promiseRejectTracker, this);
+  JS_SetHostPromiseRejectionTracker(m_runtime, promiseRejectTracker, nullptr);
 
   runningContexts++;
 }
@@ -327,7 +327,7 @@ void JSContext::dispatchGlobalPromiseRejectionEvent(JSValueConst promise, JSValu
 }
 
 void JSContext::promiseRejectTracker(QjsContext* ctx, JSValue promise, JSValue reason, int is_handled, void* opaque) {
-  auto* context = static_cast<JSContext*>(opaque);
+  auto *context = static_cast<JSContext *>(JS_GetContextOpaque(ctx));
   context->reportError(reason);
   context->dispatchGlobalPromiseRejectionEvent(promise, reason);
 }


### PR DESCRIPTION
修复当一个 新的 Context 创建后，新的 Context 会覆盖原先 context 所注册的 JS_SetHostPromiseRejectionTracker 回调，导致原先 context 触发 promise 异常时找不到上下文。