### PR TITLE
fix: fix document.createElement in multiple context

### DIFF
--- a/bridge/bindings/qjs/dom/document.cc
+++ b/bridge/bindings/qjs/dom/document.cc
@@ -164,7 +164,7 @@ JSValue Document::createElement(QjsContext* ctx, JSValue this_val, int argc, JSV
   auto document = static_cast<DocumentInstance*>(JS_GetOpaque(this_val, Document::classId()));
   auto* context = static_cast<JSContext*>(JS_GetContextOpaque(ctx));
   std::string tagName = jsValueToStdString(ctx, tagNameValue);
-  JSValue constructor = static_cast<Document *>(document->prototype())->getElementConstructor(document->m_context, tagName);
+  JSValue constructor = static_cast<Document*>(document->prototype())->getElementConstructor(document->m_context, tagName);
 
   JSValue element = JS_CallConstructor(ctx, constructor, argc, argv);
   return element;

--- a/bridge/bindings/qjs/dom/document.h
+++ b/bridge/bindings/qjs/dom/document.h
@@ -39,7 +39,13 @@ class Document : public Node {
   static JSValue getElementsByTagName(QjsContext* ctx, JSValueConst this_val, int argc, JSValueConst* argv);
   static JSValue getElementsByClassName(QjsContext* ctx, JSValueConst this_val, int argc, JSValueConst* argv);
 
+  JSValue getElementConstructor(JSContext* context, const std::string& tagName);
+  bool isCustomElement(const std::string& tagName);
+
  private:
+
+  void defineElement(const std::string& tagName, Element* constructor);
+
   ObjectFunction m_createEvent{m_context, m_prototypeObject, "createEvent", createEvent, 1};
   ObjectFunction m_createElement{m_context, m_prototypeObject, "createElement", createElement, 1};
   ObjectFunction m_createDocumentFragment{m_context, m_prototypeObject, "createDocumentFragment", createDocumentFragment, 0};
@@ -52,6 +58,7 @@ class Document : public Node {
 
   bool event_registered{false};
   bool document_registered{false};
+  std::unordered_map<std::string, Element*> elementConstructorMap;
 };
 
 class DocumentCookie {

--- a/bridge/bindings/qjs/dom/document.h
+++ b/bridge/bindings/qjs/dom/document.h
@@ -43,7 +43,6 @@ class Document : public Node {
   bool isCustomElement(const std::string& tagName);
 
  private:
-
   void defineElement(const std::string& tagName, Element* constructor);
 
   ObjectFunction m_createEvent{m_context, m_prototypeObject, "createEvent", createEvent, 1};

--- a/bridge/bindings/qjs/dom/document_test.cc
+++ b/bridge/bindings/qjs/dom/document_test.cc
@@ -50,3 +50,32 @@ TEST(Document, instanceofNode) {
   EXPECT_EQ(errorCalled, false);
   EXPECT_EQ(logCalled, true);
 }
+
+TEST(Document, createElementShouldWorkWithMultipleContext) {
+  kraken::JSBridge::consoleMessageHandler = [](void* ctx, const std::string& message, int logLevel) {
+  };
+
+  kraken::JSBridge *bridge1;
+
+  const char* code = "(() => { let img = document.createElement('img'); document.body.appendChild(img);  })();";
+
+  {
+    auto* bridge = bridge1 = new kraken::JSBridge(0, [](int32_t contextId, const char* errmsg) {
+    });
+    auto& context = bridge->getContext();
+    bridge->evaluateScript(code, strlen(code), "vm://", 0);
+  }
+
+  {
+    auto* bridge = new kraken::JSBridge(1, [](int32_t contextId, const char* errmsg) {
+    });
+    auto& context = bridge->getContext();
+    const char* code = "(() => { let img = document.createElement('img'); document.body.appendChild(img);  })();";
+    bridge->evaluateScript(code, strlen(code), "vm://", 0);
+    delete bridge;
+  }
+
+  bridge1->evaluateScript(code, strlen(code), "vm://", 0);
+
+  delete bridge1;
+}

--- a/bridge/bindings/qjs/dom/document_test.cc
+++ b/bridge/bindings/qjs/dom/document_test.cc
@@ -52,23 +52,20 @@ TEST(Document, instanceofNode) {
 }
 
 TEST(Document, createElementShouldWorkWithMultipleContext) {
-  kraken::JSBridge::consoleMessageHandler = [](void* ctx, const std::string& message, int logLevel) {
-  };
+  kraken::JSBridge::consoleMessageHandler = [](void* ctx, const std::string& message, int logLevel) {};
 
-  kraken::JSBridge *bridge1;
+  kraken::JSBridge* bridge1;
 
   const char* code = "(() => { let img = document.createElement('img'); document.body.appendChild(img);  })();";
 
   {
-    auto* bridge = bridge1 = new kraken::JSBridge(0, [](int32_t contextId, const char* errmsg) {
-    });
+    auto* bridge = bridge1 = new kraken::JSBridge(0, [](int32_t contextId, const char* errmsg) {});
     auto& context = bridge->getContext();
     bridge->evaluateScript(code, strlen(code), "vm://", 0);
   }
 
   {
-    auto* bridge = new kraken::JSBridge(1, [](int32_t contextId, const char* errmsg) {
-    });
+    auto* bridge = new kraken::JSBridge(1, [](int32_t contextId, const char* errmsg) {});
     auto& context = bridge->getContext();
     const char* code = "(() => { let img = document.createElement('img'); document.body.appendChild(img);  })();";
     bridge->evaluateScript(code, strlen(code), "vm://", 0);

--- a/bridge/bindings/qjs/dom/element.cc
+++ b/bridge/bindings/qjs/dom/element.cc
@@ -130,10 +130,10 @@ JSValue Element::instanceConstructor(QjsContext* ctx, JSValue func_obj, JSValue 
     return JS_ThrowTypeError(ctx, "Illegal constructor");
   }
 
-  auto *context = static_cast<JSContext *>(JS_GetContextOpaque(ctx));
+  auto* context = static_cast<JSContext*>(JS_GetContextOpaque(ctx));
   std::string name = jsValueToStdString(ctx, tagName);
 
-  auto *Document = Document::instance(context);
+  auto* Document = Document::instance(context);
   if (Document->isCustomElement(name)) {
     return JS_CallConstructor(ctx, Document->getElementConstructor(context, name), argc, argv);
   }

--- a/bridge/bindings/qjs/dom/element.h
+++ b/bridge/bindings/qjs/dom/element.h
@@ -87,11 +87,6 @@ class Element : public Node {
   static JSValue scroll(QjsContext* ctx, JSValueConst this_val, int argc, JSValueConst* argv);
   static JSValue scrollBy(QjsContext* ctx, JSValueConst this_val, int argc, JSValueConst* argv);
 
-  static void defineElement(const std::string& tagName, Element* constructor);
-  static JSValue getConstructor(JSContext* context, const std::string& tagName);
-
-  static std::unordered_map<std::string, Element*> elementConstructorMap;
-
   OBJECT_INSTANCE(Element);
 
  private:

--- a/bridge/bindings/qjs/html_parser.cc
+++ b/bridge/bindings/qjs/html_parser.cc
@@ -36,7 +36,7 @@ void HTMLParser::traverseHTML(NodeInstance* root, GumboNode* node) {
         tagName = std::string(piece.data, piece.length);
       }
 
-      auto *Document = Document::instance(context);
+      auto* Document = Document::instance(context);
       JSValue constructor = Document->getElementConstructor(context, tagName);
 
       JSValue tagNameValue = JS_NewString(ctx, tagName.c_str());

--- a/bridge/bindings/qjs/html_parser.cc
+++ b/bridge/bindings/qjs/html_parser.cc
@@ -36,7 +36,8 @@ void HTMLParser::traverseHTML(NodeInstance* root, GumboNode* node) {
         tagName = std::string(piece.data, piece.length);
       }
 
-      JSValue constructor = Element::getConstructor(context, tagName);
+      auto *Document = Document::instance(context);
+      JSValue constructor = Document->getElementConstructor(context, tagName);
 
       JSValue tagNameValue = JS_NewString(ctx, tagName.c_str());
       JSValue argv[] = {tagNameValue};


### PR DESCRIPTION
Fixed #931

由于 Element 构造函数没有按照 JSContext 进行分离，所以存在其中一个页面销毁的同时，销毁所有 Context 共享的公共构造函数。

修复方案：每个 Context 都有独立的 Element 构造函数，相互之间不影响。