### PR TITLE
refactor: rename RenderStyleBase to RenderStyle, RenderStyle to CSSRenderStyle

### DIFF
--- a/kraken/lib/src/css/animation.dart
+++ b/kraken/lib/src/css/animation.dart
@@ -441,7 +441,7 @@ class _Interpolation {
 }
 
 class KeyframeEffect extends AnimationEffect {
-  AbstractRenderStyle renderStyle;
+  RenderStyleBase renderStyle;
   Element? target;
   late List<_Interpolation> _interpolations;
   double? _progress;
@@ -474,7 +474,7 @@ class KeyframeEffect extends AnimationEffect {
     return progress < 0.5 ? start : end;
   }
 
-  static List<_Interpolation> _makeInterpolations(Map<String, List<Keyframe>> propertySpecificKeyframeGroups, AbstractRenderStyle? renderStyle) {
+  static List<_Interpolation> _makeInterpolations(Map<String, List<Keyframe>> propertySpecificKeyframeGroups, RenderStyleBase? renderStyle) {
     List<_Interpolation> interpolations = [];
 
     propertySpecificKeyframeGroups.forEach((String property, List<Keyframe> keyframes) {

--- a/kraken/lib/src/css/animation.dart
+++ b/kraken/lib/src/css/animation.dart
@@ -441,7 +441,7 @@ class _Interpolation {
 }
 
 class KeyframeEffect extends AnimationEffect {
-  RenderStyleBase renderStyle;
+  RenderStyle renderStyle;
   Element? target;
   late List<_Interpolation> _interpolations;
   double? _progress;
@@ -474,7 +474,7 @@ class KeyframeEffect extends AnimationEffect {
     return progress < 0.5 ? start : end;
   }
 
-  static List<_Interpolation> _makeInterpolations(Map<String, List<Keyframe>> propertySpecificKeyframeGroups, RenderStyleBase? renderStyle) {
+  static List<_Interpolation> _makeInterpolations(Map<String, List<Keyframe>> propertySpecificKeyframeGroups, RenderStyle? renderStyle) {
     List<_Interpolation> interpolations = [];
 
     propertySpecificKeyframeGroups.forEach((String property, List<Keyframe> keyframes) {

--- a/kraken/lib/src/css/animation.dart
+++ b/kraken/lib/src/css/animation.dart
@@ -441,7 +441,7 @@ class _Interpolation {
 }
 
 class KeyframeEffect extends AnimationEffect {
-  RenderStyle renderStyle;
+  AbstractRenderStyle renderStyle;
   Element? target;
   late List<_Interpolation> _interpolations;
   double? _progress;
@@ -474,7 +474,7 @@ class KeyframeEffect extends AnimationEffect {
     return progress < 0.5 ? start : end;
   }
 
-  static List<_Interpolation> _makeInterpolations(Map<String, List<Keyframe>> propertySpecificKeyframeGroups, RenderStyle? renderStyle) {
+  static List<_Interpolation> _makeInterpolations(Map<String, List<Keyframe>> propertySpecificKeyframeGroups, AbstractRenderStyle? renderStyle) {
     List<_Interpolation> interpolations = [];
 
     propertySpecificKeyframeGroups.forEach((String property, List<Keyframe> keyframes) {

--- a/kraken/lib/src/css/background.dart
+++ b/kraken/lib/src/css/background.dart
@@ -91,7 +91,7 @@ mixin CSSBackgroundMixin on AbstractRenderStyle {
   set backgroundClip(BackgroundBoundary? value) {
     if (value == _backgroundClip) return;
     _backgroundClip = value;
-    renderBoxModel!.markNeedsPaint();
+    renderBoxModel?.markNeedsPaint();
   }
 
   /// Background-origin
@@ -100,7 +100,7 @@ mixin CSSBackgroundMixin on AbstractRenderStyle {
   set backgroundOrigin(BackgroundBoundary? value) {
     if (value == _backgroundOrigin) return;
     _backgroundOrigin = value;
-    renderBoxModel!.markNeedsPaint();
+    renderBoxModel?.markNeedsPaint();
   }
 
   @override
@@ -109,7 +109,7 @@ mixin CSSBackgroundMixin on AbstractRenderStyle {
   set backgroundColor(Color? value) {
     if (value == _backgroundColor) return;
     _backgroundColor = value;
-    renderBoxModel!.markNeedsPaint();
+    renderBoxModel?.markNeedsPaint();
   }
 
   /// Background-image
@@ -119,7 +119,7 @@ mixin CSSBackgroundMixin on AbstractRenderStyle {
   set backgroundImage(CSSBackgroundImage? value) {
     if (value == _backgroundImage) return;
     _backgroundImage = value;
-    renderBoxModel!.markNeedsPaint();
+    renderBoxModel?.markNeedsPaint();
   }
 
   /// Background-position-x
@@ -129,7 +129,7 @@ mixin CSSBackgroundMixin on AbstractRenderStyle {
   set backgroundPositionX(CSSBackgroundPosition? value) {
     if (value == _backgroundPositionX) return;
     _backgroundPositionX = value;
-    renderBoxModel!.markNeedsPaint();
+    renderBoxModel?.markNeedsPaint();
   }
 
   /// Background-position-y
@@ -139,7 +139,7 @@ mixin CSSBackgroundMixin on AbstractRenderStyle {
   set backgroundPositionY(CSSBackgroundPosition? value) {
     if (value == _backgroundPositionY) return;
     _backgroundPositionY = value;
-    renderBoxModel!.markNeedsPaint();
+    renderBoxModel?.markNeedsPaint();
   }
 
   /// Background-size
@@ -148,7 +148,7 @@ mixin CSSBackgroundMixin on AbstractRenderStyle {
   set backgroundSize(CSSBackgroundSize? value) {
     if (value == _backgroundSize) return;
     _backgroundSize = value;
-    renderBoxModel!.markNeedsPaint();
+    renderBoxModel?.markNeedsPaint();
   }
 
   /// Background-attachment
@@ -157,7 +157,7 @@ mixin CSSBackgroundMixin on AbstractRenderStyle {
   set backgroundAttachment(CSSBackgroundAttachmentType? value) {
     if (value == _backgroundAttachment) return;
     _backgroundAttachment = value;
-    renderBoxModel!.markNeedsPaint();
+    renderBoxModel?.markNeedsPaint();
   }
 
   /// Background-repeat
@@ -167,7 +167,7 @@ mixin CSSBackgroundMixin on AbstractRenderStyle {
   set backgroundRepeat(ImageRepeat? value) {
     if (value == _backgroundRepeat) return;
     _backgroundRepeat = value;
-    renderBoxModel!.markNeedsPaint();
+    renderBoxModel?.markNeedsPaint();
   }
 }
 

--- a/kraken/lib/src/css/background.dart
+++ b/kraken/lib/src/css/background.dart
@@ -81,7 +81,7 @@ enum CSSBackgroundImageType {
   image,
 }
 
-mixin CSSBackgroundMixin on RenderStyleBase {
+mixin CSSBackgroundMixin on RenderStyle {
   static CSSBackgroundPosition DEFAULT_BACKGROUND_POSITION = CSSBackgroundPosition(percentage: -1);
   static CSSBackgroundSize DEFAULT_BACKGROUND_SIZE = CSSBackgroundSize(fit: BoxFit.none);
 

--- a/kraken/lib/src/css/background.dart
+++ b/kraken/lib/src/css/background.dart
@@ -81,7 +81,7 @@ enum CSSBackgroundImageType {
   image,
 }
 
-mixin CSSBackgroundMixin on AbstractRenderStyle {
+mixin CSSBackgroundMixin on RenderStyleBase {
   static CSSBackgroundPosition DEFAULT_BACKGROUND_POSITION = CSSBackgroundPosition(percentage: -1);
   static CSSBackgroundSize DEFAULT_BACKGROUND_SIZE = CSSBackgroundSize(fit: BoxFit.none);
 

--- a/kraken/lib/src/css/background.dart
+++ b/kraken/lib/src/css/background.dart
@@ -81,7 +81,7 @@ enum CSSBackgroundImageType {
   image,
 }
 
-mixin CSSBackgroundMixin on RenderStyleBase {
+mixin CSSBackgroundMixin on AbstractRenderStyle {
   static CSSBackgroundPosition DEFAULT_BACKGROUND_POSITION = CSSBackgroundPosition(percentage: -1);
   static CSSBackgroundSize DEFAULT_BACKGROUND_SIZE = CSSBackgroundSize(fit: BoxFit.none);
 
@@ -103,6 +103,7 @@ mixin CSSBackgroundMixin on RenderStyleBase {
     renderBoxModel!.markNeedsPaint();
   }
 
+  @override
   Color? get backgroundColor => _backgroundColor;
   Color? _backgroundColor;
   set backgroundColor(Color? value) {
@@ -112,6 +113,7 @@ mixin CSSBackgroundMixin on RenderStyleBase {
   }
 
   /// Background-image
+  @override
   CSSBackgroundImage? get backgroundImage => _backgroundImage;
   CSSBackgroundImage? _backgroundImage;
   set backgroundImage(CSSBackgroundImage? value) {
@@ -121,6 +123,7 @@ mixin CSSBackgroundMixin on RenderStyleBase {
   }
 
   /// Background-position-x
+  @override
   CSSBackgroundPosition get backgroundPositionX => _backgroundPositionX ?? DEFAULT_BACKGROUND_POSITION;
   CSSBackgroundPosition? _backgroundPositionX;
   set backgroundPositionX(CSSBackgroundPosition? value) {
@@ -130,6 +133,7 @@ mixin CSSBackgroundMixin on RenderStyleBase {
   }
 
   /// Background-position-y
+  @override
   CSSBackgroundPosition get backgroundPositionY => _backgroundPositionY ?? DEFAULT_BACKGROUND_POSITION;
   CSSBackgroundPosition? _backgroundPositionY;
   set backgroundPositionY(CSSBackgroundPosition? value) {
@@ -157,6 +161,7 @@ mixin CSSBackgroundMixin on RenderStyleBase {
   }
 
   /// Background-repeat
+  @override
   ImageRepeat get backgroundRepeat => _backgroundRepeat ?? ImageRepeat.repeat;
   ImageRepeat? _backgroundRepeat;
   set backgroundRepeat(ImageRepeat? value) {

--- a/kraken/lib/src/css/border.dart
+++ b/kraken/lib/src/css/border.dart
@@ -85,7 +85,7 @@ mixin CSSBorderMixin on AbstractRenderStyle {
   set borderTopWidth(CSSLengthValue? value) {
     if (value == _borderTopWidth) return;
     _borderTopWidth = value;
-    renderBoxModel!.markNeedsLayout();
+    renderBoxModel?.markNeedsLayout();
   }
   @override
   CSSLengthValue? get borderTopWidth => _borderTopWidth;
@@ -97,7 +97,7 @@ mixin CSSBorderMixin on AbstractRenderStyle {
   set borderRightWidth(CSSLengthValue? value) {
     if (value == _borderRightWidth) return;
     _borderRightWidth = value;
-    renderBoxModel!.markNeedsLayout();
+    renderBoxModel?.markNeedsLayout();
   }
 
   @override
@@ -110,7 +110,7 @@ mixin CSSBorderMixin on AbstractRenderStyle {
   set borderBottomWidth(CSSLengthValue? value) {
     if (value == _borderBottomWidth) return;
     _borderBottomWidth = value;
-    renderBoxModel!.markNeedsLayout();
+    renderBoxModel?.markNeedsLayout();
   }
 
   @override
@@ -123,7 +123,7 @@ mixin CSSBorderMixin on AbstractRenderStyle {
   set borderLeftWidth(CSSLengthValue? value) {
     if (value == _borderLeftWidth) return;
     _borderLeftWidth = value;
-    renderBoxModel!.markNeedsLayout();
+    renderBoxModel?.markNeedsLayout();
   }
 
   @override
@@ -139,7 +139,7 @@ mixin CSSBorderMixin on AbstractRenderStyle {
   set borderTopColor(Color? value) {
     if (value == _borderTopColor) return;
     _borderTopColor = value;
-    renderBoxModel!.markNeedsPaint();
+    renderBoxModel?.markNeedsPaint();
   }
 
   @override
@@ -148,7 +148,7 @@ mixin CSSBorderMixin on AbstractRenderStyle {
   set borderRightColor(Color? value) {
     if (value == _borderRightColor) return;
     _borderRightColor = value;
-    renderBoxModel!.markNeedsPaint();
+    renderBoxModel?.markNeedsPaint();
   }
 
   @override
@@ -157,7 +157,7 @@ mixin CSSBorderMixin on AbstractRenderStyle {
   set borderBottomColor(Color? value) {
     if (value == _borderBottomColor) return;
     _borderBottomColor = value;
-    renderBoxModel!.markNeedsPaint();
+    renderBoxModel?.markNeedsPaint();
   }
 
   @override
@@ -166,7 +166,7 @@ mixin CSSBorderMixin on AbstractRenderStyle {
   set borderLeftColor(Color? value) {
     if (value == _borderLeftColor) return;
     _borderLeftColor = value;
-    renderBoxModel!.markNeedsPaint();
+    renderBoxModel?.markNeedsPaint();
   }
 
   /// Border-style
@@ -176,7 +176,7 @@ mixin CSSBorderMixin on AbstractRenderStyle {
   set borderTopStyle(BorderStyle? value) {
     if (value == _borderTopStyle) return;
     _borderTopStyle = value;
-    renderBoxModel!.markNeedsPaint();
+    renderBoxModel?.markNeedsPaint();
   }
 
   @override
@@ -185,7 +185,7 @@ mixin CSSBorderMixin on AbstractRenderStyle {
   set borderRightStyle(BorderStyle? value) {
     if (value == _borderRightStyle) return;
     _borderRightStyle = value;
-    renderBoxModel!.markNeedsPaint();
+    renderBoxModel?.markNeedsPaint();
   }
 
   @override
@@ -194,7 +194,7 @@ mixin CSSBorderMixin on AbstractRenderStyle {
   set borderBottomStyle(BorderStyle? value) {
     if (value == _borderBottomStyle) return;
     _borderBottomStyle = value;
-    renderBoxModel!.markNeedsPaint();
+    renderBoxModel?.markNeedsPaint();
   }
 
   BorderStyle? _borderLeftStyle;
@@ -205,7 +205,7 @@ mixin CSSBorderMixin on AbstractRenderStyle {
   set borderLeftStyle(BorderStyle? value) {
     if (value == _borderLeftStyle) return;
     _borderLeftStyle = value;
-    renderBoxModel!.markNeedsPaint();
+    renderBoxModel?.markNeedsPaint();
   }
 }
 

--- a/kraken/lib/src/css/border.dart
+++ b/kraken/lib/src/css/border.dart
@@ -24,10 +24,11 @@ enum CSSBorderStyleType {
   outset,
 }
 
-mixin CSSBorderMixin on RenderStyleBase {
+mixin CSSBorderMixin on AbstractRenderStyle {
 
   // Effective border widths. These are used to calculate the
   // dimensions of the border box.
+  @override
   EdgeInsets get border {
     // If has border, render padding should subtracting the edge of the border
     return EdgeInsets.fromLTRB(
@@ -47,12 +48,12 @@ mixin CSSBorderMixin on RenderStyleBase {
     return constraints.deflate(border);
   }
 
+  @override
   List<BorderSide>? get borderSides {
-    RenderStyle renderStyle = this as RenderStyle;
-    BorderSide? leftSide = CSSBorderSide.getBorderSide(renderStyle, CSSBorderSide.LEFT);
-    BorderSide? topSide = CSSBorderSide.getBorderSide(renderStyle, CSSBorderSide.TOP);
-    BorderSide? rightSide = CSSBorderSide.getBorderSide(renderStyle, CSSBorderSide.RIGHT);
-    BorderSide? bottomSide = CSSBorderSide.getBorderSide(renderStyle, CSSBorderSide.BOTTOM);
+    BorderSide? leftSide = CSSBorderSide._getBorderSide(this, CSSBorderSide.LEFT);
+    BorderSide? topSide = CSSBorderSide._getBorderSide(this, CSSBorderSide.TOP);
+    BorderSide? rightSide = CSSBorderSide._getBorderSide(this, CSSBorderSide.RIGHT);
+    BorderSide? bottomSide = CSSBorderSide._getBorderSide(this, CSSBorderSide.BOTTOM);
 
     bool hasBorder = leftSide != null ||
         topSide != null ||
@@ -86,7 +87,10 @@ mixin CSSBorderMixin on RenderStyleBase {
     _borderTopWidth = value;
     renderBoxModel!.markNeedsLayout();
   }
+  @override
   CSSLengthValue? get borderTopWidth => _borderTopWidth;
+
+  @override
   CSSLengthValue get effectiveBorderTopWidth => borderTopStyle == BorderStyle.none ? CSSLengthValue.zero : (_borderTopWidth ?? _mediumWidth);
 
   CSSLengthValue? _borderRightWidth;
@@ -95,7 +99,11 @@ mixin CSSBorderMixin on RenderStyleBase {
     _borderRightWidth = value;
     renderBoxModel!.markNeedsLayout();
   }
+
+  @override
   CSSLengthValue? get borderRightWidth => _borderRightWidth;
+
+  @override
   CSSLengthValue get effectiveBorderRightWidth => borderRightStyle == BorderStyle.none ? CSSLengthValue.zero : (_borderRightWidth ?? _mediumWidth);
 
   CSSLengthValue? _borderBottomWidth;
@@ -104,7 +112,11 @@ mixin CSSBorderMixin on RenderStyleBase {
     _borderBottomWidth = value;
     renderBoxModel!.markNeedsLayout();
   }
+
+  @override
   CSSLengthValue? get borderBottomWidth => _borderBottomWidth;
+
+  @override
   CSSLengthValue get effectiveBorderBottomWidth => borderBottomStyle == BorderStyle.none ? CSSLengthValue.zero : (_borderBottomWidth ?? _mediumWidth);
 
   CSSLengthValue? _borderLeftWidth;
@@ -113,10 +125,15 @@ mixin CSSBorderMixin on RenderStyleBase {
     _borderLeftWidth = value;
     renderBoxModel!.markNeedsLayout();
   }
+
+  @override
   CSSLengthValue? get borderLeftWidth => _borderLeftWidth;
+
+  @override
   CSSLengthValue get effectiveBorderLeftWidth => borderLeftStyle == BorderStyle.none ? CSSLengthValue.zero : (_borderLeftWidth ?? _mediumWidth);
 
   /// Border-color
+  @override
   Color get borderTopColor => _borderTopColor ?? currentColor;
   Color? _borderTopColor;
   set borderTopColor(Color? value) {
@@ -125,6 +142,7 @@ mixin CSSBorderMixin on RenderStyleBase {
     renderBoxModel!.markNeedsPaint();
   }
 
+  @override
   Color get borderRightColor => _borderRightColor ?? currentColor;
   Color? _borderRightColor;
   set borderRightColor(Color? value) {
@@ -133,6 +151,7 @@ mixin CSSBorderMixin on RenderStyleBase {
     renderBoxModel!.markNeedsPaint();
   }
 
+  @override
   Color get borderBottomColor => _borderBottomColor ?? currentColor;
   Color? _borderBottomColor;
   set borderBottomColor(Color? value) {
@@ -141,6 +160,7 @@ mixin CSSBorderMixin on RenderStyleBase {
     renderBoxModel!.markNeedsPaint();
   }
 
+  @override
   Color get borderLeftColor => _borderLeftColor ?? currentColor;
   Color? _borderLeftColor;
   set borderLeftColor(Color? value) {
@@ -150,6 +170,7 @@ mixin CSSBorderMixin on RenderStyleBase {
   }
 
   /// Border-style
+  @override
   BorderStyle get borderTopStyle => _borderTopStyle ?? BorderStyle.none;
   BorderStyle? _borderTopStyle;
   set borderTopStyle(BorderStyle? value) {
@@ -158,6 +179,7 @@ mixin CSSBorderMixin on RenderStyleBase {
     renderBoxModel!.markNeedsPaint();
   }
 
+  @override
   BorderStyle get borderRightStyle => _borderRightStyle ?? BorderStyle.none;
   BorderStyle? _borderRightStyle;
   set borderRightStyle(BorderStyle? value) {
@@ -166,6 +188,7 @@ mixin CSSBorderMixin on RenderStyleBase {
     renderBoxModel!.markNeedsPaint();
   }
 
+  @override
   BorderStyle get borderBottomStyle => _borderBottomStyle ?? BorderStyle.none;
   BorderStyle? _borderBottomStyle;
   set borderBottomStyle(BorderStyle? value) {
@@ -174,8 +197,11 @@ mixin CSSBorderMixin on RenderStyleBase {
     renderBoxModel!.markNeedsPaint();
   }
 
-  BorderStyle get borderLeftStyle => _borderLeftStyle ?? BorderStyle.none;
   BorderStyle? _borderLeftStyle;
+
+  @override
+  BorderStyle get borderLeftStyle => _borderLeftStyle ?? BorderStyle.none;
+
   set borderLeftStyle(BorderStyle? value) {
     if (value == _borderLeftStyle) return;
     _borderLeftStyle = value;
@@ -242,7 +268,7 @@ class CSSBorderSide {
 
   static BorderSide none = BorderSide(color: defaultBorderColor, width: 0.0, style: BorderStyle.none);
 
-  static BorderSide? getBorderSide(RenderStyle renderStyle, String side) {
+  static BorderSide? _getBorderSide(AbstractRenderStyle renderStyle, String side) {
     BorderStyle? borderStyle;
     CSSLengthValue? borderWidth;
     Color? borderColor;

--- a/kraken/lib/src/css/border.dart
+++ b/kraken/lib/src/css/border.dart
@@ -24,7 +24,7 @@ enum CSSBorderStyleType {
   outset,
 }
 
-mixin CSSBorderMixin on AbstractRenderStyle {
+mixin CSSBorderMixin on RenderStyleBase {
 
   // Effective border widths. These are used to calculate the
   // dimensions of the border box.
@@ -268,7 +268,7 @@ class CSSBorderSide {
 
   static BorderSide none = BorderSide(color: defaultBorderColor, width: 0.0, style: BorderStyle.none);
 
-  static BorderSide? _getBorderSide(AbstractRenderStyle renderStyle, String side) {
+  static BorderSide? _getBorderSide(RenderStyleBase renderStyle, String side) {
     BorderStyle? borderStyle;
     CSSLengthValue? borderWidth;
     Color? borderColor;

--- a/kraken/lib/src/css/border.dart
+++ b/kraken/lib/src/css/border.dart
@@ -24,7 +24,7 @@ enum CSSBorderStyleType {
   outset,
 }
 
-mixin CSSBorderMixin on RenderStyleBase {
+mixin CSSBorderMixin on RenderStyle {
 
   // Effective border widths. These are used to calculate the
   // dimensions of the border box.
@@ -268,7 +268,7 @@ class CSSBorderSide {
 
   static BorderSide none = BorderSide(color: defaultBorderColor, width: 0.0, style: BorderStyle.none);
 
-  static BorderSide? _getBorderSide(RenderStyleBase renderStyle, String side) {
+  static BorderSide? _getBorderSide(RenderStyle renderStyle, String side) {
     BorderStyle? borderStyle;
     CSSLengthValue? borderWidth;
     Color? borderColor;

--- a/kraken/lib/src/css/border_radius.dart
+++ b/kraken/lib/src/css/border_radius.dart
@@ -7,7 +7,7 @@ mixin CSSBorderRadiusMixin on AbstractRenderStyle {
   set borderTopLeftRadius(CSSBorderRadius? value) {
     if (value == _borderTopLeftRadius) return;
     _borderTopLeftRadius = value;
-    renderBoxModel!.markNeedsPaint();
+    renderBoxModel?.markNeedsPaint();
   }
   @override
   CSSBorderRadius get borderTopLeftRadius => _borderTopLeftRadius ?? CSSBorderRadius.zero;
@@ -16,7 +16,7 @@ mixin CSSBorderRadiusMixin on AbstractRenderStyle {
   set borderTopRightRadius(CSSBorderRadius? value) {
     if (value == _borderTopRightRadius) return;
     _borderTopRightRadius = value;
-    renderBoxModel!.markNeedsPaint();
+    renderBoxModel?.markNeedsPaint();
   }
   @override
   CSSBorderRadius get borderTopRightRadius => _borderTopRightRadius ?? CSSBorderRadius.zero;
@@ -25,7 +25,7 @@ mixin CSSBorderRadiusMixin on AbstractRenderStyle {
   set borderBottomRightRadius(CSSBorderRadius? value) {
     if (value == _borderBottomRightRadius) return;
     _borderBottomRightRadius = value;
-    renderBoxModel!.markNeedsPaint();
+    renderBoxModel?.markNeedsPaint();
   }
   @override
   CSSBorderRadius get borderBottomRightRadius => _borderBottomRightRadius ?? CSSBorderRadius.zero;
@@ -34,7 +34,7 @@ mixin CSSBorderRadiusMixin on AbstractRenderStyle {
   set borderBottomLeftRadius(CSSBorderRadius? value) {
     if (value == _borderBottomLeftRadius) return;
     _borderBottomLeftRadius = value;
-    renderBoxModel!.markNeedsPaint();
+    renderBoxModel?.markNeedsPaint();
   }
   @override
   CSSBorderRadius get borderBottomLeftRadius => _borderBottomLeftRadius ?? CSSBorderRadius.zero;

--- a/kraken/lib/src/css/border_radius.dart
+++ b/kraken/lib/src/css/border_radius.dart
@@ -2,13 +2,14 @@ import 'dart:ui';
 
 import 'package:kraken/css.dart';
 
-mixin CSSBorderRadiusMixin on RenderStyleBase {
+mixin CSSBorderRadiusMixin on AbstractRenderStyle {
   CSSBorderRadius? _borderTopLeftRadius;
   set borderTopLeftRadius(CSSBorderRadius? value) {
     if (value == _borderTopLeftRadius) return;
     _borderTopLeftRadius = value;
     renderBoxModel!.markNeedsPaint();
   }
+  @override
   CSSBorderRadius get borderTopLeftRadius => _borderTopLeftRadius ?? CSSBorderRadius.zero;
 
   CSSBorderRadius? _borderTopRightRadius;
@@ -17,6 +18,7 @@ mixin CSSBorderRadiusMixin on RenderStyleBase {
     _borderTopRightRadius = value;
     renderBoxModel!.markNeedsPaint();
   }
+  @override
   CSSBorderRadius get borderTopRightRadius => _borderTopRightRadius ?? CSSBorderRadius.zero;
 
   CSSBorderRadius? _borderBottomRightRadius;
@@ -25,6 +27,7 @@ mixin CSSBorderRadiusMixin on RenderStyleBase {
     _borderBottomRightRadius = value;
     renderBoxModel!.markNeedsPaint();
   }
+  @override
   CSSBorderRadius get borderBottomRightRadius => _borderBottomRightRadius ?? CSSBorderRadius.zero;
 
   CSSBorderRadius? _borderBottomLeftRadius;
@@ -33,8 +36,10 @@ mixin CSSBorderRadiusMixin on RenderStyleBase {
     _borderBottomLeftRadius = value;
     renderBoxModel!.markNeedsPaint();
   }
+  @override
   CSSBorderRadius get borderBottomLeftRadius => _borderBottomLeftRadius ?? CSSBorderRadius.zero;
 
+  @override
   List<Radius>? get borderRadius {
     bool hasBorderRadius = borderTopLeftRadius != CSSBorderRadius.zero ||
         borderTopRightRadius != CSSBorderRadius.zero ||

--- a/kraken/lib/src/css/border_radius.dart
+++ b/kraken/lib/src/css/border_radius.dart
@@ -2,7 +2,7 @@ import 'dart:ui';
 
 import 'package:kraken/css.dart';
 
-mixin CSSBorderRadiusMixin on AbstractRenderStyle {
+mixin CSSBorderRadiusMixin on RenderStyleBase {
   CSSBorderRadius? _borderTopLeftRadius;
   set borderTopLeftRadius(CSSBorderRadius? value) {
     if (value == _borderTopLeftRadius) return;

--- a/kraken/lib/src/css/border_radius.dart
+++ b/kraken/lib/src/css/border_radius.dart
@@ -2,7 +2,7 @@ import 'dart:ui';
 
 import 'package:kraken/css.dart';
 
-mixin CSSBorderRadiusMixin on RenderStyleBase {
+mixin CSSBorderRadiusMixin on RenderStyle {
   CSSBorderRadius? _borderTopLeftRadius;
   set borderTopLeftRadius(CSSBorderRadius? value) {
     if (value == _borderTopLeftRadius) return;

--- a/kraken/lib/src/css/box.dart
+++ b/kraken/lib/src/css/box.dart
@@ -11,7 +11,7 @@ import 'package:flutter/rendering.dart';
 import 'package:kraken/css.dart';
 
 // CSS Box Model: https://drafts.csswg.org/css-box-4/
-mixin CSSBoxMixin on AbstractRenderStyle {
+mixin CSSBoxMixin on RenderStyleBase {
 
   final DecorationPosition decorationPosition = DecorationPosition.background;
   final ImageConfiguration imageConfiguration = ImageConfiguration.empty;

--- a/kraken/lib/src/css/box.dart
+++ b/kraken/lib/src/css/box.dart
@@ -11,7 +11,7 @@ import 'package:flutter/rendering.dart';
 import 'package:kraken/css.dart';
 
 // CSS Box Model: https://drafts.csswg.org/css-box-4/
-mixin CSSBoxMixin on RenderStyleBase {
+mixin CSSBoxMixin on RenderStyle {
 
   final DecorationPosition decorationPosition = DecorationPosition.background;
   final ImageConfiguration imageConfiguration = ImageConfiguration.empty;

--- a/kraken/lib/src/css/box.dart
+++ b/kraken/lib/src/css/box.dart
@@ -11,21 +11,16 @@ import 'package:flutter/rendering.dart';
 import 'package:kraken/css.dart';
 
 // CSS Box Model: https://drafts.csswg.org/css-box-4/
-mixin CSSBoxMixin on RenderStyleBase {
+mixin CSSBoxMixin on AbstractRenderStyle {
 
   final DecorationPosition decorationPosition = DecorationPosition.background;
   final ImageConfiguration imageConfiguration = ImageConfiguration.empty;
 
   /// What decoration to paint, should get value after layout.
   CSSBoxDecoration? get decoration {
-    RenderStyle renderStyle = this as RenderStyle;
-    List<Radius>? radius = renderStyle.borderRadius;
-    List<BorderSide>? borderSides = renderStyle.borderSides;
-    List<KrakenBoxShadow>? shadows = renderStyle.shadows;
-    var backgroundColor = renderStyle.backgroundColor;
-    var backgroundImage = renderStyle.backgroundImage;
-    var backgroundRepeat = renderStyle.backgroundRepeat;
- 
+    List<Radius>? radius = this.borderRadius;
+    List<BorderSide>? borderSides = this.borderSides;
+
     if (backgroundColor == null &&
         backgroundImage == null &&
         borderSides == null &&

--- a/kraken/lib/src/css/box_shadow.dart
+++ b/kraken/lib/src/css/box_shadow.dart
@@ -5,7 +5,7 @@ mixin CSSBoxShadowMixin on AbstractRenderStyle {
   set boxShadow(List<CSSBoxShadow>? value) {
     if (value == _boxShadow) return;
     _boxShadow = value;
-    renderBoxModel!.markNeedsPaint();
+    renderBoxModel?.markNeedsPaint();
   }
   List<CSSBoxShadow>? get boxShadow => _boxShadow;
 

--- a/kraken/lib/src/css/box_shadow.dart
+++ b/kraken/lib/src/css/box_shadow.dart
@@ -1,6 +1,6 @@
 import 'package:kraken/css.dart';
 
-mixin CSSBoxShadowMixin on RenderStyleBase {
+mixin CSSBoxShadowMixin on AbstractRenderStyle {
   List<CSSBoxShadow>? _boxShadow;
   set boxShadow(List<CSSBoxShadow>? value) {
     if (value == _boxShadow) return;
@@ -9,6 +9,7 @@ mixin CSSBoxShadowMixin on RenderStyleBase {
   }
   List<CSSBoxShadow>? get boxShadow => _boxShadow;
 
+  @override
   List<KrakenBoxShadow>? get shadows {
     if (boxShadow == null) {
       return null;

--- a/kraken/lib/src/css/box_shadow.dart
+++ b/kraken/lib/src/css/box_shadow.dart
@@ -1,6 +1,6 @@
 import 'package:kraken/css.dart';
 
-mixin CSSBoxShadowMixin on AbstractRenderStyle {
+mixin CSSBoxShadowMixin on RenderStyleBase {
   List<CSSBoxShadow>? _boxShadow;
   set boxShadow(List<CSSBoxShadow>? value) {
     if (value == _boxShadow) return;

--- a/kraken/lib/src/css/box_shadow.dart
+++ b/kraken/lib/src/css/box_shadow.dart
@@ -1,6 +1,6 @@
 import 'package:kraken/css.dart';
 
-mixin CSSBoxShadowMixin on RenderStyleBase {
+mixin CSSBoxShadowMixin on RenderStyle {
   List<CSSBoxShadow>? _boxShadow;
   set boxShadow(List<CSSBoxShadow>? value) {
     if (value == _boxShadow) return;

--- a/kraken/lib/src/css/content_visibility.dart
+++ b/kraken/lib/src/css/content_visibility.dart
@@ -32,7 +32,7 @@ mixin CSSContentVisibilityMixin on AbstractRenderStyle {
     if (value == null) return;
     if (value == _contentVisibility) return;
     _contentVisibility = value;
-    renderBoxModel!.markNeedsPaint();
+    renderBoxModel?.markNeedsPaint();
   }
 
   static ContentVisibility resolveContentVisibility(String value) {

--- a/kraken/lib/src/css/content_visibility.dart
+++ b/kraken/lib/src/css/content_visibility.dart
@@ -13,7 +13,7 @@ enum ContentVisibility {
   visible
 }
 
-mixin CSSContentVisibilityMixin on RenderStyleBase {
+mixin CSSContentVisibilityMixin on RenderStyle {
 
   /// Whether the child is hidden from the rest of the tree.
   ///

--- a/kraken/lib/src/css/content_visibility.dart
+++ b/kraken/lib/src/css/content_visibility.dart
@@ -13,7 +13,7 @@ enum ContentVisibility {
   visible
 }
 
-mixin CSSContentVisibilityMixin on RenderStyleBase {
+mixin CSSContentVisibilityMixin on AbstractRenderStyle {
 
   /// Whether the child is hidden from the rest of the tree.
   ///
@@ -25,8 +25,9 @@ mixin CSSContentVisibilityMixin on RenderStyleBase {
   ///
   /// If ContentVisibility.auto, the framework will compute the intersection bounds and not to paint when child renderObject
   /// are no longer intersection with this renderObject.
-  ContentVisibility? _contentVisibility;
+  @override
   ContentVisibility? get contentVisibility => _contentVisibility;
+  ContentVisibility? _contentVisibility;
   set contentVisibility(ContentVisibility? value) {
     if (value == null) return;
     if (value == _contentVisibility) return;

--- a/kraken/lib/src/css/content_visibility.dart
+++ b/kraken/lib/src/css/content_visibility.dart
@@ -13,7 +13,7 @@ enum ContentVisibility {
   visible
 }
 
-mixin CSSContentVisibilityMixin on AbstractRenderStyle {
+mixin CSSContentVisibilityMixin on RenderStyleBase {
 
   /// Whether the child is hidden from the rest of the tree.
   ///

--- a/kraken/lib/src/css/display.dart
+++ b/kraken/lib/src/css/display.dart
@@ -19,7 +19,7 @@ enum CSSDisplay {
   none
 }
 
-mixin CSSDisplayMixin on AbstractRenderStyle {
+mixin CSSDisplayMixin on RenderStyleBase {
 
   CSSDisplay? _display;
 

--- a/kraken/lib/src/css/display.dart
+++ b/kraken/lib/src/css/display.dart
@@ -19,9 +19,11 @@ enum CSSDisplay {
   none
 }
 
-mixin CSSDisplayMixin on RenderStyleBase {
+mixin CSSDisplayMixin on AbstractRenderStyle {
 
   CSSDisplay? _display;
+
+  @override
   CSSDisplay get display => _display ?? CSSDisplay.inline;
   set display(CSSDisplay value) {
     if (_display != value) {
@@ -59,12 +61,9 @@ mixin CSSDisplayMixin on RenderStyleBase {
   /// Some layout effects require blockification or inlinification of the box type
   /// https://www.w3.org/TR/css-display-3/#transformations
   CSSDisplay? get effectiveDisplay {
-    RenderStyle renderStyle = this as RenderStyle;
-    CSSDisplay? transformedDisplay = renderStyle.display;
+    CSSDisplay? transformedDisplay = display;
 
-    // Must take from style because it inited before flush pending properties.
-    CSSPositionType position = renderStyle.position;
-
+    // Must take `position` from style because it inited before flush pending properties.
     // Display as inline-block when element is positioned
     if (position == CSSPositionType.absolute || position == CSSPositionType.fixed) {
       return CSSDisplay.inlineBlock;
@@ -81,9 +80,6 @@ mixin CSSDisplayMixin on RenderStyleBase {
         transformedDisplay = CSSDisplay.inlineBlock;
         RenderBoxModel parent = renderBoxModel!.parent as RenderBoxModel;
         RenderStyle parentRenderStyle = parent.renderStyle;
-
-        CSSLengthValue marginLeft = renderStyle.marginLeft;
-        CSSLengthValue marginRight = renderStyle.marginRight;
 
         bool isVerticalDirection = parentRenderStyle.flexDirection == FlexDirection.column ||
             parentRenderStyle.flexDirection == FlexDirection.columnReverse;

--- a/kraken/lib/src/css/display.dart
+++ b/kraken/lib/src/css/display.dart
@@ -19,7 +19,7 @@ enum CSSDisplay {
   none
 }
 
-mixin CSSDisplayMixin on RenderStyleBase {
+mixin CSSDisplayMixin on RenderStyle {
 
   CSSDisplay? _display;
 
@@ -60,8 +60,9 @@ mixin CSSDisplayMixin on RenderStyleBase {
 
   /// Some layout effects require blockification or inlinification of the box type
   /// https://www.w3.org/TR/css-display-3/#transformations
-  CSSDisplay? get effectiveDisplay {
-    CSSDisplay? transformedDisplay = display;
+  @override
+  CSSDisplay get effectiveDisplay {
+    CSSDisplay transformedDisplay = display;
 
     // Must take `position` from style because it inited before flush pending properties.
     // Display as inline-block when element is positioned

--- a/kraken/lib/src/css/filter.dart
+++ b/kraken/lib/src/css/filter.dart
@@ -91,7 +91,7 @@ List<double> _multiplyMatrix5(List<double>? a, List<double> b) {
 
 /// Impl W3C Filter Effects Spec:
 ///   https://www.w3.org/TR/filter-effects-1/#definitions
-mixin CSSFilterEffectsMixin on RenderStyleBase {
+mixin CSSFilterEffectsMixin on RenderStyle {
 
   // Get the color filter.
   // eg: 'grayscale(1) grayscale(0.5)' -> matrix5(grayscale(1)) · matrix5(grayscale(0.5))

--- a/kraken/lib/src/css/filter.dart
+++ b/kraken/lib/src/css/filter.dart
@@ -91,7 +91,7 @@ List<double> _multiplyMatrix5(List<double>? a, List<double> b) {
 
 /// Impl W3C Filter Effects Spec:
 ///   https://www.w3.org/TR/filter-effects-1/#definitions
-mixin CSSFilterEffectsMixin on RenderStyleBase {
+mixin CSSFilterEffectsMixin on AbstractRenderStyle {
 
   // Get the color filter.
   // eg: 'grayscale(1) grayscale(0.5)' -> matrix5(grayscale(1)) · matrix5(grayscale(0.5))
@@ -138,13 +138,12 @@ mixin CSSFilterEffectsMixin on RenderStyleBase {
 
   // Get the image filter.
   ImageFilter? _parseImageFilters(List<CSSFunctionalNotation> functions) {
-    RenderStyle renderStyle = this as RenderStyle;
     if (functions.isNotEmpty) {
       for (int i = 0; i < functions.length; i ++) {
         CSSFunctionalNotation f = functions[i];
         switch (f.name.toLowerCase()) {
           case BLUR:
-            CSSLengthValue length = CSSLength.parseLength(f.args.first, renderStyle, FILTER);
+            CSSLengthValue length = CSSLength.parseLength(f.args.first, this, FILTER);
             double amount = length.computedValue;
             ImageFilter imageFilter =  ImageFilter.blur(sigmaX: amount, sigmaY: amount);
             // Only length is not relative value will cached the image filter.
@@ -159,6 +158,8 @@ mixin CSSFilterEffectsMixin on RenderStyleBase {
   }
 
   ColorFilter? _cachedColorFilter;
+
+  @override
   ColorFilter? get colorFilter {
     if (_filter == null) {
       return null;
@@ -170,6 +171,8 @@ mixin CSSFilterEffectsMixin on RenderStyleBase {
   }
 
   ImageFilter? _cachedImageFilter;
+
+  @override
   ImageFilter? get imageFilter {
     if (_filter == null) {
       return null;
@@ -180,8 +183,9 @@ mixin CSSFilterEffectsMixin on RenderStyleBase {
     }
   }
 
-  List<CSSFunctionalNotation>? _filter;
+  @override
   List<CSSFunctionalNotation>? get filter => _filter;
+  List<CSSFunctionalNotation>? _filter;
   set filter(List<CSSFunctionalNotation>? functions) {
     _filter = functions;
     // Clear cache when filter changed.
@@ -189,7 +193,7 @@ mixin CSSFilterEffectsMixin on RenderStyleBase {
     _cachedImageFilter = null;
 
     // Filter effect the stacking context.
-    RenderBoxModel? parentRenderer = (this as RenderStyle).parent?.renderBoxModel;
+    RenderBoxModel? parentRenderer = parent?.renderBoxModel;
     if (parentRenderer is RenderLayoutBox) {
       parentRenderer.markChildrenNeedsSort();
     }

--- a/kraken/lib/src/css/filter.dart
+++ b/kraken/lib/src/css/filter.dart
@@ -198,7 +198,7 @@ mixin CSSFilterEffectsMixin on AbstractRenderStyle {
       parentRenderer.markChildrenNeedsSort();
     }
 
-    renderBoxModel!.markNeedsPaint();
+    renderBoxModel?.markNeedsPaint();
 
     if (!kReleaseMode && functions != null) {
       ColorFilter? colorFilter = _parseColorFilters(functions);

--- a/kraken/lib/src/css/filter.dart
+++ b/kraken/lib/src/css/filter.dart
@@ -91,7 +91,7 @@ List<double> _multiplyMatrix5(List<double>? a, List<double> b) {
 
 /// Impl W3C Filter Effects Spec:
 ///   https://www.w3.org/TR/filter-effects-1/#definitions
-mixin CSSFilterEffectsMixin on AbstractRenderStyle {
+mixin CSSFilterEffectsMixin on RenderStyleBase {
 
   // Get the color filter.
   // eg: 'grayscale(1) grayscale(0.5)' -> matrix5(grayscale(1)) · matrix5(grayscale(0.5))

--- a/kraken/lib/src/css/flexbox.dart
+++ b/kraken/lib/src/css/flexbox.dart
@@ -248,7 +248,7 @@ mixin CSSFlexboxMixin on AbstractRenderStyle {
   set alignSelf(AlignSelf value) {
     if (_alignSelf == value) return;
     _alignSelf = value;
-    if (renderBoxModel!.parent is RenderFlexLayout) {
+    if (renderBoxModel?.parent is RenderFlexLayout) {
       renderBoxModel!.markNeedsLayout();
     }
   }
@@ -264,7 +264,7 @@ mixin CSSFlexboxMixin on AbstractRenderStyle {
       return;
     }
     _flexBasis = value;
-    if (renderBoxModel!.parent is RenderFlexLayout) {
+    if (renderBoxModel?.parent is RenderFlexLayout) {
       renderBoxModel!.markNeedsLayout();
     }
   }
@@ -275,7 +275,7 @@ mixin CSSFlexboxMixin on AbstractRenderStyle {
   set flexGrow(double? value) {
     if (_flexGrow == value) return;
     _flexGrow = value;
-    if (renderBoxModel!.parent is RenderFlexLayout) {
+    if (renderBoxModel?.parent is RenderFlexLayout) {
       renderBoxModel!.markNeedsLayout();
     }
   }
@@ -286,7 +286,7 @@ mixin CSSFlexboxMixin on AbstractRenderStyle {
   set flexShrink(double? value) {
     if (_flexShrink == value) return;
     _flexShrink = value;
-    if (renderBoxModel!.parent is RenderFlexLayout) {
+    if (renderBoxModel?.parent is RenderFlexLayout) {
       renderBoxModel!.markNeedsLayout();
     }
   }

--- a/kraken/lib/src/css/flexbox.dart
+++ b/kraken/lib/src/css/flexbox.dart
@@ -173,7 +173,7 @@ enum AlignSelf {
   baseline
 }
 
-mixin CSSFlexboxMixin on RenderStyleBase {
+mixin CSSFlexboxMixin on RenderStyle {
 
   @override
   FlexDirection get flexDirection => _flexDirection ?? FlexDirection.row;
@@ -220,6 +220,7 @@ mixin CSSFlexboxMixin on RenderStyleBase {
     }
   }
 
+  @override
   AlignItems get effectiveAlignItems {
     if (CSSFlex.isVerticalFlexDirection(flexDirection)) {
       if (textAlign == TextAlign.right) {

--- a/kraken/lib/src/css/flexbox.dart
+++ b/kraken/lib/src/css/flexbox.dart
@@ -173,10 +173,11 @@ enum AlignSelf {
   baseline
 }
 
-mixin CSSFlexboxMixin on RenderStyleBase {
+mixin CSSFlexboxMixin on AbstractRenderStyle {
 
-  FlexDirection? _flexDirection;
+  @override
   FlexDirection get flexDirection => _flexDirection ?? FlexDirection.row;
+  FlexDirection? _flexDirection;
   set flexDirection(FlexDirection? value) {
     if (value == _flexDirection) return;
     _flexDirection = value;
@@ -185,8 +186,9 @@ mixin CSSFlexboxMixin on RenderStyleBase {
     }
   }
 
-  FlexWrap? _flexWrap;
+  @override
   FlexWrap get flexWrap => _flexWrap ?? FlexWrap.nowrap;
+  FlexWrap? _flexWrap;
   set flexWrap(FlexWrap? value) {
     if (_flexWrap == value) return;
     _flexWrap = value;
@@ -195,9 +197,9 @@ mixin CSSFlexboxMixin on RenderStyleBase {
     }
   }
 
-
-  JustifyContent? _justifyContent;
+  @override
   JustifyContent get justifyContent => _justifyContent ?? JustifyContent.flexStart;
+  JustifyContent? _justifyContent;
   set justifyContent(JustifyContent? value) {
     if (_justifyContent == value) return;
     _justifyContent = value;
@@ -207,8 +209,9 @@ mixin CSSFlexboxMixin on RenderStyleBase {
   }
 
 
-  AlignItems? _alignItems;
+  @override
   AlignItems get alignItems => _alignItems ?? AlignItems.stretch;
+  AlignItems? _alignItems;
   set alignItems(AlignItems? value) {
     if (_alignItems == value) return;
     _alignItems = value;
@@ -219,7 +222,6 @@ mixin CSSFlexboxMixin on RenderStyleBase {
 
   AlignItems get effectiveAlignItems {
     if (CSSFlex.isVerticalFlexDirection(flexDirection)) {
-      TextAlign textAlign = (this as RenderStyle).textAlign;
       if (textAlign == TextAlign.right) {
         return AlignItems.flexEnd;
       } else if (textAlign == TextAlign.center) {
@@ -229,8 +231,9 @@ mixin CSSFlexboxMixin on RenderStyleBase {
     return alignItems;
   }
 
-  AlignContent? _alignContent;
+  @override
   AlignContent get alignContent => _alignContent ?? AlignContent.stretch;
+  AlignContent? _alignContent;
   set alignContent(AlignContent? value) {
     if (_alignContent == value) return;
     _alignContent = value;
@@ -239,8 +242,9 @@ mixin CSSFlexboxMixin on RenderStyleBase {
     }
   }
 
-  AlignSelf? _alignSelf;
+  @override
   AlignSelf get alignSelf => _alignSelf ?? AlignSelf.auto;
+  AlignSelf? _alignSelf;
   set alignSelf(AlignSelf value) {
     if (_alignSelf == value) return;
     _alignSelf = value;
@@ -249,8 +253,9 @@ mixin CSSFlexboxMixin on RenderStyleBase {
     }
   }
 
-  CSSLengthValue? _flexBasis;
+  @override
   CSSLengthValue? get flexBasis => _flexBasis;
+  CSSLengthValue? _flexBasis;
   set flexBasis(CSSLengthValue? value) {
     // Negative value is invalid.
     if ((value != null && ((value.value != null && value.value! < 0))) ||
@@ -264,8 +269,9 @@ mixin CSSFlexboxMixin on RenderStyleBase {
     }
   }
 
-  double? _flexGrow;
+  @override
   double get flexGrow => _flexGrow ?? 0.0;
+  double? _flexGrow;
   set flexGrow(double? value) {
     if (_flexGrow == value) return;
     _flexGrow = value;
@@ -274,8 +280,9 @@ mixin CSSFlexboxMixin on RenderStyleBase {
     }
   }
 
-  double? _flexShrink;
+  @override
   double get flexShrink => _flexShrink ?? 1.0;
+  double? _flexShrink;
   set flexShrink(double? value) {
     if (_flexShrink == value) return;
     _flexShrink = value;

--- a/kraken/lib/src/css/flexbox.dart
+++ b/kraken/lib/src/css/flexbox.dart
@@ -173,7 +173,7 @@ enum AlignSelf {
   baseline
 }
 
-mixin CSSFlexboxMixin on AbstractRenderStyle {
+mixin CSSFlexboxMixin on RenderStyleBase {
 
   @override
   FlexDirection get flexDirection => _flexDirection ?? FlexDirection.row;

--- a/kraken/lib/src/css/inline.dart
+++ b/kraken/lib/src/css/inline.dart
@@ -24,7 +24,7 @@ enum VerticalAlign {
   ///  middle,
 }
 
-mixin CSSInlineMixin on AbstractRenderStyle {
+mixin CSSInlineMixin on RenderStyleBase {
   @override
   VerticalAlign get verticalAlign => _verticalAlign;
   VerticalAlign _verticalAlign = VerticalAlign.baseline;

--- a/kraken/lib/src/css/inline.dart
+++ b/kraken/lib/src/css/inline.dart
@@ -24,9 +24,10 @@ enum VerticalAlign {
   ///  middle,
 }
 
-mixin CSSInlineMixin on RenderStyleBase {
-  VerticalAlign _verticalAlign = VerticalAlign.baseline;
+mixin CSSInlineMixin on AbstractRenderStyle {
+  @override
   VerticalAlign get verticalAlign => _verticalAlign;
+  VerticalAlign _verticalAlign = VerticalAlign.baseline;
   set verticalAlign(VerticalAlign value) {
     if (_verticalAlign != value) {
       renderBoxModel!.markNeedsLayout();

--- a/kraken/lib/src/css/inline.dart
+++ b/kraken/lib/src/css/inline.dart
@@ -30,8 +30,8 @@ mixin CSSInlineMixin on AbstractRenderStyle {
   VerticalAlign _verticalAlign = VerticalAlign.baseline;
   set verticalAlign(VerticalAlign value) {
     if (_verticalAlign != value) {
-      renderBoxModel!.markNeedsLayout();
       _verticalAlign = value;
+      renderBoxModel?.markNeedsLayout();
     }
   }
 

--- a/kraken/lib/src/css/inline.dart
+++ b/kraken/lib/src/css/inline.dart
@@ -24,7 +24,7 @@ enum VerticalAlign {
   ///  middle,
 }
 
-mixin CSSInlineMixin on RenderStyleBase {
+mixin CSSInlineMixin on RenderStyle {
   @override
   VerticalAlign get verticalAlign => _verticalAlign;
   VerticalAlign _verticalAlign = VerticalAlign.baseline;

--- a/kraken/lib/src/css/margin.dart
+++ b/kraken/lib/src/css/margin.dart
@@ -9,12 +9,13 @@ import 'package:flutter/rendering.dart';
 import 'package:kraken/css.dart';
 import 'package:kraken/rendering.dart';
 
-mixin CSSMarginMixin on RenderStyleBase {
+mixin CSSMarginMixin on AbstractRenderStyle {
 
   /// The amount to margin the child in each dimension.
   ///
   /// If this is set to an [EdgeInsetsDirectional] object, then [textDirection]
   /// must not be null.
+  @override
   EdgeInsets get margin {
     EdgeInsets insets = EdgeInsets.only(
       left: marginLeft.computedValue,
@@ -32,6 +33,8 @@ mixin CSSMarginMixin on RenderStyleBase {
     _marginLeft = value;
     _markSelfAndParentNeedsLayout();
   }
+
+  @override
   CSSLengthValue get marginLeft => _marginLeft ?? CSSLengthValue.zero;
 
   CSSLengthValue? _marginRight;
@@ -40,6 +43,8 @@ mixin CSSMarginMixin on RenderStyleBase {
     _marginRight = value;
     _markSelfAndParentNeedsLayout();
   }
+
+  @override
   CSSLengthValue get marginRight => _marginRight ?? CSSLengthValue.zero;
 
   CSSLengthValue? _marginBottom;
@@ -48,6 +53,8 @@ mixin CSSMarginMixin on RenderStyleBase {
     _marginBottom = value;
     _markSelfAndParentNeedsLayout();
   }
+
+  @override
   CSSLengthValue get marginBottom => _marginBottom ?? CSSLengthValue.zero;
 
   CSSLengthValue? _marginTop;
@@ -56,6 +63,8 @@ mixin CSSMarginMixin on RenderStyleBase {
     _marginTop = value;
     _markSelfAndParentNeedsLayout();
   }
+
+  @override
   CSSLengthValue get marginTop => _marginTop ?? CSSLengthValue.zero;
 
   void _markSelfAndParentNeedsLayout() {

--- a/kraken/lib/src/css/margin.dart
+++ b/kraken/lib/src/css/margin.dart
@@ -9,7 +9,7 @@ import 'package:flutter/rendering.dart';
 import 'package:kraken/css.dart';
 import 'package:kraken/rendering.dart';
 
-mixin CSSMarginMixin on RenderStyleBase {
+mixin CSSMarginMixin on RenderStyle {
 
   /// The amount to margin the child in each dimension.
   ///

--- a/kraken/lib/src/css/margin.dart
+++ b/kraken/lib/src/css/margin.dart
@@ -9,7 +9,7 @@ import 'package:flutter/rendering.dart';
 import 'package:kraken/css.dart';
 import 'package:kraken/rendering.dart';
 
-mixin CSSMarginMixin on AbstractRenderStyle {
+mixin CSSMarginMixin on RenderStyleBase {
 
   /// The amount to margin the child in each dimension.
   ///

--- a/kraken/lib/src/css/matrix.dart
+++ b/kraken/lib/src/css/matrix.dart
@@ -577,7 +577,7 @@ class CSSMatrix {
 
   static Matrix4 initial = Matrix4.identity();
 
-  static Matrix4? computeTransformMatrix(List<CSSFunctionalNotation> transform, RenderStyle renderStyle) {
+  static Matrix4? computeTransformMatrix(List<CSSFunctionalNotation> transform, AbstractRenderStyle renderStyle) {
     Matrix4? matrix4;
     for (CSSFunctionalNotation method in transform) {
       Matrix4? transform = _computeMatrix(method, renderStyle);
@@ -592,7 +592,7 @@ class CSSMatrix {
     return matrix4;
   }
 
-  static Matrix4? _computeMatrix(CSSFunctionalNotation method, RenderStyle renderStyle) {
+  static Matrix4? _computeMatrix(CSSFunctionalNotation method, AbstractRenderStyle renderStyle) {
     switch (method.name) {
       case MATRIX:
         if (method.args.length == 6) {

--- a/kraken/lib/src/css/matrix.dart
+++ b/kraken/lib/src/css/matrix.dart
@@ -577,7 +577,7 @@ class CSSMatrix {
 
   static Matrix4 initial = Matrix4.identity();
 
-  static Matrix4? computeTransformMatrix(List<CSSFunctionalNotation> transform, AbstractRenderStyle renderStyle) {
+  static Matrix4? computeTransformMatrix(List<CSSFunctionalNotation> transform, RenderStyleBase renderStyle) {
     Matrix4? matrix4;
     for (CSSFunctionalNotation method in transform) {
       Matrix4? transform = _computeMatrix(method, renderStyle);
@@ -592,7 +592,7 @@ class CSSMatrix {
     return matrix4;
   }
 
-  static Matrix4? _computeMatrix(CSSFunctionalNotation method, AbstractRenderStyle renderStyle) {
+  static Matrix4? _computeMatrix(CSSFunctionalNotation method, RenderStyleBase renderStyle) {
     switch (method.name) {
       case MATRIX:
         if (method.args.length == 6) {

--- a/kraken/lib/src/css/matrix.dart
+++ b/kraken/lib/src/css/matrix.dart
@@ -577,7 +577,7 @@ class CSSMatrix {
 
   static Matrix4 initial = Matrix4.identity();
 
-  static Matrix4? computeTransformMatrix(List<CSSFunctionalNotation> transform, RenderStyleBase renderStyle) {
+  static Matrix4? computeTransformMatrix(List<CSSFunctionalNotation> transform, RenderStyle renderStyle) {
     Matrix4? matrix4;
     for (CSSFunctionalNotation method in transform) {
       Matrix4? transform = _computeMatrix(method, renderStyle);
@@ -592,7 +592,7 @@ class CSSMatrix {
     return matrix4;
   }
 
-  static Matrix4? _computeMatrix(CSSFunctionalNotation method, RenderStyleBase renderStyle) {
+  static Matrix4? _computeMatrix(CSSFunctionalNotation method, RenderStyle renderStyle) {
     switch (method.name) {
       case MATRIX:
         if (method.args.length == 6) {

--- a/kraken/lib/src/css/object_fit.dart
+++ b/kraken/lib/src/css/object_fit.dart
@@ -6,7 +6,7 @@
 import 'package:flutter/rendering.dart';
 import 'package:kraken/css.dart';
 
-mixin CSSObjectFitMixin on AbstractRenderStyle {
+mixin CSSObjectFitMixin on RenderStyleBase {
 
   @override
   BoxFit get objectFit => _objectFit;

--- a/kraken/lib/src/css/object_fit.dart
+++ b/kraken/lib/src/css/object_fit.dart
@@ -6,15 +6,15 @@
 import 'package:flutter/rendering.dart';
 import 'package:kraken/css.dart';
 
-mixin CSSObjectFitMixin on RenderStyleBase {
+mixin CSSObjectFitMixin on AbstractRenderStyle {
+
+  @override
+  BoxFit get objectFit => _objectFit;
   BoxFit _objectFit = BoxFit.fill;
-  BoxFit get objectFit {
-    return _objectFit;
-  }
   set objectFit(BoxFit value) {
     if (_objectFit == value) return;
     _objectFit = value;
-    renderBoxModel!.markNeedsLayout();
+    renderBoxModel?.markNeedsLayout();
   }
 
   static BoxFit resolveBoxFit(String fit) {

--- a/kraken/lib/src/css/object_fit.dart
+++ b/kraken/lib/src/css/object_fit.dart
@@ -6,7 +6,7 @@
 import 'package:flutter/rendering.dart';
 import 'package:kraken/css.dart';
 
-mixin CSSObjectFitMixin on RenderStyleBase {
+mixin CSSObjectFitMixin on RenderStyle {
 
   @override
   BoxFit get objectFit => _objectFit;

--- a/kraken/lib/src/css/object_position.dart
+++ b/kraken/lib/src/css/object_position.dart
@@ -6,15 +6,14 @@
 import 'package:flutter/rendering.dart';
 import 'package:kraken/css.dart';
 
-mixin CSSObjectPositionMixin on RenderStyleBase {
+mixin CSSObjectPositionMixin on AbstractRenderStyle {
+  @override
+  Alignment get objectPosition => _objectPosition;
   Alignment _objectPosition = Alignment.center;
-  Alignment get objectPosition {
-    return _objectPosition;
-  }
   set objectPosition(Alignment value) {
     if (_objectPosition == value) return;
     _objectPosition = value;
-    renderBoxModel!.markNeedsLayout();
+    renderBoxModel?.markNeedsLayout();
   }
 
   static Alignment resolveObjectPosition(String? position) {

--- a/kraken/lib/src/css/object_position.dart
+++ b/kraken/lib/src/css/object_position.dart
@@ -6,7 +6,7 @@
 import 'package:flutter/rendering.dart';
 import 'package:kraken/css.dart';
 
-mixin CSSObjectPositionMixin on RenderStyleBase {
+mixin CSSObjectPositionMixin on RenderStyle {
   @override
   Alignment get objectPosition => _objectPosition;
   Alignment _objectPosition = Alignment.center;

--- a/kraken/lib/src/css/object_position.dart
+++ b/kraken/lib/src/css/object_position.dart
@@ -6,7 +6,7 @@
 import 'package:flutter/rendering.dart';
 import 'package:kraken/css.dart';
 
-mixin CSSObjectPositionMixin on AbstractRenderStyle {
+mixin CSSObjectPositionMixin on RenderStyleBase {
   @override
   Alignment get objectPosition => _objectPosition;
   Alignment _objectPosition = Alignment.center;

--- a/kraken/lib/src/css/opacity.dart
+++ b/kraken/lib/src/css/opacity.dart
@@ -31,8 +31,9 @@ mixin CSSOpacityMixin on AbstractRenderStyle {
     _opacity = value;
     int alpha = ui.Color.getAlphaFromOpacity(_opacity);
     renderBoxModel!.alpha = alpha;
-    if (alpha != 0 && alpha != 255)
-      renderBoxModel!.markNeedsCompositingBitsUpdate();
+    if (alpha != 0 && alpha != 255) {
+      renderBoxModel?.markNeedsCompositingBitsUpdate();
+    }
 
     // Opacity effect the stacking context.
     RenderBoxModel? parentRenderer = parent?.renderBoxModel;
@@ -40,7 +41,7 @@ mixin CSSOpacityMixin on AbstractRenderStyle {
       parentRenderer.markChildrenNeedsSort();
     }
 
-    renderBoxModel!.markNeedsPaint();
+    renderBoxModel?.markNeedsPaint();
   }
 
   static double? resolveOpacity(String value) {

--- a/kraken/lib/src/css/opacity.dart
+++ b/kraken/lib/src/css/opacity.dart
@@ -8,7 +8,7 @@ import 'dart:ui' as ui;
 import 'package:kraken/css.dart';
 import 'package:kraken/rendering.dart';
 
-mixin CSSOpacityMixin on AbstractRenderStyle {
+mixin CSSOpacityMixin on RenderStyleBase {
 
   /// The fraction to scale the child's alpha value.
   ///

--- a/kraken/lib/src/css/opacity.dart
+++ b/kraken/lib/src/css/opacity.dart
@@ -8,7 +8,7 @@ import 'dart:ui' as ui;
 import 'package:kraken/css.dart';
 import 'package:kraken/rendering.dart';
 
-mixin CSSOpacityMixin on RenderStyleBase {
+mixin CSSOpacityMixin on RenderStyle {
 
   /// The fraction to scale the child's alpha value.
   ///

--- a/kraken/lib/src/css/opacity.dart
+++ b/kraken/lib/src/css/opacity.dart
@@ -8,7 +8,7 @@ import 'dart:ui' as ui;
 import 'package:kraken/css.dart';
 import 'package:kraken/rendering.dart';
 
-mixin CSSOpacityMixin on RenderStyleBase {
+mixin CSSOpacityMixin on AbstractRenderStyle {
 
   /// The fraction to scale the child's alpha value.
   ///
@@ -20,6 +20,7 @@ mixin CSSOpacityMixin on RenderStyleBase {
   /// Values 1.0 and 0.0 are painted with a fast path. Other values
   /// require painting the child into an intermediate buffer, which is
   /// expensive.
+  @override
   double get opacity => _opacity;
   double _opacity = 1.0;
   set opacity(double? value) {
@@ -34,7 +35,7 @@ mixin CSSOpacityMixin on RenderStyleBase {
       renderBoxModel!.markNeedsCompositingBitsUpdate();
 
     // Opacity effect the stacking context.
-    RenderBoxModel? parentRenderer = (this as RenderStyle).parent?.renderBoxModel;
+    RenderBoxModel? parentRenderer = parent?.renderBoxModel;
     if (parentRenderer is RenderLayoutBox) {
       parentRenderer.markChildrenNeedsSort();
     }

--- a/kraken/lib/src/css/overflow.dart
+++ b/kraken/lib/src/css/overflow.dart
@@ -48,7 +48,7 @@ List<String> _scrollingContentBoxCopyStyles = [
   LINE_CLAMP,
 ];
 
-mixin CSSOverflowMixin on RenderStyleBase {
+mixin CSSOverflowMixin on RenderStyle {
   @override
   CSSOverflowType get overflowX => _overflowX ?? CSSOverflowType.visible;
   CSSOverflowType? _overflowX;
@@ -65,6 +65,7 @@ mixin CSSOverflowMixin on RenderStyleBase {
     _overflowY = value;
   }
 
+  @override
   CSSOverflowType get effectiveOverflowX {
     if (overflowX == CSSOverflowType.visible && overflowY != CSSOverflowType.visible) {
       return CSSOverflowType.auto;
@@ -72,6 +73,7 @@ mixin CSSOverflowMixin on RenderStyleBase {
     return overflowX;
   }
 
+  @override
   CSSOverflowType get effectiveOverflowY {
     if (overflowY == CSSOverflowType.visible && overflowX != CSSOverflowType.visible) {
       return CSSOverflowType.auto;
@@ -219,7 +221,7 @@ mixin ElementOverflowMixin on ElementBase {
     // Sliver content has no multi scroll content box.
     if (scrollingContentBox == null) return;
 
-    RenderStyle scrollingContentRenderStyle = scrollingContentBox.renderStyle;
+    CSSRenderStyle scrollingContentRenderStyle = scrollingContentBox.renderStyle;
 
     switch (property) {
       case DISPLAY:

--- a/kraken/lib/src/css/overflow.dart
+++ b/kraken/lib/src/css/overflow.dart
@@ -48,20 +48,18 @@ List<String> _scrollingContentBoxCopyStyles = [
   LINE_CLAMP,
 ];
 
-mixin CSSOverflowMixin on RenderStyleBase {
+mixin CSSOverflowMixin on AbstractRenderStyle {
+  @override
+  CSSOverflowType get overflowX => _overflowX ?? CSSOverflowType.visible;
   CSSOverflowType? _overflowX;
-  CSSOverflowType get overflowX {
-    return _overflowX ?? CSSOverflowType.visible;
-  }
   set overflowX(CSSOverflowType value) {
     if (_overflowX == value) return;
     _overflowX = value;
   }
 
+  @override
+  CSSOverflowType get overflowY => _overflowY ?? CSSOverflowType.visible;
   CSSOverflowType? _overflowY;
-  CSSOverflowType get overflowY {
-    return _overflowY ?? CSSOverflowType.visible;
-  }
   set overflowY(CSSOverflowType value) {
     if (_overflowY == value) return;
     _overflowY = value;

--- a/kraken/lib/src/css/overflow.dart
+++ b/kraken/lib/src/css/overflow.dart
@@ -48,7 +48,7 @@ List<String> _scrollingContentBoxCopyStyles = [
   LINE_CLAMP,
 ];
 
-mixin CSSOverflowMixin on AbstractRenderStyle {
+mixin CSSOverflowMixin on RenderStyleBase {
   @override
   CSSOverflowType get overflowX => _overflowX ?? CSSOverflowType.visible;
   CSSOverflowType? _overflowX;

--- a/kraken/lib/src/css/padding.dart
+++ b/kraken/lib/src/css/padding.dart
@@ -9,11 +9,12 @@ import 'package:flutter/rendering.dart';
 import 'package:kraken/css.dart';
 import 'package:kraken/rendering.dart';
 
-mixin CSSPaddingMixin on RenderStyleBase {
+mixin CSSPaddingMixin on AbstractRenderStyle {
   /// The amount to pad the child in each dimension.
   ///
   /// If this is set to an [EdgeInsetsDirectional] object, then [textDirection]
   /// must not be null.
+  @override
   EdgeInsets get padding {
     EdgeInsets insets = EdgeInsets.only(
       left: paddingLeft.computedValue,
@@ -31,6 +32,8 @@ mixin CSSPaddingMixin on RenderStyleBase {
     _paddingLeft = value;
     _markSelfAndParentNeedsLayout();
   }
+
+  @override
   CSSLengthValue get paddingLeft => _paddingLeft ?? CSSLengthValue.zero;
 
   CSSLengthValue? _paddingRight;
@@ -39,6 +42,8 @@ mixin CSSPaddingMixin on RenderStyleBase {
     _paddingRight = value;
     _markSelfAndParentNeedsLayout();
   }
+
+  @override
   CSSLengthValue get paddingRight => _paddingRight ?? CSSLengthValue.zero;
 
   CSSLengthValue? _paddingBottom;
@@ -47,6 +52,8 @@ mixin CSSPaddingMixin on RenderStyleBase {
     _paddingBottom = value;
     _markSelfAndParentNeedsLayout();
   }
+
+  @override
   CSSLengthValue get paddingBottom => _paddingBottom ?? CSSLengthValue.zero;
 
   CSSLengthValue? _paddingTop;
@@ -55,6 +62,8 @@ mixin CSSPaddingMixin on RenderStyleBase {
     _paddingTop = value;
     _markSelfAndParentNeedsLayout();
   }
+
+  @override
   CSSLengthValue get paddingTop => _paddingTop ?? CSSLengthValue.zero;
 
   void _markSelfAndParentNeedsLayout() {

--- a/kraken/lib/src/css/padding.dart
+++ b/kraken/lib/src/css/padding.dart
@@ -9,7 +9,7 @@ import 'package:flutter/rendering.dart';
 import 'package:kraken/css.dart';
 import 'package:kraken/rendering.dart';
 
-mixin CSSPaddingMixin on RenderStyleBase {
+mixin CSSPaddingMixin on RenderStyle {
   /// The amount to pad the child in each dimension.
   ///
   /// If this is set to an [EdgeInsetsDirectional] object, then [textDirection]

--- a/kraken/lib/src/css/padding.dart
+++ b/kraken/lib/src/css/padding.dart
@@ -9,7 +9,7 @@ import 'package:flutter/rendering.dart';
 import 'package:kraken/css.dart';
 import 'package:kraken/rendering.dart';
 
-mixin CSSPaddingMixin on AbstractRenderStyle {
+mixin CSSPaddingMixin on RenderStyleBase {
   /// The amount to pad the child in each dimension.
   ///
   /// If this is set to an [EdgeInsetsDirectional] object, then [textDirection]

--- a/kraken/lib/src/css/position.dart
+++ b/kraken/lib/src/css/position.dart
@@ -14,7 +14,7 @@ enum CSSPositionType {
   sticky,
 }
 
-mixin CSSPositionMixin on AbstractRenderStyle {
+mixin CSSPositionMixin on RenderStyleBase {
 
   static const CSSPositionType DEFAULT_POSITION_TYPE = CSSPositionType.static;
 

--- a/kraken/lib/src/css/position.dart
+++ b/kraken/lib/src/css/position.dart
@@ -102,7 +102,7 @@ mixin CSSPositionMixin on AbstractRenderStyle {
   }
 
   void _markNeedsSort() {
-    if (renderBoxModel!.parentData is RenderLayoutParentData) {
+    if (renderBoxModel?.parentData is RenderLayoutParentData) {
       RenderLayoutBox parent = renderBoxModel!.parent as RenderLayoutBox;
       parent.markChildrenNeedsSort();
     }
@@ -112,7 +112,7 @@ mixin CSSPositionMixin on AbstractRenderStyle {
     // Should mark positioned element's containing block needs layout directly
     // cause RelayoutBoundary of positioned element will prevent the needsLayout flag
     // to bubble up in the RenderObject tree.
-    if (renderBoxModel!.parentData is RenderLayoutParentData) {
+    if (renderBoxModel?.parentData is RenderLayoutParentData) {
       RenderStyle renderStyle = renderBoxModel!.renderStyle;
       if (renderStyle.position != DEFAULT_POSITION_TYPE) {
         RenderBoxModel parent = renderBoxModel!.parent as RenderBoxModel;

--- a/kraken/lib/src/css/position.dart
+++ b/kraken/lib/src/css/position.dart
@@ -14,7 +14,7 @@ enum CSSPositionType {
   sticky,
 }
 
-mixin CSSPositionMixin on RenderStyleBase {
+mixin CSSPositionMixin on AbstractRenderStyle {
 
   static const CSSPositionType DEFAULT_POSITION_TYPE = CSSPositionType.static;
 
@@ -28,10 +28,9 @@ mixin CSSPositionMixin on RenderStyleBase {
   // Computed value: the keyword auto or a computed <length-percentage> value
   // Canonical order: per grammar
   // Animation type: by computed value type
+  @override
+  CSSLengthValue get top => _top ?? CSSLengthValue.auto;
   CSSLengthValue? _top;
-  CSSLengthValue get top {
-    return _top ?? CSSLengthValue.auto;
-  }
   set top(CSSLengthValue? value) {
     if (_top == value) {
       return;
@@ -40,10 +39,9 @@ mixin CSSPositionMixin on RenderStyleBase {
     _markParentNeedsLayout();
   }
 
+  @override
+  CSSLengthValue get bottom => _bottom ?? CSSLengthValue.auto;
   CSSLengthValue? _bottom;
-  CSSLengthValue get bottom {
-    return _bottom ?? CSSLengthValue.auto;
-  }
   set bottom(CSSLengthValue? value) {
     if (_bottom == value) {
       return;
@@ -52,10 +50,9 @@ mixin CSSPositionMixin on RenderStyleBase {
     _markParentNeedsLayout();
   }
 
+  @override
+  CSSLengthValue get left => _left ?? CSSLengthValue.auto;
   CSSLengthValue? _left;
-  CSSLengthValue get left {
-    return _left ?? CSSLengthValue.auto;
-  }
   set left(CSSLengthValue? value) {
     if (_left == value) {
       return;
@@ -64,10 +61,9 @@ mixin CSSPositionMixin on RenderStyleBase {
     _markParentNeedsLayout();
   }
 
+  @override
+  CSSLengthValue get right => _right ?? CSSLengthValue.auto;
   CSSLengthValue? _right;
-  CSSLengthValue get right {
-    return _right ?? CSSLengthValue.auto;
-  }
   set right(CSSLengthValue? value) {
     if (_right == value) {
       return;
@@ -78,9 +74,10 @@ mixin CSSPositionMixin on RenderStyleBase {
   // The z-index property specifies the stack order of an element.
   // Only works on positioned elements(position: absolute/relative/fixed).
   int? _zIndex;
-  int? get zIndex {
-    return _zIndex;
-  }
+
+  @override
+  int? get zIndex => _zIndex;
+
   set zIndex(int? value) {
     if (_zIndex == value) return;
     _zIndex = value;
@@ -89,13 +86,14 @@ mixin CSSPositionMixin on RenderStyleBase {
   }
 
   CSSPositionType _position = DEFAULT_POSITION_TYPE;
-  CSSPositionType get position {
-    return _position;
-  }
+
+  @override
+  CSSPositionType get position => _position;
+
   set position(CSSPositionType value) {
     if (_position == value) return;
     _position = value;
-    
+
     // Position effect the stacking context.
     _markNeedsSort();
     _markParentNeedsLayout();
@@ -154,5 +152,4 @@ mixin CSSPositionMixin on RenderStyleBase {
         return CSSPositionType.static;
     }
   }
-
 }

--- a/kraken/lib/src/css/position.dart
+++ b/kraken/lib/src/css/position.dart
@@ -14,7 +14,7 @@ enum CSSPositionType {
   sticky,
 }
 
-mixin CSSPositionMixin on RenderStyleBase {
+mixin CSSPositionMixin on RenderStyle {
 
   static const CSSPositionType DEFAULT_POSITION_TYPE = CSSPositionType.static;
 

--- a/kraken/lib/src/css/render_style.dart
+++ b/kraken/lib/src/css/render_style.dart
@@ -13,10 +13,10 @@ import 'package:kraken/rendering.dart';
 
 /// The abstract class for render-style, declare the
 /// getter interface for all available CSS rule.
-abstract class AbstractRenderStyle {
+abstract class RenderStyleBase {
   // Common
   Element get target;
-  AbstractRenderStyle? get parent;
+  RenderStyleBase? get parent;
   getProperty(String key);
 
   // Geometry
@@ -161,7 +161,7 @@ abstract class AbstractRenderStyle {
 }
 
 class RenderStyle
-  extends AbstractRenderStyle
+  extends RenderStyleBase
   with
     CSSSizingMixin,
     CSSPaddingMixin,

--- a/kraken/lib/src/css/render_style.dart
+++ b/kraken/lib/src/css/render_style.dart
@@ -13,10 +13,10 @@ import 'package:kraken/rendering.dart';
 
 /// The abstract class for render-style, declare the
 /// getter interface for all available CSS rule.
-abstract class RenderStyleBase {
+abstract class RenderStyle {
   // Common
   Element get target;
-  RenderStyleBase? get parent;
+  RenderStyle? get parent;
   getProperty(String key);
 
   // Geometry
@@ -107,15 +107,19 @@ abstract class RenderStyleBase {
   double? get contentBoxHeight;
   CSSPositionType get position;
   CSSDisplay get display;
+  CSSDisplay get effectiveDisplay;
   Alignment get objectPosition;
   CSSOverflowType get overflowX;
   CSSOverflowType get overflowY;
+  CSSOverflowType get effectiveOverflowX;
+  CSSOverflowType get effectiveOverflowY;
 
   // Flex
   FlexDirection get flexDirection;
   FlexWrap get flexWrap;
   JustifyContent get justifyContent;
   AlignItems get alignItems;
+  AlignItems get effectiveAlignItems;
   AlignContent get alignContent;
   AlignSelf get alignSelf;
   CSSLengthValue? get flexBasis;
@@ -149,7 +153,10 @@ abstract class RenderStyleBase {
 
   void addFontRelativeProperty(String propertyName);
   void addRootFontRelativeProperty(String propertyName);
+  void addColorRelativeProperty(String propertyName);
   String? removeAnimationProperty(String propertyName);
+  double getWidthByIntrinsicRatio();
+  double getHeightByIntrinsicRatio();
 
   // Following properties used for exposing APIs
   // for class that extends [AbstractRenderStyle].
@@ -160,8 +167,8 @@ abstract class RenderStyleBase {
   double get rootFontSize => target.elementManager.getRootFontSize();
 }
 
-class RenderStyle
-  extends RenderStyleBase
+class CSSRenderStyle
+  extends RenderStyle
   with
     CSSSizingMixin,
     CSSPaddingMixin,
@@ -186,13 +193,13 @@ class RenderStyle
     CSSFilterEffectsMixin,
     CSSOpacityMixin,
     CSSTransitionMixin {
-  RenderStyle({ required this.target });
+  CSSRenderStyle({ required this.target });
 
   @override
   Element target;
 
   @override
-  RenderStyle? parent;
+  CSSRenderStyle? parent;
 
   @override
   getProperty(String name) {
@@ -758,6 +765,7 @@ class RenderStyle
   }
 
   /// Get height of replaced element by intrinsic ratio if height is not defined
+  @override
   double getHeightByIntrinsicRatio() {
     // @TODO: move intrinsic width/height to renderStyle
     double? intrinsicWidth = renderBoxModel!.intrinsicWidth;
@@ -774,6 +782,7 @@ class RenderStyle
   }
 
   /// Get width of replaced element by intrinsic ratio if width is not defined
+  @override
   double getWidthByIntrinsicRatio() {
     // @TODO: move intrinsic width/height to renderStyle
     double? intrinsicHeight = renderBoxModel!.intrinsicHeight;

--- a/kraken/lib/src/css/render_style.dart
+++ b/kraken/lib/src/css/render_style.dart
@@ -11,19 +11,158 @@ import 'package:kraken/css.dart';
 import 'package:kraken/dom.dart';
 import 'package:kraken/rendering.dart';
 
-mixin RenderStyleBase {
+/// The abstract class for render-style, declare the
+/// getter interface for all available CSS rule.
+abstract class AbstractRenderStyle {
+  // Common
+  Element get target;
+  AbstractRenderStyle? get parent;
+  getProperty(String key);
+
+  // Geometry
+  CSSLengthValue get top;
+  CSSLengthValue get right;
+  CSSLengthValue get bottom;
+  CSSLengthValue get left;
+  int? get zIndex;
+  CSSLengthValue get width;
+  CSSLengthValue get height;
+  CSSLengthValue get minWidth;
+  CSSLengthValue get minHeight;
+  CSSLengthValue get maxWidth;
+  CSSLengthValue get maxHeight;
+  EdgeInsets get margin;
+  CSSLengthValue get marginLeft;
+  CSSLengthValue get marginRight;
+  CSSLengthValue get marginTop;
+  CSSLengthValue get marginBottom;
+  EdgeInsets get padding;
+  CSSLengthValue get paddingLeft;
+  CSSLengthValue get paddingRight;
+  CSSLengthValue get paddingBottom;
+  CSSLengthValue get paddingTop;
+
+  // Border
+  EdgeInsets get border;
+  CSSLengthValue? get borderTopWidth;
+  CSSLengthValue? get borderRightWidth;
+  CSSLengthValue? get borderBottomWidth;
+  CSSLengthValue? get borderLeftWidth;
+  BorderStyle get borderLeftStyle;
+  BorderStyle get borderRightStyle;
+  BorderStyle get borderTopStyle;
+  BorderStyle get borderBottomStyle;
+  CSSLengthValue get effectiveBorderLeftWidth;
+  CSSLengthValue get effectiveBorderRightWidth;
+  CSSLengthValue get effectiveBorderTopWidth;
+  CSSLengthValue get effectiveBorderBottomWidth;
+  double? get logicalContentWidth;
+  double? get logicalContentHeight;
+  double get contentMaxConstraintsWidth;
+  Color get borderLeftColor;
+  Color get borderRightColor;
+  Color get borderTopColor;
+  Color get borderBottomColor;
+  List<Radius>? get borderRadius;
+  CSSBorderRadius get borderTopLeftRadius;
+  CSSBorderRadius get borderTopRightRadius;
+  CSSBorderRadius get borderBottomRightRadius;
+  CSSBorderRadius get borderBottomLeftRadius;
+  List<BorderSide>? get borderSides;
+  List<KrakenBoxShadow>? get shadows;
+
+  // Decorations
+  Color? get backgroundColor;
+  CSSBackgroundImage? get backgroundImage;
+  ImageRepeat get backgroundRepeat;
+  CSSBackgroundPosition get backgroundPositionX;
+  CSSBackgroundPosition get backgroundPositionY;
+
+  // Text
+  CSSLengthValue get fontSize;
+  FontWeight get fontWeight;
+  FontStyle get fontStyle;
+  List<String>? get fontFamily;
+  List<Shadow>? get textShadow;
+  WhiteSpace get whiteSpace;
+  TextOverflow get textOverflow;
+  TextAlign get textAlign;
+  int? get lineClamp;
+  CSSLengthValue get lineHeight;
+  CSSLengthValue? get letterSpacing;
+  CSSLengthValue? get wordSpacing;
+
+  // BoxModel
+  double? get borderBoxLogicalWidth;
+  double? get borderBoxLogicalHeight;
+  double? get borderBoxWidth;
+  double? get borderBoxHeight;
+  double? get paddingBoxLogicalWidth;
+  double? get paddingBoxLogicalHeight;
+  double? get paddingBoxWidth;
+  double? get paddingBoxHeight;
+  double? get contentBoxLogicalWidth;
+  double? get contentBoxLogicalHeight;
+  double? get contentBoxWidth;
+  double? get contentBoxHeight;
+  CSSPositionType get position;
+  CSSDisplay get display;
+  Alignment get objectPosition;
+  CSSOverflowType get overflowX;
+  CSSOverflowType get overflowY;
+
+  // Flex
+  FlexDirection get flexDirection;
+  FlexWrap get flexWrap;
+  JustifyContent get justifyContent;
+  AlignItems get alignItems;
+  AlignContent get alignContent;
+  AlignSelf get alignSelf;
+  CSSLengthValue? get flexBasis;
+  double get flexGrow;
+  double get flexShrink;
+
+  // Color
+  Color get color;
+  Color get currentColor;
+
+  // Filter
+  ColorFilter? get colorFilter;
+  ImageFilter? get imageFilter;
+  List<CSSFunctionalNotation>? get filter;
+
+  // Misc
+  double get opacity;
+  Visibility get visibility;
+  ContentVisibility? get contentVisibility;
+  VerticalAlign get verticalAlign;
+  BoxFit get objectFit;
+
+  // Transition
+  List<String> get transitionProperty;
+  List<String> get transitionDuration;
+  List<String> get transitionTimingFunction;
+  List<String> get transitionDelay;
+
+  // Sliver
+  Axis get sliverDirection;
+
+  void addFontRelativeProperty(String propertyName);
+  void addRootFontRelativeProperty(String propertyName);
+  String? removeAnimationProperty(String propertyName);
+
   // Following properties used for exposing APIs
-  // for class that extends [RenderStyleBase].
-  late Element target;
+  // for class that extends [AbstractRenderStyle].
   RenderBoxModel? get renderBoxModel => target.renderBoxModel;
+
   Size get viewportSize => target.elementManager.viewport.viewportSize;
+
   double get rootFontSize => target.elementManager.getRootFontSize();
-  Color get currentColor => (this as RenderStyle).color;
 }
 
 class RenderStyle
+  extends AbstractRenderStyle
   with
-    RenderStyleBase,
     CSSSizingMixin,
     CSSPaddingMixin,
     CSSBorderMixin,
@@ -47,200 +186,199 @@ class RenderStyle
     CSSFilterEffectsMixin,
     CSSOpacityMixin,
     CSSTransitionMixin {
+  RenderStyle({ required this.target });
 
   @override
   Element target;
 
+  @override
   RenderStyle? parent;
 
-  RenderStyle({
-    required this.target,
-  });
-
-  dynamic getProperty(String name) {
-    RenderStyle renderStyle = this;
+  @override
+  getProperty(String name) {
     switch (name) {
       case DISPLAY:
-        return renderStyle.display;
+        return display;
       case Z_INDEX:
-        return renderStyle.zIndex;
+        return zIndex;
       case OVERFLOW_X:
-        return renderStyle.overflowX;
+        return overflowX;
       case OVERFLOW_Y:
-        return renderStyle.overflowY;
+        return overflowY;
       case OPACITY:
-        return renderStyle.opacity;
+        return opacity;
       case VISIBILITY:
-        return renderStyle.visibility;
+        return visibility;
       case CONTENT_VISIBILITY:
-        return renderStyle.contentVisibility;
+        return contentVisibility;
       case POSITION:
-        return renderStyle.position;
+        return position;
       case TOP:
-        return renderStyle.top;
+        return top;
       case LEFT:
-        return renderStyle.left;
+        return left;
       case BOTTOM:
-        return renderStyle.bottom;
+        return bottom;
       case RIGHT:
-        return renderStyle.right;
+        return right;
       // Size
       case WIDTH:
-        return renderStyle.width;
+        return width;
       case MIN_WIDTH:
-        return renderStyle.minWidth;
+        return minWidth;
       case MAX_WIDTH:
-        return renderStyle.maxWidth;
+        return maxWidth;
       case HEIGHT:
-        return renderStyle.height;
+        return height;
       case MIN_HEIGHT:
-        return renderStyle.minHeight;
+        return minHeight;
       case MAX_HEIGHT:
-        return renderStyle.maxHeight;
+        return maxHeight;
       // Flex
       case FLEX_DIRECTION:
-        return renderStyle.flexDirection;
+        return flexDirection;
       case FLEX_WRAP:
-        return renderStyle.flexWrap;
+        return flexWrap;
       case ALIGN_CONTENT:
-        return renderStyle.alignContent;
+        return alignContent;
       case ALIGN_ITEMS:
-        return renderStyle.alignItems;
+        return alignItems;
       case JUSTIFY_CONTENT:
-        return renderStyle.justifyContent;
+        return justifyContent;
       case ALIGN_SELF:
-        return renderStyle.alignSelf;
+        return alignSelf;
       case FLEX_GROW:
-        return renderStyle.flexGrow;
+        return flexGrow;
       case FLEX_SHRINK:
-        return renderStyle.flexShrink;
+        return flexShrink;
       case FLEX_BASIS:
-        return renderStyle.flexBasis;
+        return flexBasis;
       // Background
       case BACKGROUND_COLOR:
-        return renderStyle.backgroundColor;
+        return backgroundColor;
       case BACKGROUND_ATTACHMENT:
-        return renderStyle.backgroundAttachment;
+        return backgroundAttachment;
       case BACKGROUND_IMAGE:
-        return renderStyle.backgroundImage;
+        return backgroundImage;
       case BACKGROUND_REPEAT:
-        return renderStyle.backgroundRepeat;
+        return backgroundRepeat;
       case BACKGROUND_POSITION_X:
-        return renderStyle.backgroundPositionX;
+        return backgroundPositionX;
       case BACKGROUND_POSITION_Y:
-        return renderStyle.backgroundPositionY;
+        return backgroundPositionY;
       case BACKGROUND_SIZE:
-        return renderStyle.backgroundSize;
+        return backgroundSize;
       case BACKGROUND_CLIP:
-        return renderStyle.backgroundClip;
+        return backgroundClip;
       case BACKGROUND_ORIGIN:
-        return renderStyle.backgroundOrigin;
+        return backgroundOrigin;
       // Padding
       case PADDING_TOP:
-        return renderStyle.paddingTop;
+        return paddingTop;
       case PADDING_RIGHT:
-        return renderStyle.paddingRight;
+        return paddingRight;
       case PADDING_BOTTOM:
-        return renderStyle.paddingBottom;
+        return paddingBottom;
       case PADDING_LEFT:
-        return renderStyle.paddingLeft;
+        return paddingLeft;
       // Border
       case BORDER_LEFT_WIDTH:
-        return renderStyle.borderLeftWidth;
+        return borderLeftWidth;
       case BORDER_TOP_WIDTH:
-        return renderStyle.borderTopWidth;
+        return borderTopWidth;
       case BORDER_RIGHT_WIDTH:
-        return renderStyle.borderRightWidth;
+        return borderRightWidth;
       case BORDER_BOTTOM_WIDTH:
-        return renderStyle.borderBottomWidth;
+        return borderBottomWidth;
       case BORDER_LEFT_STYLE:
-        return renderStyle.borderLeftStyle;
+        return borderLeftStyle;
       case BORDER_TOP_STYLE:
-        return renderStyle.borderTopStyle;
+        return borderTopStyle;
       case BORDER_RIGHT_STYLE:
-        return renderStyle.borderRightStyle;
+        return borderRightStyle;
       case BORDER_BOTTOM_STYLE:
-        return renderStyle.borderBottomStyle;
+        return borderBottomStyle;
       case BORDER_LEFT_COLOR:
-        return renderStyle.borderLeftColor;
+        return borderLeftColor;
       case BORDER_TOP_COLOR:
-        return renderStyle.borderTopColor;
+        return borderTopColor;
       case BORDER_RIGHT_COLOR:
-        return renderStyle.borderRightColor;
+        return borderRightColor;
       case BORDER_BOTTOM_COLOR:
-        return renderStyle.borderBottomColor;
+        return borderBottomColor;
       case BOX_SHADOW:
-        return renderStyle.boxShadow;
+        return boxShadow;
       case BORDER_TOP_LEFT_RADIUS:
-        return renderStyle.borderTopLeftRadius;
+        return borderTopLeftRadius;
       case BORDER_TOP_RIGHT_RADIUS:
-        return renderStyle.borderTopRightRadius;
+        return borderTopRightRadius;
       case BORDER_BOTTOM_LEFT_RADIUS:
-        return renderStyle.borderBottomLeftRadius;
+        return borderBottomLeftRadius;
       case BORDER_BOTTOM_RIGHT_RADIUS:
-        return renderStyle.borderBottomRightRadius;
+        return borderBottomRightRadius;
       // Margin
       case MARGIN_LEFT:
-        return renderStyle.marginLeft;
+        return marginLeft;
       case MARGIN_TOP:
-        return renderStyle.marginTop;
+        return marginTop;
       case MARGIN_RIGHT:
-        return renderStyle.marginRight;
+        return marginRight;
       case MARGIN_BOTTOM:
-        return renderStyle.marginBottom;
+        return marginBottom;
       // Text
       case COLOR:
-        return renderStyle.color;
+        return color;
       case TEXT_DECORATION_LINE:
-        return renderStyle.textDecorationLine;
+        return textDecorationLine;
       case TEXT_DECORATION_STYLE:
-        return renderStyle.textDecorationStyle;
+        return textDecorationStyle;
       case TEXT_DECORATION_COLOR:
-        return renderStyle.textDecorationColor;
+        return textDecorationColor;
       case FONT_WEIGHT:
-        return renderStyle.fontWeight;
+        return fontWeight;
       case FONT_STYLE:
-        return renderStyle.fontStyle;
+        return fontStyle;
       case FONT_FAMILY:
-        return renderStyle.fontFamily;
+        return fontFamily;
       case FONT_SIZE:
-        return renderStyle.fontSize;
+        return fontSize;
       case LINE_HEIGHT:
-        return renderStyle.lineHeight;
+        return lineHeight;
       case LETTER_SPACING:
-        return renderStyle.letterSpacing;
+        return letterSpacing;
       case WORD_SPACING:
-        return renderStyle.wordSpacing;
+        return wordSpacing;
       case TEXT_SHADOW:
-        return renderStyle.textShadow;
+        return textShadow;
       case WHITE_SPACE:
-        return renderStyle.whiteSpace;
+        return whiteSpace;
       case TEXT_OVERFLOW:
-        return renderStyle.textOverflow;
+        return textOverflow;
       case LINE_CLAMP:
-        return renderStyle.lineClamp;
+        return lineClamp;
       case VERTICAL_ALIGN:
-        return renderStyle.verticalAlign;
+        return verticalAlign;
       case TEXT_ALIGN:
-        return renderStyle.textAlign;
+        return textAlign;
       // Transform
       case TRANSFORM:
-        return renderStyle.transform;
+        return transform;
       case TRANSFORM_ORIGIN:
-        return renderStyle.transformOrigin;
+        return transformOrigin;
       case SLIVER_DIRECTION:
-        return renderStyle.sliverDirection;
+        return sliverDirection;
       case OBJECT_FIT:
-        return renderStyle.objectFit;
+        return objectFit;
       case OBJECT_POSITION:
-        return renderStyle.objectPosition;
+        return objectPosition;
       case FILTER:
-        return renderStyle.filter;
+        return filter;
     }
   }
 
   // Content width of render box model calculated from style.
-  double? getLogicalContentWidth() {
+  @override
+  double? get logicalContentWidth {
     RenderStyle renderStyle = this;
     double? intrinsicRatio = renderBoxModel!.intrinsicRatio;
     CSSDisplay? effectiveDisplay = renderStyle.effectiveDisplay;
@@ -341,7 +479,8 @@ class RenderStyle
   }
 
   // Content height of render box model calculated from style.
-  double? getLogicalContentHeight() {
+  @override
+  double? get logicalContentHeight {
     RenderStyle renderStyle = this;
     CSSDisplay? effectiveDisplay = renderStyle.effectiveDisplay;
     double? height = renderStyle.height.isAuto ? null : renderStyle.height.computedValue;
@@ -414,6 +553,7 @@ class RenderStyle
 
   // Max constraints width of content, used in calculating the remaining space for line wrapping
   // in the stage of layout.
+  @override
   double get contentMaxConstraintsWidth {
     // If renderBoxModel definite content constraints, use it as max constrains width of content.
     BoxConstraints? contentConstraints = renderBoxModel!.contentConstraints;
@@ -486,6 +626,7 @@ class RenderStyle
   // Content width calculated from renderStyle tree.
   // https://www.w3.org/TR/css-box-3/#valdef-box-content-box
   // @TODO: add cache to avoid recalculate every time.
+  @override
   double? get contentBoxLogicalWidth {
     // If renderBox has tight width, its logical size equals max size.
     if (renderBoxModel != null &&
@@ -496,12 +637,13 @@ class RenderStyle
         effectiveBorderLeftWidth.computedValue - effectiveBorderRightWidth.computedValue -
         paddingLeft.computedValue - paddingRight.computedValue;
     }
-    return getLogicalContentWidth();
+    return logicalContentWidth;
   }
 
   // Content height calculated from renderStyle tree.
   // https://www.w3.org/TR/css-box-3/#valdef-box-content-box
   // @TODO: add cache to avoid recalculate every time.
+  @override
   double? get contentBoxLogicalHeight {
     // If renderBox has tight height, its logical size equals max size.
     if (renderBoxModel != null &&
@@ -512,11 +654,12 @@ class RenderStyle
         effectiveBorderTopWidth.computedValue - effectiveBorderBottomWidth.computedValue -
         paddingTop.computedValue - paddingBottom.computedValue;
     }
-    return getLogicalContentHeight();
+    return logicalContentHeight;
   }
 
   // Padding box width calculated from renderStyle tree.
   // https://www.w3.org/TR/css-box-3/#valdef-box-padding-box
+  @override
   double? get paddingBoxLogicalWidth {
     if (contentBoxLogicalWidth == null) {
       return null;
@@ -526,6 +669,7 @@ class RenderStyle
 
   // Padding box height calculated from renderStyle tree.
   // https://www.w3.org/TR/css-box-3/#valdef-box-padding-box
+  @override
   double? get paddingBoxLogicalHeight {
     if (contentBoxLogicalHeight == null) {
       return null;
@@ -535,6 +679,7 @@ class RenderStyle
 
   // Border box width calculated from renderStyle tree.
   // https://www.w3.org/TR/css-box-3/#valdef-box-border-box
+  @override
   double? get borderBoxLogicalWidth {
     if (paddingBoxLogicalWidth == null) {
       return null;
@@ -544,6 +689,7 @@ class RenderStyle
 
   // Border box height calculated from renderStyle tree.
   // https://www.w3.org/TR/css-box-3/#valdef-box-border-box
+  @override
   double? get borderBoxLogicalHeight {
     if (paddingBoxLogicalHeight == null) {
       return null;
@@ -553,6 +699,7 @@ class RenderStyle
 
   // Content box width of renderBoxModel after it was rendered.
   // https://www.w3.org/TR/css-box-3/#valdef-box-content-box
+  @override
   double? get contentBoxWidth {
     if (paddingBoxWidth == null) {
       return null;
@@ -562,6 +709,7 @@ class RenderStyle
 
   // Content box height of renderBoxModel after it was rendered.
   // https://www.w3.org/TR/css-box-3/#valdef-box-content-box
+  @override
   double? get contentBoxHeight {
     if (paddingBoxHeight == null) {
       return null;
@@ -571,6 +719,7 @@ class RenderStyle
 
   // Padding box width of renderBoxModel after it was rendered.
   // https://www.w3.org/TR/css-box-3/#valdef-box-padding-box
+  @override
   double? get paddingBoxWidth {
     if (borderBoxWidth == null) {
       return null;
@@ -580,6 +729,7 @@ class RenderStyle
 
   // Padding box height of renderBoxModel after it was rendered.
   // https://www.w3.org/TR/css-box-3/#valdef-box-padding-box
+  @override
   double? get paddingBoxHeight {
     if (borderBoxHeight == null) {
       return null;
@@ -589,6 +739,7 @@ class RenderStyle
 
   // Border box width of renderBoxModel after it was rendered.
   // https://www.w3.org/TR/css-box-3/#valdef-box-border-box
+  @override
   double? get borderBoxWidth {
     if (renderBoxModel!.hasSize && renderBoxModel!.boxSize != null) {
       return renderBoxModel!.boxSize!.width;
@@ -598,6 +749,7 @@ class RenderStyle
 
   // Border box height of renderBoxModel after it was rendered.
   // https://www.w3.org/TR/css-box-3/#valdef-box-border-box
+  @override
   double? get borderBoxHeight {
     if (renderBoxModel!.hasSize && renderBoxModel!.boxSize != null) {
       return renderBoxModel!.boxSize!.height;

--- a/kraken/lib/src/css/sizing.dart
+++ b/kraken/lib/src/css/sizing.dart
@@ -15,7 +15,7 @@ import 'package:kraken/rendering.dart';
 /// - min-width
 /// - min-height
 
-mixin CSSSizingMixin on AbstractRenderStyle {
+mixin CSSSizingMixin on RenderStyleBase {
 
   // https://drafts.csswg.org/css-sizing-3/#preferred-size-properties
   // Name: width, height

--- a/kraken/lib/src/css/sizing.dart
+++ b/kraken/lib/src/css/sizing.dart
@@ -15,7 +15,7 @@ import 'package:kraken/rendering.dart';
 /// - min-width
 /// - min-height
 
-mixin CSSSizingMixin on RenderStyleBase {
+mixin CSSSizingMixin on RenderStyle {
 
   // https://drafts.csswg.org/css-sizing-3/#preferred-size-properties
   // Name: width, height

--- a/kraken/lib/src/css/sizing.dart
+++ b/kraken/lib/src/css/sizing.dart
@@ -15,7 +15,7 @@ import 'package:kraken/rendering.dart';
 /// - min-width
 /// - min-height
 
-mixin CSSSizingMixin on RenderStyleBase {
+mixin CSSSizingMixin on AbstractRenderStyle {
 
   // https://drafts.csswg.org/css-sizing-3/#preferred-size-properties
   // Name: width, height
@@ -28,9 +28,10 @@ mixin CSSSizingMixin on RenderStyleBase {
   // Canonical order: per grammar
   // Animation type: by computed value type, recursing into fit-content()
   CSSLengthValue? _width;
-  CSSLengthValue get width {
-    return _width ?? CSSLengthValue.auto;
-  }
+
+  @override
+  CSSLengthValue get width =>  _width ?? CSSLengthValue.auto;
+
   set width(CSSLengthValue? value) {
     // Negative value is invalid, auto value is parsed at layout stage.
     if ((value != null && value.value != null && value.value! < 0) || width == value) {
@@ -41,9 +42,10 @@ mixin CSSSizingMixin on RenderStyleBase {
   }
 
   CSSLengthValue? _height;
-  CSSLengthValue get height {
-    return _height ?? CSSLengthValue.auto;
-  }
+
+  @override
+  CSSLengthValue get height => _height ?? CSSLengthValue.auto;
+
   set height(CSSLengthValue? value) {
     // Negative value is invalid, auto value is parsed at layout stage.
     if ((value != null && value.value != null && value.value! < 0) || height == value) {
@@ -64,9 +66,10 @@ mixin CSSSizingMixin on RenderStyleBase {
   // Canonical order: per grammar
   // Animatable: by computed value, recursing into fit-content()
   CSSLengthValue? _minWidth;
-  CSSLengthValue get minWidth {
-    return _minWidth ?? CSSLengthValue.auto;
-  }
+
+  @override
+  CSSLengthValue get minWidth =>  _minWidth ?? CSSLengthValue.auto;
+
   set minWidth(CSSLengthValue? value) {
     // Negative value is invalid, auto value is parsed at layout stage.
     if ((value != null && value.value != null && value.value! < 0) || minWidth == value) {
@@ -77,9 +80,10 @@ mixin CSSSizingMixin on RenderStyleBase {
   }
 
   CSSLengthValue? _minHeight;
-  CSSLengthValue get minHeight {
-    return _minHeight ?? CSSLengthValue.auto;
-  }
+
+  @override
+  CSSLengthValue get minHeight => _minHeight ?? CSSLengthValue.auto;
+
   set minHeight(CSSLengthValue? value) {
     // Negative value is invalid, auto value is parsed at layout stage.
     if ((value != null && value.value != null && value.value! < 0) || minHeight == value) {
@@ -100,9 +104,10 @@ mixin CSSSizingMixin on RenderStyleBase {
   // Canonical order: per grammar
   // Animatable: by computed value, recursing into fit-content()
   CSSLengthValue? _maxWidth;
-  CSSLengthValue get maxWidth {
-    return _maxWidth ?? CSSLengthValue.none;
-  }
+
+  @override
+  CSSLengthValue get maxWidth => _maxWidth ?? CSSLengthValue.none;
+
   set maxWidth(CSSLengthValue? value) {
     // Negative value is invalid, auto value is parsed at layout stage.
     if ((value != null && value.value != null && value.value! < 0) || maxWidth == value) {
@@ -113,9 +118,12 @@ mixin CSSSizingMixin on RenderStyleBase {
   }
 
   CSSLengthValue? _maxHeight;
+
+  @override
   CSSLengthValue get maxHeight {
     return _maxHeight ?? CSSLengthValue.none;
   }
+
   set maxHeight(CSSLengthValue? value) {
     // Negative value is invalid, auto value is parsed at layout stage.
     if ((value != null && value.value != null && value.value! < 0) || maxHeight == value) {

--- a/kraken/lib/src/css/sliver.dart
+++ b/kraken/lib/src/css/sliver.dart
@@ -6,14 +6,15 @@
 import 'package:flutter/rendering.dart';
 import 'package:kraken/css.dart';
 
-mixin CSSSliverMixin on RenderStyleBase {
+mixin CSSSliverMixin on AbstractRenderStyle {
 
-  Axis _sliverDirection = Axis.vertical;
+  @override
   Axis get sliverDirection => _sliverDirection;
+  Axis _sliverDirection = Axis.vertical;
   set sliverDirection(Axis value) {
     if (_sliverDirection == value) return;
     _sliverDirection = value;
-    renderBoxModel!.markNeedsLayout();
+    renderBoxModel?.markNeedsLayout();
   }
 
   static Axis resolveAxis(String sliverDirection) {

--- a/kraken/lib/src/css/sliver.dart
+++ b/kraken/lib/src/css/sliver.dart
@@ -6,7 +6,7 @@
 import 'package:flutter/rendering.dart';
 import 'package:kraken/css.dart';
 
-mixin CSSSliverMixin on RenderStyleBase {
+mixin CSSSliverMixin on RenderStyle {
 
   @override
   Axis get sliverDirection => _sliverDirection;

--- a/kraken/lib/src/css/sliver.dart
+++ b/kraken/lib/src/css/sliver.dart
@@ -6,7 +6,7 @@
 import 'package:flutter/rendering.dart';
 import 'package:kraken/css.dart';
 
-mixin CSSSliverMixin on AbstractRenderStyle {
+mixin CSSSliverMixin on RenderStyleBase {
 
   @override
   Axis get sliverDirection => _sliverDirection;

--- a/kraken/lib/src/css/text.dart
+++ b/kraken/lib/src/css/text.dart
@@ -12,7 +12,7 @@ final RegExp _commaRegExp = RegExp(r'\s*,\s*');
 // CSS Text: https://drafts.csswg.org/css-text-3/
 // CSS Text Decoration: https://drafts.csswg.org/css-text-decor-3/
 // CSS Box Alignment: https://drafts.csswg.org/css-align/
-mixin CSSTextMixin on AbstractRenderStyle {
+mixin CSSTextMixin on RenderStyleBase {
   bool get hasColor => _color != null;
 
   @override

--- a/kraken/lib/src/css/text.dart
+++ b/kraken/lib/src/css/text.dart
@@ -12,19 +12,20 @@ final RegExp _commaRegExp = RegExp(r'\s*,\s*');
 // CSS Text: https://drafts.csswg.org/css-text-3/
 // CSS Text Decoration: https://drafts.csswg.org/css-text-decor-3/
 // CSS Box Alignment: https://drafts.csswg.org/css-align/
-mixin CSSTextMixin on RenderStyleBase {
-
+mixin CSSTextMixin on AbstractRenderStyle {
   bool get hasColor => _color != null;
 
+  @override
+  Color get currentColor => color;
+
   Color? _color;
+
+  @override
   Color get color {
     // Get style from self or closest parent if specified style property is not set
     // due to style inheritance.
-    if (_color == null) {
-      RenderStyle renderStyle = this as RenderStyle;
-      if (renderStyle.parent != null) {
-        return renderStyle.parent!.color;
-      }
+    if (_color == null && parent != null) {
+      return parent!.color;
     }
 
     // The root element has no color, and the color is initial.
@@ -39,18 +40,17 @@ mixin CSSTextMixin on RenderStyleBase {
   }
 
   // Current not update the dependent property relative to the color.
-  final Map<String, bool> _colorRealativeProperties = {};
+  final Map<String, bool> _colorRelativeProperties = {};
 
   void addColorRelativeProperty(String propertyName) {
-    _colorRealativeProperties[propertyName] = true;
+    _colorRelativeProperties[propertyName] = true;
   }
 
   void updateColorRelativeProperty() {
-    if (_colorRealativeProperties.isEmpty) return;
-    RenderStyle renderStyle = this as RenderStyle;
-    _colorRealativeProperties.forEach((String propertyName, _) {
+    if (_colorRelativeProperties.isEmpty) return;
+    _colorRelativeProperties.forEach((String propertyName, _) {
       // TODO: use css color abstraction avoid re-parse the property string.
-      renderStyle.target.setRenderStyle(propertyName, renderStyle.target.style.getPropertyValue(propertyName));
+      target.setRenderStyle(propertyName, target.style.getPropertyValue(propertyName));
     });
   }
 
@@ -86,14 +86,12 @@ mixin CSSTextMixin on RenderStyleBase {
   }
 
   FontWeight? _fontWeight;
+  @override
   FontWeight get fontWeight {
     // Get style from self or closest parent if specified style property is not set
     // due to style inheritance.
-    if (_fontWeight == null) {
-      RenderStyle renderStyle = this as RenderStyle;
-      if (renderStyle.parent != null) {
-        return renderStyle.parent!.fontWeight;
-      }
+    if (_fontWeight == null && parent != null) {
+      return parent!.fontWeight;
     }
 
     // The root element has no fontWeight, and the fontWeight is initial.
@@ -107,14 +105,13 @@ mixin CSSTextMixin on RenderStyleBase {
   }
 
   FontStyle? _fontStyle;
+
+  @override
   FontStyle get fontStyle {
     // Get style from self or closest parent if specified style property is not set
     // due to style inheritance.
-    if (_fontStyle == null) {
-      RenderStyle renderStyle = this as RenderStyle;
-      if (renderStyle.parent != null) {
-        return renderStyle.parent!.fontStyle;
-      }
+    if (_fontStyle == null && parent != null) {
+      return parent!.fontStyle;
     }
 
     // The root element has no fontWeight, and the fontWeight is initial.
@@ -128,14 +125,13 @@ mixin CSSTextMixin on RenderStyleBase {
   }
 
   List<String>? _fontFamily;
+
+  @override
   List<String>? get fontFamily {
     // Get style from self or closest parent if specified style property is not set
     // due to style inheritance.
-    if (_fontFamily == null) {
-      RenderStyle renderStyle = this as RenderStyle;
-      if (renderStyle.parent != null) {
-        return renderStyle.parent!.fontFamily;
-      }
+    if (_fontFamily == null && parent != null) {
+      return parent!.fontFamily;
     }
     return _fontFamily ?? CSSText.DEFAULT_FONT_FAMILY_FALLBACK;
   }
@@ -149,14 +145,13 @@ mixin CSSTextMixin on RenderStyleBase {
   bool get hasFontSize => _fontSize != null;
 
   CSSLengthValue? _fontSize;
+
+  @override
   CSSLengthValue get fontSize {
     // Get style from self or closest parent if specified style property is not set
     // due to style inheritance.
-    if (_fontSize == null) {
-      RenderStyle renderStyle = this as RenderStyle;
-      if (renderStyle.parent != null) {
-        return renderStyle.parent!.fontSize;
-      }
+    if (_fontSize == null && parent != null) {
+      return parent!.fontSize;
     }
     return _fontSize ?? CSSText.DEFAULT_FONT_SIZE;
   }
@@ -175,6 +170,7 @@ mixin CSSTextMixin on RenderStyleBase {
   final Map<String, bool> _fontRealativeProperties = {};
   final Map<String, bool> _rootFontRealativeProperties = {};
 
+  @override
   void addFontRelativeProperty(String propertyName) {
     _fontRealativeProperties[propertyName] = true;
   }
@@ -184,6 +180,7 @@ mixin CSSTextMixin on RenderStyleBase {
     renderBoxModel?.markNeedsLayout();
   }
 
+  @override
   void addRootFontRelativeProperty(String propertyName) {
     _rootFontRealativeProperties[propertyName] = true;
   }
@@ -194,12 +191,11 @@ mixin CSSTextMixin on RenderStyleBase {
   }
 
   CSSLengthValue? _lineHeight;
+
+  @override
   CSSLengthValue get lineHeight {
-    if (_lineHeight == null) {
-      RenderStyle renderStyle = this as RenderStyle;
-      if (renderStyle.parent != null) {
-        return renderStyle.parent!.lineHeight;
-      }
+    if (_lineHeight == null && parent != null) {
+      return parent!.lineHeight;
     }
 
     return _lineHeight ?? CSSText.DEFAULT_LINE_HEIGHT;
@@ -213,14 +209,13 @@ mixin CSSTextMixin on RenderStyleBase {
   }
 
   CSSLengthValue? _letterSpacing;
+
+  @override
   CSSLengthValue? get letterSpacing {
     // Get style from self or closest parent if specified style property is not set
     // due to style inheritance.
-    if (_letterSpacing == null) {
-      RenderStyle renderStyle = this as RenderStyle;
-      if (renderStyle.parent != null) {
-        return renderStyle.parent!.letterSpacing;
-      }
+    if (_letterSpacing == null && parent != null) {
+      return parent!.letterSpacing;
     }
     return _letterSpacing;
   }
@@ -232,14 +227,13 @@ mixin CSSTextMixin on RenderStyleBase {
   }
 
   CSSLengthValue? _wordSpacing;
+
+  @override
   CSSLengthValue? get wordSpacing {
     // Get style from self or closest parent if specified style property is not set
     // due to style inheritance.
-    if (_wordSpacing == null) {
-      RenderStyle renderStyle = this as RenderStyle;
-      if (renderStyle.parent != null) {
-        return renderStyle.parent!.wordSpacing;
-      }
+    if (_wordSpacing == null && parent != null) {
+      return parent!.wordSpacing;
     }
     return _wordSpacing;
   }
@@ -251,14 +245,13 @@ mixin CSSTextMixin on RenderStyleBase {
   }
 
   List<Shadow>? _textShadow;
+
+  @override
   List<Shadow>? get textShadow {
     // Get style from self or closest parent if specified style property is not set
     // due to style inheritance.
-    if (_textShadow == null) {
-      RenderStyle renderStyle = this as RenderStyle;
-      if (renderStyle.parent != null) {
-        return renderStyle.parent!.textShadow;
-      }
+    if (_textShadow == null && parent != null) {
+      return parent!.textShadow;
     }
     return _textShadow;
   }
@@ -270,14 +263,13 @@ mixin CSSTextMixin on RenderStyleBase {
   }
 
   WhiteSpace? _whiteSpace;
+
+  @override
   WhiteSpace get whiteSpace {
     // Get style from self or closest parent if specified style property is not set
     // due to style inheritance.
-    if (_whiteSpace == null) {
-      RenderStyle renderStyle = this as RenderStyle;
-      if (renderStyle.parent != null) {
-        return renderStyle.parent!.whiteSpace;
-      }
+    if (_whiteSpace == null && parent != null) {
+      return parent!.whiteSpace;
     }
     return _whiteSpace ?? WhiteSpace.normal;
   }
@@ -289,6 +281,8 @@ mixin CSSTextMixin on RenderStyleBase {
   }
 
   TextOverflow _textOverflow = TextOverflow.clip;
+
+  @override
   TextOverflow get textOverflow {
     return _textOverflow;
   }
@@ -300,6 +294,8 @@ mixin CSSTextMixin on RenderStyleBase {
   }
 
   int? _lineClamp;
+
+  @override
   int? get lineClamp {
     return _lineClamp;
   }
@@ -311,14 +307,13 @@ mixin CSSTextMixin on RenderStyleBase {
   }
 
   TextAlign? _textAlign;
+
+  @override
   TextAlign get textAlign {
     // Get style from self or closest parent if specified style property is not set
     // due to style inheritance.
-    if (_textAlign == null) {
-      RenderStyle renderStyle = this as RenderStyle;
-      if (renderStyle.parent != null) {
-        return renderStyle.parent!.textAlign;
-      }
+    if (_textAlign == null && parent != null) {
+      return parent!.textAlign;
     }
     return _textAlign ?? TextAlign.start;
   }

--- a/kraken/lib/src/css/text.dart
+++ b/kraken/lib/src/css/text.dart
@@ -12,7 +12,7 @@ final RegExp _commaRegExp = RegExp(r'\s*,\s*');
 // CSS Text: https://drafts.csswg.org/css-text-3/
 // CSS Text Decoration: https://drafts.csswg.org/css-text-decor-3/
 // CSS Box Alignment: https://drafts.csswg.org/css-align/
-mixin CSSTextMixin on RenderStyleBase {
+mixin CSSTextMixin on RenderStyle {
   bool get hasColor => _color != null;
 
   @override
@@ -42,6 +42,7 @@ mixin CSSTextMixin on RenderStyleBase {
   // Current not update the dependent property relative to the color.
   final Map<String, bool> _colorRelativeProperties = {};
 
+  @override
   void addColorRelativeProperty(String propertyName) {
     _colorRelativeProperties[propertyName] = true;
   }
@@ -412,7 +413,7 @@ mixin CSSTextMixin on RenderStyleBase {
     return alignment;
   }
 
-  static TextSpan createTextSpan(String? text, RenderStyle renderStyle) {
+  static TextSpan createTextSpan(String? text, CSSRenderStyle renderStyle) {
     /// Creates a new TextStyle object.
     ///   color: The color to use when painting the text. If this is specified, foreground must be null.
     ///   decoration: The decorations to paint near the text (e.g., an underline).

--- a/kraken/lib/src/css/transform.dart
+++ b/kraken/lib/src/css/transform.dart
@@ -40,7 +40,7 @@ mixin CSSTransformMixin on AbstractRenderStyle {
       parentRenderer.markChildrenNeedsSort();
     }
 
-    renderBoxModel!.markNeedsLayout();
+    renderBoxModel?.markNeedsLayout();
   }
 
   static List<CSSFunctionalNotation>? resolveTransform(String present) {
@@ -60,7 +60,7 @@ mixin CSSTransformMixin on AbstractRenderStyle {
   set transformMatrix(Matrix4? value) {
     if (value == null || _transformMatrix == value) return;
     _transformMatrix = value;
-    renderBoxModel!.markNeedsLayout();
+    renderBoxModel?.markNeedsLayout();
   }
 
   Offset get transformOffset => _transformOffset;
@@ -68,7 +68,7 @@ mixin CSSTransformMixin on AbstractRenderStyle {
   set transformOffset(Offset value) {
     if (_transformOffset == value) return;
     _transformOffset = value;
-    renderBoxModel!.markNeedsPaint();
+    renderBoxModel?.markNeedsPaint();
   }
 
   Alignment get transformAlignment => _transformAlignment;
@@ -76,7 +76,7 @@ mixin CSSTransformMixin on AbstractRenderStyle {
   set transformAlignment(Alignment value) {
     if (_transformAlignment == value) return;
     _transformAlignment = value;
-    renderBoxModel!.markNeedsPaint();
+    renderBoxModel?.markNeedsPaint();
   }
 
   CSSOrigin? _transformOrigin;

--- a/kraken/lib/src/css/transform.dart
+++ b/kraken/lib/src/css/transform.dart
@@ -9,7 +9,7 @@ import 'package:kraken/rendering.dart';
 import 'package:vector_math/vector_math_64.dart';
 
 // CSS Transforms: https://drafts.csswg.org/css-transforms/
-mixin CSSTransformMixin on RenderStyleBase {
+mixin CSSTransformMixin on AbstractRenderStyle {
 
   static Offset DEFAULT_TRANSFORM_OFFSET = Offset(0, 0);
   static Alignment DEFAULT_TRANSFORM_ALIGNMENT = Alignment.center;
@@ -35,7 +35,7 @@ mixin CSSTransformMixin on RenderStyleBase {
     _transformMatrix = null;
 
     // Transform effect the stacking context.
-    RenderBoxModel? parentRenderer = (this as RenderStyle).parent?.renderBoxModel;
+    RenderBoxModel? parentRenderer = parent?.renderBoxModel;
     if (parentRenderer is RenderLayoutBox) {
       parentRenderer.markChildrenNeedsSort();
     }
@@ -52,7 +52,7 @@ mixin CSSTransformMixin on RenderStyleBase {
   Matrix4? get transformMatrix {
     if (_transformMatrix == null && _transform != null) {
       // Illegal transform syntax will return null.
-      _transformMatrix = CSSMatrix.computeTransformMatrix(_transform!, this as RenderStyle);
+      _transformMatrix = CSSMatrix.computeTransformMatrix(_transform!, this);
     }
     return _transformMatrix;
   }

--- a/kraken/lib/src/css/transform.dart
+++ b/kraken/lib/src/css/transform.dart
@@ -9,7 +9,7 @@ import 'package:kraken/rendering.dart';
 import 'package:vector_math/vector_math_64.dart';
 
 // CSS Transforms: https://drafts.csswg.org/css-transforms/
-mixin CSSTransformMixin on RenderStyleBase {
+mixin CSSTransformMixin on RenderStyle {
 
   static Offset DEFAULT_TRANSFORM_OFFSET = Offset(0, 0);
   static Alignment DEFAULT_TRANSFORM_ALIGNMENT = Alignment.center;

--- a/kraken/lib/src/css/transform.dart
+++ b/kraken/lib/src/css/transform.dart
@@ -9,7 +9,7 @@ import 'package:kraken/rendering.dart';
 import 'package:vector_math/vector_math_64.dart';
 
 // CSS Transforms: https://drafts.csswg.org/css-transforms/
-mixin CSSTransformMixin on AbstractRenderStyle {
+mixin CSSTransformMixin on RenderStyleBase {
 
   static Offset DEFAULT_TRANSFORM_OFFSET = Offset(0, 0);
   static Alignment DEFAULT_TRANSFORM_ALIGNMENT = Alignment.center;

--- a/kraken/lib/src/css/transition.dart
+++ b/kraken/lib/src/css/transition.dart
@@ -179,7 +179,7 @@ enum CSSTransitionEvent {
   cancel,
 }
 
-mixin CSSTransitionMixin on AbstractRenderStyle {
+mixin CSSTransitionMixin on RenderStyleBase {
 
   // https://drafts.csswg.org/css-transitions/#transition-property-property
   // Name: transition-property

--- a/kraken/lib/src/css/transition.dart
+++ b/kraken/lib/src/css/transition.dart
@@ -58,7 +58,7 @@ double? _parseLength(String length, RenderStyle renderStyle, String property) {
   return CSSLength.parseLength(length, renderStyle, property).computedValue;
 }
 
-void _updateLength(double oldLengthValue, double newLengthValue, double progress, String property, RenderStyle renderStyle) {
+void _updateLength(double oldLengthValue, double newLengthValue, double progress, String property, CSSRenderStyle renderStyle) {
   double value = oldLengthValue * (1 - progress) + newLengthValue * progress;
   renderStyle.target.setRenderStyleProperty(property, CSSLengthValue(value, CSSLengthType.PX));
 }
@@ -67,7 +67,7 @@ FontWeight _parseFontWeight(String fontWeight, RenderStyle renderStyle, String p
   return CSSText.resolveFontWeight(fontWeight);
 }
 
-void _updateFontWeight(FontWeight oldValue, FontWeight newValue, double progress, String property, RenderStyle renderStyle) {
+void _updateFontWeight(FontWeight oldValue, FontWeight newValue, double progress, String property, CSSRenderStyle renderStyle) {
   FontWeight? fontWeight = FontWeight.lerp(oldValue, newValue, progress);
   switch (property) {
     case FONT_WEIGHT:
@@ -96,7 +96,7 @@ double _parseLineHeight(String lineHeight, RenderStyle renderStyle, String prope
   return CSSLength.parseLength(lineHeight, renderStyle, LINE_HEIGHT).computedValue;
 }
 
-void _updateLineHeight(double oldValue, double newValue, double progress, String property, RenderStyle renderStyle) {
+void _updateLineHeight(double oldValue, double newValue, double progress, String property, CSSRenderStyle renderStyle) {
   renderStyle.lineHeight = CSSLengthValue(_getNumber(oldValue, newValue, progress), CSSLengthType.PX);
 }
 
@@ -104,7 +104,7 @@ Matrix4? _parseTransform(String value, RenderStyle renderStyle, String property)
   return CSSMatrix.computeTransformMatrix(CSSFunction.parseFunction(value), renderStyle);
 }
 
-void _updateTransform(Matrix4 begin, Matrix4 end, double t, String property, RenderStyle renderStyle) {
+void _updateTransform(Matrix4 begin, Matrix4 end, double t, String property, CSSRenderStyle renderStyle) {
   Matrix4 newMatrix4 = CSSMatrix.lerpMatrix(begin, end, t);
   renderStyle.transformMatrix = newMatrix4;
 }
@@ -179,7 +179,7 @@ enum CSSTransitionEvent {
   cancel,
 }
 
-mixin CSSTransitionMixin on RenderStyleBase {
+mixin CSSTransitionMixin on RenderStyle {
 
   // https://drafts.csswg.org/css-transitions/#transition-property-property
   // Name: transition-property

--- a/kraken/lib/src/css/transition.dart
+++ b/kraken/lib/src/css/transition.dart
@@ -179,7 +179,7 @@ enum CSSTransitionEvent {
   cancel,
 }
 
-mixin CSSTransitionMixin on RenderStyleBase {
+mixin CSSTransitionMixin on AbstractRenderStyle {
 
   // https://drafts.csswg.org/css-transitions/#transition-property-property
   // Name: transition-property
@@ -199,8 +199,9 @@ mixin CSSTransitionMixin on RenderStyleBase {
     // Any animation found in previousAnimations but not found in newAnimations is not longer current and should be canceled.
     // @HACK: There are no way to get animationList from styles(Webkit will create an new Style object when style changes, but Kraken not).
     // Therefore we should cancel all running transition to get thing works.
-    finishRunningTransiton();
+    finishRunningTransition();
   }
+  @override
   List<String> get transitionProperty => _transitionProperty ?? const [ALL];
 
   // https://drafts.csswg.org/css-transitions/#transition-duration-property
@@ -218,6 +219,7 @@ mixin CSSTransitionMixin on RenderStyleBase {
     _transitionDuration = value;
     _effectiveTransitions = null;
   }
+  @override
   List<String> get transitionDuration => _transitionDuration ?? const [_0s];
 
   // https://drafts.csswg.org/css-transitions/#transition-timing-function-property
@@ -235,6 +237,7 @@ mixin CSSTransitionMixin on RenderStyleBase {
     _transitionTimingFunction = value;
     _effectiveTransitions = null;
   }
+  @override
   List<String> get transitionTimingFunction => _transitionTimingFunction ?? const [EASE];
 
   // https://drafts.csswg.org/css-transitions/#transition-delay-property
@@ -252,6 +255,7 @@ mixin CSSTransitionMixin on RenderStyleBase {
     _transitionDelay = value;
     _effectiveTransitions = null;
   }
+  @override
   List<String> get transitionDelay => _transitionDelay ?? const [_0s];
 
   Map<String, List>? _effectiveTransitions;
@@ -299,6 +303,7 @@ mixin CSSTransitionMixin on RenderStyleBase {
     return _propertyRunningTransition.containsKey(property);
   }
 
+  @override
   String? removeAnimationProperty(String propertyName) {
     String? prevValue = EMPTY_STRING;
 
@@ -317,7 +322,7 @@ mixin CSSTransitionMixin on RenderStyleBase {
 
       // An Event fired when a CSS transition has been cancelled.
       target.dispatchEvent(Event(EVENT_TRANSITION_CANCEL));
-      
+
       // Maybe set transition twice in a same frame. should check animationProperties has contains propertyName.
       if (_animationProperties.containsKey(propertyName)) {
         begin = _animationProperties[propertyName];
@@ -337,7 +342,7 @@ mixin CSSTransitionMixin on RenderStyleBase {
       Keyframe(propertyName, begin, 0, LINEAR),
       Keyframe(propertyName, end, 1, LINEAR),
     ];
-    KeyframeEffect effect = KeyframeEffect(this as RenderStyle, target, keyframes, options);
+    KeyframeEffect effect = KeyframeEffect(this, target, keyframes, options);
     Animation animation = Animation(effect);
     _propertyRunningTransition[propertyName] = animation;
 
@@ -356,11 +361,11 @@ mixin CSSTransitionMixin on RenderStyleBase {
     };
 
     target.dispatchEvent(Event(EVENT_TRANSITION_RUN));
-    
+
     animation.play();
   }
 
-  void cancelRunningTransiton() {
+  void cancelRunningTransition() {
     if (_propertyRunningTransition.isNotEmpty) {
       for (String property in _propertyRunningTransition.keys) {
         _propertyRunningTransition[property]!.cancel();
@@ -369,7 +374,7 @@ mixin CSSTransitionMixin on RenderStyleBase {
     }
   }
 
-  void finishRunningTransiton() {
+  void finishRunningTransition() {
     if (_propertyRunningTransition.isNotEmpty) {
       for (String property in _propertyRunningTransition.keys) {
         _propertyRunningTransition[property]!.finish();

--- a/kraken/lib/src/css/values/length.dart
+++ b/kraken/lib/src/css/values/length.dart
@@ -65,7 +65,7 @@ class CSSLengthValue {
   // Length is applied in horizontal or vertical direction.
   Axis? axisType;
 
-  AbstractRenderStyle? renderStyle;
+  RenderStyleBase? renderStyle;
   String? propertyName;
   double? _computedValue;
 
@@ -121,7 +121,7 @@ class CSSLengthValue {
         bool isPositioned = positionType == CSSPositionType.absolute ||
           positionType == CSSPositionType.fixed;
 
-        AbstractRenderStyle? parentRenderStyle = renderStyle!.parent;
+        RenderStyleBase? parentRenderStyle = renderStyle!.parent;
 
         // Percentage relative width priority: logical width > renderer width
         double? relativeParentWidth = isPositioned ?
@@ -166,7 +166,7 @@ class CSSLengthValue {
             // There are two exceptions when percentage height is resolved against actual render height of parent:
             // 1. positioned element
             // 2. parent is flex item
-            AbstractRenderStyle? grandParentRenderStyle = parentRenderStyle?.parent;
+            RenderStyleBase? grandParentRenderStyle = parentRenderStyle?.parent;
             bool isGrandParentFlexLayout = grandParentRenderStyle?.display == CSSDisplay.flex ||
               grandParentRenderStyle?.display == CSSDisplay.inlineFlex;
 
@@ -220,7 +220,7 @@ class CSSLengthValue {
           case FLEX_BASIS:
             // Flex-basis computation is called in RenderFlexLayout which
             // will ensure parent exists.
-            AbstractRenderStyle parentRenderStyle = renderStyle!.parent!;
+            RenderStyleBase parentRenderStyle = renderStyle!.parent!;
             double? mainContentSize = parentRenderStyle.flexDirection == FlexDirection.row ?
               parentRenderStyle.contentBoxLogicalWidth :
               parentRenderStyle.contentBoxLogicalHeight;
@@ -416,7 +416,7 @@ class CSSLength {
     }
   }
 
-  static CSSLengthValue parseLength(String text, AbstractRenderStyle? renderStyle, [String? propertyName, Axis? axisType]) {
+  static CSSLengthValue parseLength(String text, RenderStyleBase? renderStyle, [String? propertyName, Axis? axisType]) {
     if (_cachedParsedLength.containsKey(text)) {
       return _cachedParsedLength[text]!;
     }

--- a/kraken/lib/src/css/values/length.dart
+++ b/kraken/lib/src/css/values/length.dart
@@ -65,7 +65,7 @@ class CSSLengthValue {
   // Length is applied in horizontal or vertical direction.
   Axis? axisType;
 
-  RenderStyleBase? renderStyle;
+  RenderStyle? renderStyle;
   String? propertyName;
   double? _computedValue;
 
@@ -121,7 +121,7 @@ class CSSLengthValue {
         bool isPositioned = positionType == CSSPositionType.absolute ||
           positionType == CSSPositionType.fixed;
 
-        RenderStyleBase? parentRenderStyle = renderStyle!.parent;
+        RenderStyle? parentRenderStyle = renderStyle!.parent;
 
         // Percentage relative width priority: logical width > renderer width
         double? relativeParentWidth = isPositioned ?
@@ -166,7 +166,7 @@ class CSSLengthValue {
             // There are two exceptions when percentage height is resolved against actual render height of parent:
             // 1. positioned element
             // 2. parent is flex item
-            RenderStyleBase? grandParentRenderStyle = parentRenderStyle?.parent;
+            RenderStyle? grandParentRenderStyle = parentRenderStyle?.parent;
             bool isGrandParentFlexLayout = grandParentRenderStyle?.display == CSSDisplay.flex ||
               grandParentRenderStyle?.display == CSSDisplay.inlineFlex;
 
@@ -220,7 +220,7 @@ class CSSLengthValue {
           case FLEX_BASIS:
             // Flex-basis computation is called in RenderFlexLayout which
             // will ensure parent exists.
-            RenderStyleBase parentRenderStyle = renderStyle!.parent!;
+            RenderStyle parentRenderStyle = renderStyle!.parent!;
             double? mainContentSize = parentRenderStyle.flexDirection == FlexDirection.row ?
               parentRenderStyle.contentBoxLogicalWidth :
               parentRenderStyle.contentBoxLogicalHeight;
@@ -416,7 +416,7 @@ class CSSLength {
     }
   }
 
-  static CSSLengthValue parseLength(String text, RenderStyleBase? renderStyle, [String? propertyName, Axis? axisType]) {
+  static CSSLengthValue parseLength(String text, RenderStyle? renderStyle, [String? propertyName, Axis? axisType]) {
     if (_cachedParsedLength.containsKey(text)) {
       return _cachedParsedLength[text]!;
     }

--- a/kraken/lib/src/css/values/length.dart
+++ b/kraken/lib/src/css/values/length.dart
@@ -65,7 +65,7 @@ class CSSLengthValue {
   // Length is applied in horizontal or vertical direction.
   Axis? axisType;
 
-  RenderStyle? renderStyle;
+  AbstractRenderStyle? renderStyle;
   String? propertyName;
   double? _computedValue;
 
@@ -121,7 +121,7 @@ class CSSLengthValue {
         bool isPositioned = positionType == CSSPositionType.absolute ||
           positionType == CSSPositionType.fixed;
 
-        RenderStyle? parentRenderStyle = renderStyle!.parent;
+        AbstractRenderStyle? parentRenderStyle = renderStyle!.parent;
 
         // Percentage relative width priority: logical width > renderer width
         double? relativeParentWidth = isPositioned ?
@@ -166,7 +166,7 @@ class CSSLengthValue {
             // There are two exceptions when percentage height is resolved against actual render height of parent:
             // 1. positioned element
             // 2. parent is flex item
-            RenderStyle? grandParentRenderStyle = parentRenderStyle?.parent;
+            AbstractRenderStyle? grandParentRenderStyle = parentRenderStyle?.parent;
             bool isGrandParentFlexLayout = grandParentRenderStyle?.display == CSSDisplay.flex ||
               grandParentRenderStyle?.display == CSSDisplay.inlineFlex;
 
@@ -220,7 +220,7 @@ class CSSLengthValue {
           case FLEX_BASIS:
             // Flex-basis computation is called in RenderFlexLayout which
             // will ensure parent exists.
-            RenderStyle parentRenderStyle = renderStyle!.parent!;
+            AbstractRenderStyle parentRenderStyle = renderStyle!.parent!;
             double? mainContentSize = parentRenderStyle.flexDirection == FlexDirection.row ?
               parentRenderStyle.contentBoxLogicalWidth :
               parentRenderStyle.contentBoxLogicalHeight;
@@ -416,7 +416,7 @@ class CSSLength {
     }
   }
 
-  static CSSLengthValue parseLength(String text, RenderStyle? renderStyle, [String? propertyName, Axis? axisType]) {
+  static CSSLengthValue parseLength(String text, AbstractRenderStyle? renderStyle, [String? propertyName, Axis? axisType]) {
     if (_cachedParsedLength.containsKey(text)) {
       return _cachedParsedLength[text]!;
     }

--- a/kraken/lib/src/css/visibility.dart
+++ b/kraken/lib/src/css/visibility.dart
@@ -15,7 +15,7 @@ mixin CSSVisibilityMixin on AbstractRenderStyle {
   void set visibility(Visibility value) {
     if (_visibility == value) return;
     _visibility = value;
-    renderBoxModel!.markNeedsPaint();
+    renderBoxModel?.markNeedsPaint();
   }
 
   @override

--- a/kraken/lib/src/css/visibility.dart
+++ b/kraken/lib/src/css/visibility.dart
@@ -9,7 +9,7 @@ enum Visibility {
   hidden,
 }
 
-mixin CSSVisibilityMixin on RenderStyleBase {
+mixin CSSVisibilityMixin on RenderStyle {
   Visibility _visibility = Visibility.visible;
 
   void set visibility(Visibility value) {

--- a/kraken/lib/src/css/visibility.dart
+++ b/kraken/lib/src/css/visibility.dart
@@ -9,7 +9,7 @@ enum Visibility {
   hidden,
 }
 
-mixin CSSVisibilityMixin on AbstractRenderStyle {
+mixin CSSVisibilityMixin on RenderStyleBase {
   Visibility _visibility = Visibility.visible;
 
   void set visibility(Visibility value) {

--- a/kraken/lib/src/css/visibility.dart
+++ b/kraken/lib/src/css/visibility.dart
@@ -9,7 +9,7 @@ enum Visibility {
   hidden,
 }
 
-mixin CSSVisibilityMixin on RenderStyleBase {
+mixin CSSVisibilityMixin on AbstractRenderStyle {
   Visibility _visibility = Visibility.visible;
 
   void set visibility(Visibility value) {
@@ -18,6 +18,7 @@ mixin CSSVisibilityMixin on RenderStyleBase {
     renderBoxModel!.markNeedsPaint();
   }
 
+  @override
   Visibility get visibility => _visibility;
 
   bool get isVisibilityHidden {

--- a/kraken/lib/src/dom/element.dart
+++ b/kraken/lib/src/dom/element.dart
@@ -408,7 +408,7 @@ class Element extends Node
   @override
   void willDetachRenderer() {
     // Cancel running transition.
-    renderStyle.cancelRunningTransiton();
+    renderStyle.cancelRunningTransition();
     // Remove all intersection change listeners.
     renderBoxModel!.clearIntersectionChangeListeners();
 

--- a/kraken/lib/src/dom/element.dart
+++ b/kraken/lib/src/dom/element.dart
@@ -67,7 +67,7 @@ mixin ElementBase on Node {
     }
   }
 
-  late RenderStyle renderStyle;
+  late CSSRenderStyle renderStyle;
 }
 
 typedef BeforeRendererAttach = RenderObject Function();
@@ -160,7 +160,7 @@ class Element extends Node
     style = CSSStyleDeclaration.computedStyle(this, _defaultStyle, _onStyleChanged);
 
     // Init render style.
-    renderStyle = RenderStyle(target: this);
+    renderStyle = CSSRenderStyle(target: this);
   }
 
   @override
@@ -250,7 +250,7 @@ class Element extends Node
   // Create renderLayoutBox if type changed and copy children if there has previous renderLayoutBox.
   RenderLayoutBox _createRenderLayout({
       RenderLayoutBox? previousRenderLayoutBox,
-      RenderStyle? renderStyle,
+      CSSRenderStyle? renderStyle,
       bool isRepaintBoundary = false
   }) {
     renderStyle = renderStyle ?? this.renderStyle;
@@ -1347,8 +1347,7 @@ class Element extends Node
   }
 
   void _updateColorRelativePropertyWithColor(Element element) {
-    RenderStyle renderStyle = element.renderStyle;
-    renderStyle.updateColorRelativeProperty();
+    element.renderStyle.updateColorRelativeProperty();
     if (element.children.isNotEmpty) {
       element.children.forEach((Element child) {
         if (!child.renderStyle.hasColor) {
@@ -1369,8 +1368,7 @@ class Element extends Node
   }
 
   void _updateChildrenFontRelativeLength(Element element) {
-    RenderStyle renderStyle = element.renderStyle;
-    renderStyle.updateFontRelativeLength();
+    element.renderStyle.updateFontRelativeLength();
     if (element.children.isNotEmpty) {
       element.children.forEach((Element child) {
         if (!child.renderStyle.hasFontSize) {
@@ -1381,8 +1379,7 @@ class Element extends Node
   }
 
   void _updateChildrenRootFontRelativeLength(Element element) {
-    RenderStyle renderStyle = element.renderStyle;
-    renderStyle.updateRootFontRelativeLength();
+    element.renderStyle.updateRootFontRelativeLength();
     if (element.children.isNotEmpty) {
       element.children.forEach((Element child) {
         _updateChildrenRootFontRelativeLength(child);
@@ -1669,7 +1666,7 @@ class Element extends Node
   // Create a new RenderLayoutBox for the scrolling content.
   RenderLayoutBox createScrollingContentLayout() {
     // FIXME: Create an empty renderStyle for do not share renderStyle with element.
-    RenderStyle scrollingContentRenderStyle = RenderStyle(target: this);
+    CSSRenderStyle scrollingContentRenderStyle = CSSRenderStyle(target: this);
     // Scrolling content layout need to be share the same display with its outer layout box.
     scrollingContentRenderStyle.display = renderStyle.display;
     RenderLayoutBox scrollingContentLayoutBox = _createRenderLayout(

--- a/kraken/lib/src/dom/elements/body.dart
+++ b/kraken/lib/src/dom/elements/body.dart
@@ -22,8 +22,7 @@ class BodyElement extends Element {
   @override
   void willAttachRenderer() {
     super.willAttachRenderer();
-    RenderStyle renderStyle = renderBoxModel!.renderStyle;
-    renderStyle.width = CSSLengthValue(elementManager.viewportWidth, CSSLengthType.PX);
+    renderBoxModel!.renderStyle.width = CSSLengthValue(elementManager.viewportWidth, CSSLengthType.PX);
   }
 
   @override

--- a/kraken/lib/src/dom/elements/input.dart
+++ b/kraken/lib/src/dom/elements/input.dart
@@ -364,7 +364,7 @@ class InputElement extends Element implements TextInputClient, TickerProvider {
   void _onStyleChanged(String property, String? original, String present) {
 
     if (_renderInputLeaderLayer != null && isRendererAttached) {
-      RenderStyle renderStyle = renderBoxModel!.renderStyle;
+      CSSRenderStyle renderStyle = renderBoxModel!.renderStyle;
       if (property == HEIGHT) {
         _renderInputLeaderLayer!.markNeedsLayout();
 

--- a/kraken/lib/src/rendering/box_decoration_painter.dart
+++ b/kraken/lib/src/rendering/box_decoration_painter.dart
@@ -25,10 +25,8 @@ class BoxDecorationPainter extends BoxPainter {
     : super(onChanged);
 
   EdgeInsets? padding;
-  RenderStyle renderStyle;
-  CSSBoxDecoration get _decoration {
-    return renderStyle.decoration!;
-  }
+  CSSRenderStyle renderStyle;
+  CSSBoxDecoration get _decoration => renderStyle.decoration!;
 
   Paint? _cachedBackgroundPaint;
   Rect? _rectForCachedBackgroundPaint;
@@ -480,7 +478,7 @@ class BoxDecorationImagePainter {
     this._onChanged
   );
 
-  final RenderStyle _renderStyle;
+  final CSSRenderStyle _renderStyle;
   final DecorationImage _details;
   CSSBackgroundPosition get _backgroundPositionX {
     return _renderStyle.backgroundPositionX;

--- a/kraken/lib/src/rendering/box_model.dart
+++ b/kraken/lib/src/rendering/box_model.dart
@@ -155,11 +155,7 @@ class RenderLayoutBox extends RenderBoxModel
     ContainerBoxParentData<RenderBox>>,
     RenderBoxContainerDefaultsMixin<RenderBox,
     ContainerBoxParentData<RenderBox>> {
-  RenderLayoutBox({
-    required RenderStyle renderStyle,
-  }) : super(
-    renderStyle: renderStyle,
-  );
+  RenderLayoutBox({required CSSRenderStyle renderStyle}) : super(renderStyle: renderStyle);
 
   // Host content which can be scrolled.
   RenderLayoutBox? get renderScrollingContent {
@@ -559,7 +555,7 @@ class RenderLayoutBox extends RenderBoxModel
 }
 
 mixin RenderBoxModelBase on RenderBox {
-  late RenderStyle renderStyle;
+  late CSSRenderStyle renderStyle;
   Size? boxSize;
 }
 
@@ -586,7 +582,7 @@ class RenderBoxModel extends RenderBox
   bool _debugShouldPaintOverlay = false;
 
   @override
-  late RenderStyle renderStyle;
+  late CSSRenderStyle renderStyle;
 
   bool get debugShouldPaintOverlay => _debugShouldPaintOverlay;
 
@@ -1324,7 +1320,7 @@ class RenderBoxModel extends RenderBox
     return null;
   }
 
-  bool _hasLocalBackgroundImage(RenderStyle renderStyle) {
+  bool _hasLocalBackgroundImage(CSSRenderStyle renderStyle) {
     return renderStyle.backgroundImage != null &&
         renderStyle.backgroundAttachment == CSSBackgroundAttachmentType.local;
   }

--- a/kraken/lib/src/rendering/box_model.dart
+++ b/kraken/lib/src/rendering/box_model.dart
@@ -895,8 +895,8 @@ class RenderBoxModel extends RenderBox
     double? maxHeight = renderStyle.maxHeight.isNone ? null : renderStyle.maxHeight.computedValue;
 
     // Content size calculated from style
-    logicalContentWidth = renderStyle.getLogicalContentWidth();
-    logicalContentHeight = renderStyle.getLogicalContentHeight();
+    logicalContentWidth = renderStyle.logicalContentWidth;
+    logicalContentHeight = renderStyle.logicalContentHeight;
 
     // Box size calculated from style
     double? logicalWidth = logicalContentWidth != null
@@ -1041,8 +1041,8 @@ class RenderBoxModel extends RenderBox
     // Deflate padding constraints.
     boxConstraints = renderStyle.deflatePaddingConstraints(boxConstraints);
 
-    logicalContentWidth = renderStyle.getLogicalContentWidth();
-    logicalContentHeight = renderStyle.getLogicalContentHeight();
+    logicalContentWidth = renderStyle.logicalContentWidth;
+    logicalContentHeight = renderStyle.logicalContentHeight;
 
     if (!isScrollingContentBox && (logicalContentWidth != null || logicalContentHeight != null)) {
       double minWidth;

--- a/kraken/lib/src/rendering/flex.dart
+++ b/kraken/lib/src/rendering/flex.dart
@@ -158,10 +158,8 @@ class RenderFlexLayout extends RenderLayoutBox {
   /// start of the main axis and the center of the cross axis.
   RenderFlexLayout({
     List<RenderBox>? children,
-    required RenderStyle renderStyle,
-  }) : super(
-    renderStyle: renderStyle,
-  ) {
+    required CSSRenderStyle renderStyle,
+  }) : super(renderStyle: renderStyle) {
     addAll(children);
   }
 
@@ -2461,7 +2459,7 @@ class RenderFlexLayout extends RenderLayoutBox {
 class RenderRepaintBoundaryFlexLayout extends RenderFlexLayout {
   RenderRepaintBoundaryFlexLayout({
     List<RenderBox>? children,
-    required RenderStyle renderStyle,
+    required CSSRenderStyle renderStyle,
   }) : super(
     children: children,
     renderStyle: renderStyle,

--- a/kraken/lib/src/rendering/flow.dart
+++ b/kraken/lib/src/rendering/flow.dart
@@ -37,10 +37,8 @@ class _RunMetrics {
 class RenderFlowLayout extends RenderLayoutBox {
   RenderFlowLayout({
     List<RenderBox>? children,
-    required RenderStyle renderStyle,
-  }) : super(
-    renderStyle: renderStyle,
-  ) {
+    required CSSRenderStyle renderStyle,
+  }) : super(renderStyle: renderStyle) {
     addAll(children);
   }
 
@@ -1589,7 +1587,7 @@ class RenderFlowLayout extends RenderLayoutBox {
 class RenderRepaintBoundaryFlowLayout extends RenderFlowLayout {
   RenderRepaintBoundaryFlowLayout({
     List<RenderBox>? children,
-    required RenderStyle renderStyle,
+    required CSSRenderStyle renderStyle,
   }) : super(
     children: children,
     renderStyle: renderStyle,

--- a/kraken/lib/src/rendering/intrinsic.dart
+++ b/kraken/lib/src/rendering/intrinsic.dart
@@ -12,11 +12,7 @@ import 'package:kraken/rendering.dart';
 
 class RenderIntrinsic extends RenderBoxModel
     with RenderObjectWithChildMixin<RenderBox>, RenderProxyBoxMixin<RenderBox> {
-  RenderIntrinsic(
-      RenderStyle renderStyle,
-  ) : super(
-      renderStyle: renderStyle,
-  );
+  RenderIntrinsic(CSSRenderStyle renderStyle) : super(renderStyle: renderStyle);
 
   @override
   BoxSizeType get widthSizeType {
@@ -222,11 +218,7 @@ class RenderIntrinsic extends RenderBoxModel
 }
 
 class RenderRepaintBoundaryIntrinsic extends RenderIntrinsic {
-  RenderRepaintBoundaryIntrinsic(
-    RenderStyle renderStyle,
-  ) : super(
-    renderStyle,
-  );
+  RenderRepaintBoundaryIntrinsic(CSSRenderStyle renderStyle) : super(renderStyle);
 
   @override
   bool get isRepaintBoundary => true;

--- a/kraken/lib/src/rendering/sliver_list.dart
+++ b/kraken/lib/src/rendering/sliver_list.dart
@@ -36,7 +36,7 @@ class RenderSliverListLayout extends RenderLayoutBox {
   final RenderSliverBoxChildManager _renderSliverBoxChildManager;
 
   RenderSliverListLayout({
-    required RenderStyle renderStyle,
+    required CSSRenderStyle renderStyle,
     required RenderSliverElementChildManager manager,
     ScrollListener? onScroll,
   }) : _renderSliverBoxChildManager = manager,

--- a/kraken/lib/src/rendering/text.dart
+++ b/kraken/lib/src/rendering/text.dart
@@ -27,7 +27,7 @@ class RenderTextBox extends RenderBox
 
   late String data;
   late KrakenRenderParagraph _renderParagraph;
-  RenderStyle renderStyle;
+  CSSRenderStyle renderStyle;
 
   BoxSizeType? widthSizeType;
   BoxSizeType? heightSizeType;


### PR DESCRIPTION
See comment below: https://github.com/openkraken/kraken/pull/915#pullrequestreview-818509081

Remove code like `(this as RenderStyle).xxxx`, declare the getter interface for RenderStyle.
Using `renderBoxModel?.markNeedsXxxx` instead of `renderBoxModel!.op`, for which may be null.