### PR TITLE
fix: fix markParentNeedsRelayout error.

### DIFF
--- a/kraken/lib/src/rendering/box_model.dart
+++ b/kraken/lib/src/rendering/box_model.dart
@@ -745,8 +745,8 @@ class RenderBoxModel extends RenderBox
   // child has percentage length and parent's size can not be calculated by style
   // thus parent needs relayout for its child calculate percentage length.
   void markParentNeedsRelayout() {
-    RenderBoxModel? parent = this.parent as RenderBoxModel?;
-    if (parent != null) {
+    AbstractNode? parent = this.parent;
+    if (parent is RenderBoxModel) {
       parent.needsRelayout = true;
     }
   }


### PR DESCRIPTION
修复 parent 有可能不是 RenderBoxModel 的类型错误。