### PR TITLE
feat: remove intersectionObserver Event

### DIFF
--- a/bridge/CMakeLists.txt
+++ b/bridge/CMakeLists.txt
@@ -237,8 +237,6 @@ if ($ENV{KRAKEN_JS_ENGINE} MATCHES "quickjs")
     bindings/qjs/dom/events/.gen/input_event.h
     bindings/qjs/dom/events/.gen/popstate_event.cc
     bindings/qjs/dom/events/.gen/popstate_event.h
-    bindings/qjs/dom/events/.gen/intersection_change.cc
-    bindings/qjs/dom/events/.gen/intersection_change.h
     bindings/qjs/dom/events/.gen/media_error_event.cc
     bindings/qjs/dom/events/.gen/media_error_event.h
     bindings/qjs/dom/events/.gen/mouse_event.cc

--- a/bridge/bindings/qjs/dom/document.cc
+++ b/bridge/bindings/qjs/dom/document.cc
@@ -25,7 +25,6 @@
 #include "events/.gen/close_event.h"
 #include "events/.gen/gesture_event.h"
 #include "events/.gen/input_event.h"
-#include "events/.gen/intersection_change.h"
 #include "events/.gen/media_error_event.h"
 #include "events/.gen/message_event.h"
 #include "events/.gen/mouse_event.h"
@@ -89,9 +88,6 @@ Document::Document(JSContext* context) : Node(context, "Document") {
                        [](JSContext* context, void* nativeEvent) -> EventInstance* { return new MessageEventInstance(MessageEvent::instance(context), reinterpret_cast<NativeEvent*>(nativeEvent)); });
     Event::defineEvent(EVENT_CLOSE,
                        [](JSContext* context, void* nativeEvent) -> EventInstance* { return new CloseEventInstance(CloseEvent::instance(context), reinterpret_cast<NativeEvent*>(nativeEvent)); });
-    Event::defineEvent(EVENT_INTERSECTION_CHANGE, [](JSContext* context, void* nativeEvent) -> EventInstance* {
-      return new IntersectionChangeEventInstance(IntersectionChangeEvent::instance(context), reinterpret_cast<NativeEvent*>(nativeEvent));
-    });
     Event::defineEvent(EVENT_TOUCH_START,
                        [](JSContext* context, void* nativeEvent) -> EventInstance* { return new TouchEventInstance(TouchEvent::instance(context), reinterpret_cast<NativeEvent*>(nativeEvent)); });
     Event::defineEvent(EVENT_TOUCH_END,

--- a/bridge/bindings/qjs/dom/events/intersection_change.d.ts
+++ b/bridge/bindings/qjs/dom/events/intersection_change.d.ts
@@ -1,5 +1,0 @@
-interface Event {}
-
-interface IntersectionChangeEvent extends Event {
-  readonly intersectionRatio: number;
-}

--- a/bridge/bridge_qjs.cc
+++ b/bridge/bridge_qjs.cc
@@ -33,7 +33,6 @@
 #include "bindings/qjs/dom/events/.gen/close_event.h"
 #include "bindings/qjs/dom/events/.gen/gesture_event.h"
 #include "bindings/qjs/dom/events/.gen/input_event.h"
-#include "bindings/qjs/dom/events/.gen/intersection_change.h"
 #include "bindings/qjs/dom/events/.gen/media_error_event.h"
 #include "bindings/qjs/dom/events/.gen/message_event.h"
 #include "bindings/qjs/dom/events/.gen/mouse_event.h"
@@ -91,7 +90,6 @@ JSBridge::JSBridge(int32_t contextId, const JSExceptionHandler& handler) : conte
   bindCloseEvent(m_context);
   bindGestureEvent(m_context);
   bindInputEvent(m_context);
-  bindIntersectionChangeEvent(m_context);
   bindMediaErrorEvent(m_context);
   bindMouseEvent(m_context);
   bindMessageEvent(m_context);

--- a/kraken/lib/src/dom/event.dart
+++ b/kraken/lib/src/dom/event.dart
@@ -428,24 +428,6 @@ class CloseEvent extends Event {
   }
 }
 
-class IntersectionChangeEvent extends Event {
-  IntersectionChangeEvent(this.intersectionRatio) : super(EVENT_INTERSECTION_CHANGE);
-  final double intersectionRatio;
-
-  @override
-  Pointer<RawNativeIntersectionChangeEvent> toRaw([int methodLength = 0]) {
-    List<int> methods = [
-      doubleToUint64(intersectionRatio)
-    ];
-
-    Pointer<RawNativeIntersectionChangeEvent> rawEvent = super.toRaw(methods.length).cast<RawNativeIntersectionChangeEvent>();
-    Uint64List bytes = rawEvent.ref.bytes.asTypedList((rawEvent.ref.length + methods.length));
-    bytes.setAll(rawEvent.ref.length, methods);
-
-    return rawEvent;
-  }
-}
-
 /// reference: https://w3c.github.io/touch-events/#touchevent-interface
 class TouchEvent extends Event {
   TouchEvent(String type) : super(type, EventInit(bubbles: true, cancelable: true));

--- a/kraken/lib/src/dom/event_handler.dart
+++ b/kraken/lib/src/dom/event_handler.dart
@@ -78,7 +78,6 @@ mixin ElementEventMixin on EventTarget {
   }
 
   void handleIntersectionChange(IntersectionObserverEntry entry) {
-    dispatchEvent(IntersectionChangeEvent(entry.intersectionRatio));
     if (entry.intersectionRatio > 0) {
       handleAppear();
     } else {


### PR DESCRIPTION
IntersectionChangeEvent 属于非标准 API，并且用户在绑定了 appear 或者 disappear 之后，都会频繁触发，会影响一定的性能。

在已经有了 appear & disappear 的前提下，没有必要有这个 API