### PR TITLE
fix: intersection observer cache

### DIFF
--- a/kraken/lib/src/rendering/intersection_observer.dart
+++ b/kraken/lib/src/rendering/intersection_observer.dart
@@ -171,7 +171,7 @@ class IntersectionObserverLayer extends ContainerLayer {
         Matrix4? cachedTransform = _layerTransformCache[child.hashCode];
         // Get the transform of parent layer to root layer directly if exists.
         if (cachedTransform != null) {
-          transform = cachedTransform;
+          transform = cachedTransform.clone();
         } else {
           (parent as ContainerLayer).applyTransform(child, transform);
           // Cache the transform of parent layer to root layer.


### PR DESCRIPTION
由于 layer 的 applyTransform 有副作用，传入的 transform 会被改掉，因此 intersection observer 的 cache 在使用时需要先 clone 防止下一次使用时被修改。