### PR TITLE
Fix/some sliver usage cases

### DIFF
--- a/integration_tests/specs/css/css-display/sliver.ts
+++ b/integration_tests/specs/css/css-display/sliver.ts
@@ -199,4 +199,17 @@ describe('display sliver', () => {
 
     await simulateClick(50, 20); // Will trigger done.
   });
+
+  it('sliver child with none-static position not throw errors', () => {
+    var container = createSliverBasicCase();
+    var firstChild = container.firstChild; // should be element.
+    firstChild.style.position = 'relative';
+    
+    var innerChild = document.createElement('div');
+    innerChild.appendChild(document.createTextNode('helloworld'));
+    innerChild.style.position = 'relative';
+    innerChild.style.top = innerChild.style.left = '15px';
+    firstChild?.appendChild(innerChild);
+    await snapshot();
+  });
 });

--- a/integration_tests/specs/css/css-display/sliver.ts
+++ b/integration_tests/specs/css/css-display/sliver.ts
@@ -200,7 +200,7 @@ describe('display sliver', () => {
     await simulateClick(50, 20); // Will trigger done.
   });
 
-  it('sliver child with none-static position not throw errors', () => {
+  it('sliver child with none-static position not throw errors', async () => {
     var container = createSliverBasicCase();
     var firstChild = container.firstChild; // should be element.
     firstChild.style.position = 'relative';

--- a/integration_tests/specs/window/global.ts
+++ b/integration_tests/specs/window/global.ts
@@ -1,4 +1,4 @@
-describe('windowisglobal', () => {
+describe('window', () => {
   it('window equal to globalThis', () => {
     expect(window).toBe(globalThis as any);
   });
@@ -7,6 +7,7 @@ describe('windowisglobal', () => {
     // @ts-ignore
     expect(typeof window.kraken).toBe('object');
   });
+
   it('equal to this', () => {
     function f() {
       // @ts-ignore

--- a/kraken/lib/src/css/display.dart
+++ b/kraken/lib/src/css/display.dart
@@ -14,7 +14,7 @@ enum CSSDisplay {
   flex,
   inlineFlex,
 
-  sliver, // @TODO temp name.
+  sliver,
 
   none
 }
@@ -26,7 +26,7 @@ mixin CSSDisplayMixin on RenderStyleBase {
   set display(CSSDisplay value) {
     if (_display != value) {
       _display = value;
-      
+
       // Display effect the stacking context.
       RenderBoxModel? parentRenderer = (this as RenderStyle).parent?.renderBoxModel;
       if (parentRenderer is RenderLayoutBox) {

--- a/kraken/lib/src/css/overflow.dart
+++ b/kraken/lib/src/css/overflow.dart
@@ -217,7 +217,10 @@ mixin ElementOverflowMixin on ElementBase {
   }
 
   void scrollingContentBoxStyleListener(String property, String? original, String present) {
-    RenderLayoutBox scrollingContentBox = (renderBoxModel as RenderLayoutBox).renderScrollingContent!;
+    RenderLayoutBox? scrollingContentBox = (renderBoxModel as RenderLayoutBox).renderScrollingContent;
+    // Sliver content has no multi scroll content box.
+    if (scrollingContentBox == null) return;
+
     RenderStyle scrollingContentRenderStyle = scrollingContentBox.renderStyle;
 
     switch (property) {

--- a/kraken/lib/src/css/positioned.dart
+++ b/kraken/lib/src/css/positioned.dart
@@ -31,13 +31,16 @@ BoxSizeType? _getChildHeightSizeType(RenderBox child) {
 
 // RenderPositionHolder may be affected by overflow: scroller offset.
 // We need to reset these offset to keep positioned elements render at their original position.
+// @NOTE: Attention that renderObjects in tree may not all subtype of RenderBoxModel, use `is` to identify.
 Offset? _getRenderPositionHolderScrollOffset(RenderPositionPlaceholder holder, RenderObject root) {
-  RenderBoxModel? parent = holder.parent as RenderBoxModel?;
-  while (parent != null && parent != root) {
-    if (parent.clipX || parent.clipY) {
-      return Offset(parent.scrollLeft, parent.scrollTop);
+  AbstractNode? current = holder.parent;
+  while (current != null && current != root) {
+    if (current is RenderBoxModel) {
+      if (current.clipX || current.clipY) {
+        return Offset(current.scrollLeft, current.scrollTop);
+      }
     }
-    parent = parent.parent as RenderBoxModel?;
+    current = current.parent;
   }
   return null;
 }

--- a/kraken/lib/src/css/style_declaration.dart
+++ b/kraken/lib/src/css/style_declaration.dart
@@ -367,7 +367,14 @@ class CSSStyleDeclaration {
   }
 
   void flushPendingProperties() {
-    if (target?.parentNode?.renderer == null) return;
+    Element? _target = target;
+    // If style target element not exists, no need to do flush operation.
+    if (_target == null) return;
+    // If target's renderer has created, but not adopted by a parent,
+    // in most cases it's a sliver child orphan, should not flush styles.
+    if (_target.renderer?.parent == null) return;
+    // If target's parent element has no renderer attached, no need to flush.
+    if (_target.parentNode?.isRendererAttached == false) return;
 
     // Display change from none to other value that the renderBoxModel is null.
     if (_pendingProperties.containsKey(DISPLAY) && target!.isConnected) {

--- a/kraken/lib/src/css/style_declaration.dart
+++ b/kraken/lib/src/css/style_declaration.dart
@@ -370,8 +370,8 @@ class CSSStyleDeclaration {
     Element? _target = target;
     // If style target element not exists, no need to do flush operation.
     if (_target == null) return;
-    // If target's parent element has no renderer attached, no need to flush.
-    if (_target.parentNode?.renderer == null) return;
+    // If target has no renderer attached, skip flush.
+    if (!_target.isRendererAttached) return;
 
     // Display change from none to other value that the renderBoxModel is null.
     if (_pendingProperties.containsKey(DISPLAY) && _target.isConnected) {

--- a/kraken/lib/src/css/style_declaration.dart
+++ b/kraken/lib/src/css/style_declaration.dart
@@ -370,9 +370,6 @@ class CSSStyleDeclaration {
     Element? _target = target;
     // If style target element not exists, no need to do flush operation.
     if (_target == null) return;
-    // If target's renderer has created, but not adopted by a parent,
-    // in most cases it's a sliver child orphan, should not flush styles.
-    if (_target.renderer?.parent == null) return;
     // If target's parent element has no renderer attached, no need to flush.
     if (_target.parentNode?.isRendererAttached == false) return;
 

--- a/kraken/lib/src/css/style_declaration.dart
+++ b/kraken/lib/src/css/style_declaration.dart
@@ -370,17 +370,19 @@ class CSSStyleDeclaration {
     Element? _target = target;
     // If style target element not exists, no need to do flush operation.
     if (_target == null) return;
-    // If target has no renderer attached, skip flush.
-    if (!_target.isRendererAttached) return;
 
     // Display change from none to other value that the renderBoxModel is null.
-    if (_pendingProperties.containsKey(DISPLAY) && _target.isConnected) {
+    if (_pendingProperties.containsKey(DISPLAY) && _target.isConnected &&
+        _target.parentElement?.renderStyle.display != CSSDisplay.sliver) {
       String? prevValue = _properties[DISPLAY];
       String currentValue = _pendingProperties[DISPLAY]!;
       _properties[DISPLAY] = currentValue;
       _pendingProperties.remove(DISPLAY);
       _emitPropertyChanged(DISPLAY, prevValue, currentValue);
     }
+
+    // If target has no renderer attached, no need to flush.
+    if (!_target.isRendererAttached) return;
 
     RenderBoxModel? renderBoxModel = _target.renderBoxModel;
     if (_pendingProperties.isEmpty || renderBoxModel == null) {

--- a/kraken/lib/src/css/style_declaration.dart
+++ b/kraken/lib/src/css/style_declaration.dart
@@ -371,10 +371,10 @@ class CSSStyleDeclaration {
     // If style target element not exists, no need to do flush operation.
     if (_target == null) return;
     // If target's parent element has no renderer attached, no need to flush.
-    if (_target.parentNode?.isRendererAttached == false) return;
+    if (_target.parentNode?.renderer == null) return;
 
     // Display change from none to other value that the renderBoxModel is null.
-    if (_pendingProperties.containsKey(DISPLAY) && target!.isConnected) {
+    if (_pendingProperties.containsKey(DISPLAY) && _target.isConnected) {
       String? prevValue = _properties[DISPLAY];
       String currentValue = _pendingProperties[DISPLAY]!;
       _properties[DISPLAY] = currentValue;
@@ -382,7 +382,7 @@ class CSSStyleDeclaration {
       _emitPropertyChanged(DISPLAY, prevValue, currentValue);
     }
 
-    RenderBoxModel? renderBoxModel = target!.renderBoxModel;
+    RenderBoxModel? renderBoxModel = _target.renderBoxModel;
     if (_pendingProperties.isEmpty || renderBoxModel == null) {
       return;
     }

--- a/kraken/lib/src/dom/element.dart
+++ b/kraken/lib/src/dom/element.dart
@@ -501,7 +501,6 @@ class Element extends Node
 
     // Detach renderBoxModel from original parent.
     _detachRenderBoxModel(_renderBoxModel);
-
     _updateRenderBoxModel();
     _addToContainingBlock(after: previousSibling);
 

--- a/kraken/lib/src/dom/element.dart
+++ b/kraken/lib/src/dom/element.dart
@@ -481,11 +481,6 @@ class Element extends Node
     RenderBoxModel _renderBoxModel = renderBoxModel!;
     CSSPositionType currentPosition = renderStyle.position;
 
-    // If renderer itself not attached, no need to re-attach it.
-    if (!_renderBoxModel.attached) {
-      return;
-    }
-
     // Remove fixed children before convert to non repaint boundary renderObject
     if (currentPosition != CSSPositionType.fixed) {
       _removeFixedChild(_renderBoxModel, elementManager.viewportElement._renderLayoutBox!);

--- a/kraken/lib/src/dom/element.dart
+++ b/kraken/lib/src/dom/element.dart
@@ -477,6 +477,11 @@ class Element extends Node
     RenderBoxModel _renderBoxModel = renderBoxModel!;
     CSSPositionType currentPosition = renderStyle.position;
 
+    // If renderer itself not attached, no need to re-attach it.
+    if (!_renderBoxModel.attached) {
+      return;
+    }
+
     // Remove fixed children before convert to non repaint boundary renderObject
     if (currentPosition != CSSPositionType.fixed) {
       _removeFixedChild(_renderBoxModel, elementManager.viewportElement._renderLayoutBox!);

--- a/kraken/lib/src/dom/element.dart
+++ b/kraken/lib/src/dom/element.dart
@@ -192,7 +192,11 @@ class Element extends Node
       RenderBox? after;
       if (previousRenderBoxModel != null) {
         parentRenderBox = previousRenderBoxModel.parent as RenderBox?;
-        after = (previousRenderBoxModel.parentData as ContainerParentDataMixin<RenderBox>?)?.previousSibling;
+
+        if (previousRenderBoxModel.parentData is ContainerParentDataMixin<RenderBox>) {
+          after = (previousRenderBoxModel.parentData as ContainerParentDataMixin<RenderBox>).previousSibling;
+        }
+
         _detachRenderBoxModel(previousRenderBoxModel);
 
         if (parentRenderBox != null) {

--- a/kraken/lib/src/dom/elements/head.dart
+++ b/kraken/lib/src/dom/elements/head.dart
@@ -131,6 +131,7 @@ class StyleElement extends Element {
       type = value.toString().toLowerCase().trim();
     }
   }
+
   @override
   void connectedCallback() {
     if (type == _CSS_MIME) {

--- a/kraken/lib/src/dom/elements/html.dart
+++ b/kraken/lib/src/dom/elements/html.dart
@@ -41,6 +41,8 @@ class HTMLElement extends Element {
     super.attachTo(parent);
     if (renderBoxModel != null) {
       elementManager.viewport.child = renderBoxModel!;
+      // Flush pending style immediately.
+      style.flushPendingProperties();
     }
   }
 

--- a/kraken/lib/src/dom/elements/html.dart
+++ b/kraken/lib/src/dom/elements/html.dart
@@ -64,4 +64,7 @@ class HTMLElement extends Element {
 
   @override
   String get tagName => HTML;
+
+  @override
+  bool get isRendererAttached => true;
 }

--- a/kraken/lib/src/dom/sliver_manager.dart
+++ b/kraken/lib/src/dom/sliver_manager.dart
@@ -49,11 +49,6 @@ class RenderSliverElementChildManager implements RenderSliverBoxChildManager {
     childNode.willAttachRenderer();
 
     RenderBox? child;
-
-    if (childNode is Element) {
-      childNode.style.flushPendingProperties();
-    }
-
     if (childNode is Node) {
       child = childNode.renderer;
     } else {
@@ -68,8 +63,11 @@ class RenderSliverElementChildManager implements RenderSliverBoxChildManager {
       _sliverListLayout.insertSliverChild(child, after: after);
     }
 
+    if (childNode is Element) {
+      childNode.style.flushPendingProperties();
+    }
+
     childNode.didAttachRenderer();
-    childNode.ensureChildAttached();
   }
 
   RenderBox _createEmptyRenderObject() {

--- a/kraken/lib/src/rendering/box_model.dart
+++ b/kraken/lib/src/rendering/box_model.dart
@@ -551,7 +551,7 @@ class RenderLayoutBox extends RenderBoxModel
     super.dispose();
 
     stickyChildren.clear();
-    _paintingOrder = null;                                                                                                                                                      
+    _paintingOrder = null;
   }
 
 }

--- a/kraken/lib/src/rendering/flex.dart
+++ b/kraken/lib/src/rendering/flex.dart
@@ -920,19 +920,23 @@ class RenderFlexLayout extends RenderLayoutBox {
         childNodeId = child.hashCode;
       }
 
-      if (child is RenderPositionPlaceholder && isPlaceholderPositioned(child)) {
-        RenderBoxModel realDisplayedBox = child.positioned!;
-        // Flutter only allow access size of direct children, so cannot use realDisplayedBox.size
-        Size realDisplayedBoxSize =
-            realDisplayedBox.getBoxSize(realDisplayedBox.contentSize);
-        double realDisplayedBoxWidth = realDisplayedBoxSize.width;
-        double realDisplayedBoxHeight = realDisplayedBoxSize.height;
-        childConstraints = BoxConstraints(
-          minWidth: realDisplayedBoxWidth,
-          maxWidth: realDisplayedBoxWidth,
-          minHeight: realDisplayedBoxHeight,
-          maxHeight: realDisplayedBoxHeight,
-        );
+      if (isPlaceholderPositioned(child)) {
+        RenderBoxModel realDisplayedBox = (child as RenderPositionPlaceholder).positioned!;
+        if (realDisplayedBox.hasSize) {
+          // Flutter only allow access size of direct children, so cannot use realDisplayedBox.size
+          Size realDisplayedBoxSize =
+          realDisplayedBox.getBoxSize(realDisplayedBox.contentSize);
+          double realDisplayedBoxWidth = realDisplayedBoxSize.width;
+          double realDisplayedBoxHeight = realDisplayedBoxSize.height;
+          childConstraints = BoxConstraints(
+            minWidth: realDisplayedBoxWidth,
+            maxWidth: realDisplayedBoxWidth,
+            minHeight: realDisplayedBoxHeight,
+            maxHeight: realDisplayedBoxHeight,
+          );
+        } else {
+          childConstraints = BoxConstraints();
+        }
       } else if (child is RenderBoxModel) {
         childConstraints = child.getConstraints();
       } else if (child is RenderTextBox) {

--- a/kraken/lib/src/rendering/flex.dart
+++ b/kraken/lib/src/rendering/flex.dart
@@ -667,7 +667,7 @@ class RenderFlexLayout extends RenderLayoutBox {
       // Layout placeholder of positioned element(absolute/fixed) in new layer
       if (child is RenderBoxModel && childParentData.isPositioned) {
         CSSPositionedLayout.layoutPositionedChild(this, child);
-      } else if (child is RenderPositionPlaceholder && isPlaceholderPositioned(child)) {
+      } else if (child is RenderPositionPlaceholder && _isPlaceholderPositioned(child)) {
         _layoutChildren(child);
       }
 
@@ -714,19 +714,6 @@ class RenderFlexLayout extends RenderLayoutBox {
     }
 
     didLayout();
-  }
-
-
-  bool isPlaceholderPositioned(RenderObject child) {
-    if (child is RenderPositionPlaceholder) {
-      RenderBoxModel realDisplayedBox = child.positioned!;
-      RenderLayoutParentData parentData =
-          realDisplayedBox.parentData as RenderLayoutParentData;
-      if (parentData.isPositioned) {
-        return true;
-      }
-    }
-    return false;
   }
 
   /// There are 4 stages when layouting children
@@ -906,7 +893,7 @@ class RenderFlexLayout extends RenderLayoutBox {
       // Exclude positioned placeholder renderObject when layout non placeholder object
       // and positioned renderObject
       if (placeholderChild == null &&
-          (isPlaceholderPositioned(child) || childParentData!.isPositioned)) {
+          (_isPlaceholderPositioned(child) || childParentData!.isPositioned)) {
         child = childParentData!.nextSibling;
         continue;
       }
@@ -920,12 +907,11 @@ class RenderFlexLayout extends RenderLayoutBox {
         childNodeId = child.hashCode;
       }
 
-      if (isPlaceholderPositioned(child)) {
-        RenderBoxModel realDisplayedBox = (child as RenderPositionPlaceholder).positioned!;
-        if (realDisplayedBox.hasSize) {
+      if (_isPlaceholderPositioned(child)) {
+        RenderBoxModel positionedBox = (child as RenderPositionPlaceholder).positioned!;
+        if (positionedBox.hasSize) {
           // Flutter only allow access size of direct children, so cannot use realDisplayedBox.size
-          Size realDisplayedBoxSize =
-          realDisplayedBox.getBoxSize(realDisplayedBox.contentSize);
+          Size realDisplayedBoxSize = positionedBox.getBoxSize(positionedBox.contentSize);
           double realDisplayedBoxWidth = realDisplayedBoxSize.width;
           double realDisplayedBoxHeight = realDisplayedBoxSize.height;
           childConstraints = BoxConstraints(
@@ -1349,7 +1335,7 @@ class RenderFlexLayout extends RenderLayoutBox {
 
         // Whether child is positioned placeholder or positioned renderObject
         bool isChildPositioned = placeholderChild == null &&
-            (isPlaceholderPositioned(child) || childParentData!.isPositioned);
+            (_isPlaceholderPositioned(child) || childParentData!.isPositioned);
         // Whether child cross size should be changed based on cross axis alignment change
         bool isCrossSizeChanged = false;
 
@@ -2012,7 +1998,7 @@ class RenderFlexLayout extends RenderLayoutBox {
         // Exclude positioned placeholder renderObject when layout non placeholder object
         // and positioned renderObject
         if (placeholderChild == null &&
-            (isPlaceholderPositioned(child) || childParentData!.isPositioned)) {
+            (_isPlaceholderPositioned(child) || childParentData!.isPositioned)) {
           child = childParentData!.nextSibling;
           continue;
         }
@@ -2499,6 +2485,17 @@ class RenderFlexLayout extends RenderLayoutBox {
         DiagnosticsProperty<AlignItems>('alignItems', renderStyle.alignItems));
     properties
         .add(DiagnosticsProperty<FlexWrap>('flexWrap', renderStyle.flexWrap));
+  }
+
+  static bool _isPlaceholderPositioned(RenderObject child) {
+    if (child is RenderPositionPlaceholder) {
+      RenderBoxModel realDisplayedBox = child.positioned!;
+      RenderLayoutParentData parentData = realDisplayedBox.parentData as RenderLayoutParentData;
+      if (parentData.isPositioned) {
+        return true;
+      }
+    }
+    return false;
   }
 }
 


### PR DESCRIPTION
1. 修复 position 非 static 的场景在 sliver 下报错的问题
2. 双层滚动容器逻辑在 sliver 滚动场景下异常的问题
3. Sliver 节点初始化的时候随着 Element#attachTo 创建了 RenderObject 的问题 (消耗内存和计算)