### PR TITLE
Fix: should pending dispatchEvent when GC is running.

### DIFF
--- a/bridge/bindings/qjs/dom/event_target.cc
+++ b/bridge/bindings/qjs/dom/event_target.cc
@@ -485,6 +485,33 @@ void EventTargetInstance::copyNodeProperties(EventTargetInstance* newNode, Event
 void NativeEventTarget::dispatchEventImpl(NativeEventTarget* nativeEventTarget, NativeString* nativeEventType, void* rawEvent, int32_t isCustomEvent) {
   assert_m(nativeEventTarget->instance != nullptr, "NativeEventTarget should have owner");
   EventTargetInstance* eventTargetInstance = nativeEventTarget->instance;
+
+  auto *runtime = getGlobalJSRuntime();
+  // We should avoid trigger event if eventTarget are no long live on heap.
+  if (!JS_IsLiveObject(runtime, eventTargetInstance->instanceObject)) {
+    return;
+  }
+
+  // It's no safe to allocate new js object at GC phase. We should waiting for GC to finish his tasks and resume all pending callbacks.
+  JSGCPhaseEnum gcPhase = JS_GetGCPhase(runtime);
+  if (gcPhase != JSGCPhaseEnum::JS_GC_PHASE_NONE) {
+#if FLUTTER_BACKEND
+    // We store all params and data into pendingEvents and dispatch them in the next frame.Nativ
+    auto *newPendingEvents = new PendingEvent{
+      nativeEventTarget,
+      nativeEventType->clone(), /* nativeEventType will be freed by dart after dispatchEventImpl() called., Should keep an clone instead of a ptr. */
+      rawEvent,
+      isCustomEvent
+    };
+    getDartMethod()->scheduleMicrotask(newPendingEvents, [](void *ptr) {
+      auto *pendingEvent = static_cast<PendingEvent*>(ptr);
+      NativeEventTarget::dispatchEventImpl(pendingEvent->nativeEventTarget, pendingEvent->nativeEventType, pendingEvent->rawEvent, pendingEvent->isCustomEvent);
+      delete pendingEvent;
+    });
+#endif
+    return;
+  }
+
   JSContext* context = eventTargetInstance->context();
   std::u16string u16EventType = std::u16string(reinterpret_cast<const char16_t*>(nativeEventType->string), nativeEventType->length);
   std::string eventType = toUTF8(u16EventType);

--- a/bridge/bindings/qjs/dom/event_target.cc
+++ b/bridge/bindings/qjs/dom/event_target.cc
@@ -149,7 +149,7 @@ JSValue EventTarget::removeEventListener(QjsContext* ctx, JSValue this_val, int 
 
 JSValue EventTarget::dispatchEvent(QjsContext* ctx, JSValue this_val, int argc, JSValue* argv) {
   if (argc != 1) {
-    return JS_ThrowTypeError(ctx, "Failed to TEST_dispatchEvent: first arguments should be an event object");
+    return JS_ThrowTypeError(ctx, "Failed to dispatchEvent: first arguments should be an event object");
   }
 
   auto* eventTargetInstance = static_cast<EventTargetInstance*>(JS_GetOpaque(this_val, EventTarget::classId(this_val)));

--- a/bridge/bindings/qjs/dom/event_target.h
+++ b/bridge/bindings/qjs/dom/event_target.h
@@ -52,7 +52,7 @@ class EventTarget : public HostClass {
 
   ObjectFunction m_addEventListener{m_context, m_prototypeObject, "addEventListener", addEventListener, 3};
   ObjectFunction m_removeEventListener{m_context, m_prototypeObject, "removeEventListener", removeEventListener, 2};
-  ObjectFunction m_dispatchEvent{m_context, m_prototypeObject, "TEST_dispatchEvent", dispatchEvent, 1};
+  ObjectFunction m_dispatchEvent{m_context, m_prototypeObject, "dispatchEvent", dispatchEvent, 1};
 #if IS_TEST
   ObjectFunction m_kraken_clear_event_listener_{m_context, m_prototypeObject, "__kraken_clear_event_listeners__", __kraken_clear_event_listener, 0};
 #endif

--- a/bridge/bindings/qjs/dom/event_target.h
+++ b/bridge/bindings/qjs/dom/event_target.h
@@ -20,6 +20,13 @@ class NativeEventTarget;
 class CSSStyleDeclaration;
 class StyleDeclarationInstance;
 
+struct PendingEvent {
+  NativeEventTarget* nativeEventTarget;
+  NativeString* nativeEventType;
+  void* rawEvent;
+  int32_t isCustomEvent;
+};
+
 void bindEventTarget(std::unique_ptr<JSContext>& context);
 
 class EventTarget : public HostClass {
@@ -63,6 +70,7 @@ struct NativeEventTarget {
   EventTargetInstance* instance{nullptr};
   NativeDispatchEvent dispatchEvent{nullptr};
   CallNativeMethods callNativeMethods{nullptr};
+  friend EventTargetInstance;
 };
 
 class EventTargetInstance : public Instance {
@@ -104,6 +112,7 @@ class EventTargetInstance : public Instance {
   static void finalize(JSRuntime* rt, JSValue val);
   friend EventTarget;
   friend StyleDeclarationInstance;
+  friend NativeEventTarget;
 };
 
 }  // namespace kraken::binding::qjs

--- a/bridge/bindings/qjs/dom/event_target.h
+++ b/bridge/bindings/qjs/dom/event_target.h
@@ -52,7 +52,7 @@ class EventTarget : public HostClass {
 
   ObjectFunction m_addEventListener{m_context, m_prototypeObject, "addEventListener", addEventListener, 3};
   ObjectFunction m_removeEventListener{m_context, m_prototypeObject, "removeEventListener", removeEventListener, 2};
-  ObjectFunction m_dispatchEvent{m_context, m_prototypeObject, "dispatchEvent", dispatchEvent, 1};
+  ObjectFunction m_dispatchEvent{m_context, m_prototypeObject, "TEST_dispatchEvent", dispatchEvent, 1};
 #if IS_TEST
   ObjectFunction m_kraken_clear_event_listener_{m_context, m_prototypeObject, "__kraken_clear_event_listeners__", __kraken_clear_event_listener, 0};
 #endif

--- a/bridge/bindings/qjs/dom/event_target_test.cc
+++ b/bridge/bindings/qjs/dom/event_target_test.cc
@@ -137,12 +137,12 @@ let div = document.createElement('div');
 
   static auto *window = static_cast<WindowInstance*>(JS_GetOpaque(context->global(), 1));
 
-  registerEventTargetDisposedCallback(context->uniqueId, [](EventTargetInstance *eventTargetInstance) {
+  TEST_registerEventTargetDisposedCallback(context->uniqueId, [](EventTargetInstance* eventTargetInstance) {
     // Check to not crash when trigger click on disposed eventTarget
-    dispatchEvent(eventTargetInstance, "click");
+    TEST_dispatchEvent(eventTargetInstance, "click");
 
     // Check to not crash when trigger event on any eventTarget.
-    dispatchEvent(window, "click");
+    TEST_dispatchEvent(window, "click");
   });
 
   // Run gc to trigger eventTarget been disposed by GC.

--- a/bridge/bindings/qjs/qjs_patch.cc
+++ b/bridge/bindings/qjs/qjs_patch.cc
@@ -8,12 +8,6 @@
 #include <quickjs/list.h>
 #include <cstring>
 
-typedef enum {
-  JS_GC_PHASE_NONE,
-  JS_GC_PHASE_DECREF,
-  JS_GC_PHASE_REMOVE_CYCLES,
-} JSGCPhaseEnum;
-
 typedef struct JSProxyData {
   JSValue target;
   JSValue handler;
@@ -313,4 +307,8 @@ bool JS_IsProxy(JSValue value) {
 JSValue JS_GetProxyTarget(JSValue value) {
   JSObject* p = JS_VALUE_GET_OBJ(value);
   return p->u.proxy_data->target;
+}
+
+JSGCPhaseEnum JS_GetGCPhase(JSRuntime* runtime) {
+  return runtime->gc_phase;
 }

--- a/bridge/bindings/qjs/qjs_patch.h
+++ b/bridge/bindings/qjs/qjs_patch.h
@@ -9,6 +9,12 @@
 #include <quickjs/list.h>
 #include <quickjs/quickjs.h>
 
+typedef enum {
+  JS_GC_PHASE_NONE,
+  JS_GC_PHASE_DECREF,
+  JS_GC_PHASE_REMOVE_CYCLES,
+} JSGCPhaseEnum;
+
 struct JSString {
   JSRefCountHeader header; /* must come first, 32-bit */
   uint32_t len : 31;
@@ -104,6 +110,7 @@ JSValue JS_NewUnicodeString(JSRuntime* runtime, JSContext* ctx, const uint16_t* 
 JSClassID JSValueGetClassId(JSValue);
 bool JS_IsProxy(JSValue value);
 JSValue JS_GetProxyTarget(JSValue value);
+JSGCPhaseEnum JS_GetGCPhase(JSRuntime* runtime);
 
 #ifdef __cplusplus
 }

--- a/bridge/dart_methods.cc
+++ b/bridge/dart_methods.cc
@@ -36,6 +36,7 @@ void registerDartMethods(uint64_t* methodBytes, int32_t length) {
   methodPointer->setTimeout = reinterpret_cast<SetTimeout>(methodBytes[i++]);
   methodPointer->setInterval = reinterpret_cast<SetInterval>(methodBytes[i++]);
   methodPointer->clearTimeout = reinterpret_cast<ClearTimeout>(methodBytes[i++]);
+  methodPointer->scheduleMicrotask = reinterpret_cast<ScheduleMicrotask>(methodBytes[i++]);
   methodPointer->requestAnimationFrame = reinterpret_cast<RequestAnimationFrame>(methodBytes[i++]);
   methodPointer->cancelAnimationFrame = reinterpret_cast<CancelAnimationFrame>(methodBytes[i++]);
   methodPointer->getScreen = reinterpret_cast<GetScreen>(methodBytes[i++]);

--- a/bridge/include/dart_methods.h
+++ b/bridge/include/dart_methods.h
@@ -20,6 +20,7 @@ using AsyncCallback = void (*)(void* callbackContext, int32_t contextId, const c
 using AsyncRAFCallback = void (*)(void* callbackContext, int32_t contextId, double result, const char* errmsg);
 using AsyncModuleCallback = void (*)(void* callbackContext, int32_t contextId, NativeString* errmsg, NativeString* json);
 using AsyncBlobCallback = void (*)(void* callbackContext, int32_t contextId, const char* error, uint8_t* bytes, int32_t length);
+using AsyncMicrotaskCallback = void (*)(void *callbackContext);
 typedef NativeString* (*InvokeModule)(void* callbackContext, int32_t contextId, NativeString* moduleName, NativeString* method, NativeString* params, AsyncModuleCallback callback);
 typedef void (*RequestBatchUpdate)(int32_t contextId);
 typedef void (*ReloadApp)(int32_t contextId);
@@ -27,6 +28,7 @@ typedef int32_t (*SetTimeout)(void* callbackContext, int32_t contextId, AsyncCal
 typedef int32_t (*SetInterval)(void* callbackContext, int32_t contextId, AsyncCallback callback, int32_t timeout);
 typedef int32_t (*RequestAnimationFrame)(void* callbackContext, int32_t contextId, AsyncRAFCallback callback);
 typedef void (*ClearTimeout)(int32_t contextId, int32_t timerId);
+typedef void (*ScheduleMicrotask)(void *callbackContext, AsyncMicrotaskCallback callback);
 typedef void (*CancelAnimationFrame)(int32_t contextId, int32_t id);
 typedef NativeScreen* (*GetScreen)(int32_t contextId);
 typedef double (*DevicePixelRatio)(int32_t contextId);
@@ -68,6 +70,7 @@ struct DartMethodPointer {
   SetTimeout setTimeout{nullptr};
   SetInterval setInterval{nullptr};
   ClearTimeout clearTimeout{nullptr};
+  ScheduleMicrotask scheduleMicrotask{nullptr};
   RequestAnimationFrame requestAnimationFrame{nullptr};
   CancelAnimationFrame cancelAnimationFrame{nullptr};
   GetScreen getScreen{nullptr};

--- a/bridge/test/test.cmake
+++ b/bridge/test/test.cmake
@@ -19,6 +19,8 @@ elseif($ENV{KRAKEN_JS_ENGINE} MATCHES "quickjs")
     bridge_test_qjs.h
   )
   list(APPEND KRAKEN_UNIT_TEST_SOURCE
+    ./test/unit_test_util.cc
+    ./test/unit_test_util.h
     ./bindings/qjs/js_context_test.cc
     ./bindings/qjs/bom/console_test.cc
     ./bindings/qjs/qjs_patch_test.cc
@@ -36,13 +38,14 @@ elseif($ENV{KRAKEN_JS_ENGINE} MATCHES "quickjs")
 
   ### kraken_unit_test executable
   add_executable(kraken_unit_test ${KRAKEN_UNIT_TEST_SOURCE} ${KRAKEN_TEST_SOURCE} ${BRIDGE_SOURCE} ../bindings/qjs/html_parser.cc ../bindings/qjs/html_parser.h ../bindings/qjs/module_manager_test.cc)
-  target_include_directories(kraken_unit_test PUBLIC ./third_party/googletest/googletest/include ${BRIDGE_INCLUDE})
+  target_include_directories(kraken_unit_test PUBLIC ./third_party/googletest/googletest/include ${BRIDGE_INCLUDE} ./test)
   target_link_libraries(kraken_unit_test gtest gtest_main ${BRIDGE_LINK_LIBS})
 
   target_compile_options(quickjs PUBLIC -DDUMP_LEAKS=1)
   target_compile_options(kraken PUBLIC -DDUMP_LEAKS=1)
 
   target_compile_definitions(kraken_unit_test PUBLIC -DFLUTTER_BACKEND=0)
+  target_compile_definitions(kraken_unit_test PUBLIC -DUNIT_TEST_ENV=1)
   target_compile_definitions(kraken_static PUBLIC -DFLUTTER_BACKEND=1)
   if (DEFINED ENV{LIBRARY_OUTPUT_DIR})
     set_target_properties(kraken_unit_test

--- a/bridge/test/unit_test_util.cc
+++ b/bridge/test/unit_test_util.cc
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2021 Alibaba Inc. All rights reserved.
+ * Author: Kraken Team.
+ */
+
+#include "unit_test_util.h"
+#include "bindings/qjs/js_context.h"
+#include "include/kraken_bridge.h"
+
+std::unordered_map<int32_t, std::shared_ptr<UnitTestEnv>> unitTestEnvMap;
+std::shared_ptr<UnitTestEnv> getUnitTestEnv(int32_t contextUniqueId) {
+  if (unitTestEnvMap.count(contextUniqueId) == 0) {
+    unitTestEnvMap[contextUniqueId] = std::make_shared<UnitTestEnv>();
+  }
+
+  return  unitTestEnvMap[contextUniqueId];
+}
+
+void registerEventTargetDisposedCallback(int32_t contextUniqueId, OnEventTargetDisposed callback) {
+  if (unitTestEnvMap.count(contextUniqueId) == 0) {
+    unitTestEnvMap[contextUniqueId] = std::make_shared<UnitTestEnv>();
+  }
+
+  unitTestEnvMap[contextUniqueId]->onEventTargetDisposed = callback;
+}
+
+void dispatchEvent(kraken::binding::qjs::EventTargetInstance* eventTarget, std::string event) {
+  using namespace kraken::binding::qjs;
+  std::unique_ptr<NativeString> clickEvent = stringToNativeString(event);
+  auto *nativeEvent = new NativeEvent{clickEvent.get()};
+  RawEvent rawEvent{reinterpret_cast<uint64_t*>(reinterpret_cast<int64_t*>(nativeEvent))};
+  NativeEventTarget::dispatchEventImpl(eventTarget->nativeEventTarget, clickEvent.get(), &rawEvent, 0);
+}

--- a/bridge/test/unit_test_util.h
+++ b/bridge/test/unit_test_util.h
@@ -6,14 +6,16 @@
 #include <memory>
 #include "bindings/qjs/dom/event_target.h"
 
-using OnEventTargetDisposed = void (*)(kraken::binding::qjs::EventTargetInstance *eventTargetInstance);
+using TEST_OnEventTargetDisposed = void (*)(kraken::binding::qjs::EventTargetInstance *eventTargetInstance);
+using TEST_PendingJobCallback = void (*)(void *ptr);
 
 struct UnitTestEnv {
-  OnEventTargetDisposed onEventTargetDisposed{nullptr};
+  TEST_OnEventTargetDisposed onEventTargetDisposed{nullptr};
 };
 
-std::shared_ptr<UnitTestEnv> getUnitTestEnv(int32_t contextUniqueId);
 
-void dispatchEvent(kraken::binding::qjs::EventTargetInstance *eventTarget, std::string event);
-
-void registerEventTargetDisposedCallback(int32_t contextUniqueId, OnEventTargetDisposed callback);
+std::shared_ptr<UnitTestEnv> TEST_getEnv(int32_t contextUniqueId);
+void TEST_dispatchEvent(kraken::binding::qjs::EventTargetInstance *eventTarget, std::string event);
+void TEST_registerEventTargetDisposedCallback(int32_t contextUniqueId, TEST_OnEventTargetDisposed callback);
+void TEST_schedulePendingJob(void *ptr, TEST_PendingJobCallback callback);
+void TEST_flushPendingJob();

--- a/bridge/test/unit_test_util.h
+++ b/bridge/test/unit_test_util.h
@@ -1,0 +1,19 @@
+/*
+ * Copyright (C) 2021 Alibaba Inc. All rights reserved.
+ * Author: Kraken Team.
+ */
+
+#include <memory>
+#include "bindings/qjs/dom/event_target.h"
+
+using OnEventTargetDisposed = void (*)(kraken::binding::qjs::EventTargetInstance *eventTargetInstance);
+
+struct UnitTestEnv {
+  OnEventTargetDisposed onEventTargetDisposed{nullptr};
+};
+
+std::shared_ptr<UnitTestEnv> getUnitTestEnv(int32_t contextUniqueId);
+
+void dispatchEvent(kraken::binding::qjs::EventTargetInstance *eventTarget, std::string event);
+
+void registerEventTargetDisposedCallback(int32_t contextUniqueId, OnEventTargetDisposed callback);

--- a/kraken/lib/src/bridge/from_native.dart
+++ b/kraken/lib/src/bridge/from_native.dart
@@ -3,6 +3,7 @@
  * Author: Kraken Team.
  */
 
+import 'dart:async';
 import 'dart:convert';
 import 'dart:ffi';
 import 'dart:typed_data';
@@ -219,6 +220,19 @@ void _clearTimeout(int contextId, int timerId) {
   return controller.module.clearTimeout(timerId);
 }
 
+typedef NativeScheduleMicrotaskCallback = Void Function(Pointer<Void> callbackContext);
+typedef DartScheduleMicrotaskCallback = void Function(Pointer<Void> callbackContext);
+typedef NativeScheduleMicrotask = Void Function(Pointer<Void> callbackContext, Pointer<NativeFunction<NativeScheduleMicrotaskCallback>> callback);
+
+final Pointer<NativeFunction<NativeScheduleMicrotask>> _nativeScheduleMicrotask = Pointer.fromFunction(_scheduleMicrotask);
+
+void _scheduleMicrotask(Pointer<Void> callbackContext, Pointer<NativeFunction<NativeScheduleMicrotaskCallback>> nativeCallback) {
+  DartScheduleMicrotaskCallback callback = nativeCallback.asFunction();
+  Future.microtask(() {
+    callback(callbackContext);
+  });
+}
+
 final Pointer<NativeFunction<NativeClearTimeout>> _nativeClearTimeout = Pointer.fromFunction(_clearTimeout);
 
 // Register requestAnimationFrame
@@ -384,6 +398,7 @@ final List<int> _dartNativeMethods = [
   _nativeSetTimeout.address,
   _nativeSetInterval.address,
   _nativeClearTimeout.address,
+  _nativeScheduleMicrotask.address,
   _nativeRequestAnimationFrame.address,
   _nativeCancelAnimationFrame.address,
   _nativeGetScreen.address,


### PR DESCRIPTION
1. 在 JS GC 的过程中，再分配对象是非常不安全的情况。现在有可能会出现 disposeEventTarget 调用回 Dart，然后 Dart 立刻同步触发事件到 JS 的情况。这样就等同于 JS GC (disposeEventTarget) --> dispatchEvent(new JSObject)，从而导致 crash。

所以将 GC 阶段触发的事件临时存下来，然后下帧再触发。