### PR TITLE
fix: sliver usage and other problems

### DIFF
--- a/kraken/lib/src/bridge/to_native.dart
+++ b/kraken/lib/src/bridge/to_native.dart
@@ -231,8 +231,9 @@ typedef DartProfileModeEnabled = int Function();
 final DartProfileModeEnabled _profileModeEnabled =
 nativeDynamicLibrary.lookup<NativeFunction<NativeProfileModeEnabled>>('profileModeEnabled').asFunction();
 
+const _CODE_ENABLED = 1;
 bool profileModeEnabled() {
-  return _profileModeEnabled() == 1 ? true : false;
+  return _profileModeEnabled() == _CODE_ENABLED;
 }
 
 // Regisdster reloadJsContext

--- a/kraken/lib/src/css/positioned.dart
+++ b/kraken/lib/src/css/positioned.dart
@@ -47,6 +47,9 @@ Offset? _getRenderPositionHolderScrollOffset(RenderPositionPlaceholder holder, R
 
 // Get the offset of the RenderPlaceholder of positioned element to its parent RenderBoxModel.
 Offset _getPlaceholderToParentOffset(RenderPositionPlaceholder placeholder, RenderBoxModel parent) {
+  if (!placeholder.attached) {
+    return Offset.zero;
+  }
   Offset positionHolderScrollOffset = _getRenderPositionHolderScrollOffset(placeholder, parent) ?? Offset.zero;
   Offset placeholderOffset = placeholder.localToGlobal(positionHolderScrollOffset, ancestor: parent);
   return placeholderOffset;

--- a/kraken/lib/src/dom/element.dart
+++ b/kraken/lib/src/dom/element.dart
@@ -567,8 +567,11 @@ class Element extends Node
   void attachTo(Node parent, {RenderBox? after}) {
     _applyStyle(style);
 
-    // @NOTE: Sliver should not create renderer here.
-    if (parentElement?.renderStyle.display != CSSDisplay.sliver) {
+    if (parentElement?.renderStyle.display == CSSDisplay.sliver) {
+      // Sliver should not create renderer here, but need to trigger
+      // render sliver list dynamical rebuild child by element tree.
+      parentElement?._renderLayoutBox?.markNeedsLayout();
+    } else {
       willAttachRenderer();
     }
 
@@ -642,11 +645,6 @@ class Element extends Node
         }
 
         child.attachTo(this, after: after);
-
-        // Lazy trigger render sliver to dynamic rebuild child by element tree.
-        if (renderLayoutBox is RenderSliverListLayout) {
-          renderLayoutBox.markSliverListNeedsLayout();
-        }
       }
     }
 

--- a/kraken/lib/src/dom/element.dart
+++ b/kraken/lib/src/dom/element.dart
@@ -628,18 +628,25 @@ class Element extends Node
     if (child is Element) {
       child.renderStyle.parent = renderStyle;
     }
+
+    RenderLayoutBox? renderLayoutBox = _renderLayoutBox;
     if (isRendererAttached) {
       // Only append child renderer when which is not attached.
-      if (!child.isRendererAttached && _renderLayoutBox != null) {
+      if (!child.isRendererAttached && renderLayoutBox != null) {
         RenderBox? after;
-        RenderLayoutBox? scrollingContentBox = _renderLayoutBox!.renderScrollingContent;
+        RenderLayoutBox? scrollingContentBox = renderLayoutBox.renderScrollingContent;
         if (scrollingContentBox != null) {
           after = scrollingContentBox.lastChild;
         } else {
-          after = _renderLayoutBox!.lastChild;
+          after = renderLayoutBox.lastChild;
         }
 
         child.attachTo(this, after: after);
+
+        // Lazy trigger render sliver to dynamic rebuild child by element tree.
+        if (renderLayoutBox is RenderSliverListLayout) {
+          renderLayoutBox.markSliverListNeedsLayout();
+        }
       }
     }
 

--- a/kraken/lib/src/dom/elements/img.dart
+++ b/kraken/lib/src/dom/elements/img.dart
@@ -331,8 +331,8 @@ class ImageElement extends Element {
     if (resolvedUri == null) return;
 
     // Try to make sure that this image can be encoded into a smaller size.
-    int? cachedWidth = width > 0 ? (width * ui.window.devicePixelRatio).toInt() : null;
-    int? cachedHeight = height > 0 ? (height * ui.window.devicePixelRatio).toInt() : null;
+    int? cachedWidth = width > 0 && width.isFinite ? (width * ui.window.devicePixelRatio).toInt() : null;
+    int? cachedHeight = height > 0 && height.isFinite ? (height * ui.window.devicePixelRatio).toInt() : null;
 
     ImageProvider? provider = _cachedImageProvider;
     if (updateImageProvider || provider == null) {
@@ -459,11 +459,13 @@ class ImageElement extends Element {
   void _stylePropertyChanged(String property, String? original, String present) {
     if (property == WIDTH || property == HEIGHT) {
       if (property == WIDTH) {
-        _styleWidth = renderStyle.width.value == null && renderStyle.width.isNotAuto
+        double? resolveStyleWidth = renderStyle.width.value == null && renderStyle.width.isNotAuto
           ? null : renderStyle.width.computedValue;
+        _styleWidth = resolveStyleWidth == double.infinity ? null : resolveStyleWidth;
       } else if (property == HEIGHT) {
-        _styleHeight = renderStyle.height.value == null && renderStyle.height.isNotAuto
+        double? resolveStyleHeight = renderStyle.height.value == null && renderStyle.height.isNotAuto
           ? null : renderStyle.height.computedValue;
+        _styleHeight = resolveStyleHeight == double.infinity ? null : resolveStyleHeight;
       }
       // Resize image
       _resolveImage(_resolvedUri, updateImageProvider: true);

--- a/kraken/lib/src/dom/elements/img.dart
+++ b/kraken/lib/src/dom/elements/img.dart
@@ -461,6 +461,9 @@ class ImageElement extends Element {
       if (property == WIDTH) {
         double? resolveStyleWidth = renderStyle.width.value == null && renderStyle.width.isNotAuto
           ? null : renderStyle.width.computedValue;
+        // To avoid resolved auto, which computed value is infinity, we can not calculate
+        // infinite double as valid number, mark null to let width/height resized by decode
+        // size.
         _styleWidth = resolveStyleWidth == double.infinity ? null : resolveStyleWidth;
       } else if (property == HEIGHT) {
         double? resolveStyleHeight = renderStyle.height.value == null && renderStyle.height.isNotAuto

--- a/kraken/lib/src/rendering/sliver_list.dart
+++ b/kraken/lib/src/rendering/sliver_list.dart
@@ -42,7 +42,6 @@ class RenderSliverListLayout extends RenderLayoutBox {
   }) : _renderSliverBoxChildManager = manager,
        _scrollListener = onScroll,
         super(renderStyle: renderStyle) {
-    scrollablePointerListener = _scrollablePointerListener;
     scrollable = KrakenScrollable(axisDirection: getAxisDirection(axis));
     axis = renderStyle.sliverDirection;
 
@@ -67,6 +66,10 @@ class RenderSliverListLayout extends RenderLayoutBox {
     manager.setupSliverListLayout(this);
     super.insert(_renderViewport);
   }
+
+  // Override the scrollable pointer listener.
+  @override
+  void Function(PointerEvent event) get scrollablePointerListener => _scrollablePointerListener;
 
   @override
   ScrollListener? get scrollListener => _scrollListener;
@@ -130,6 +133,11 @@ class RenderSliverListLayout extends RenderLayoutBox {
   @protected
   RenderSliverList _buildRenderSliverList() {
     return _renderSliverList = RenderSliverList(childManager: _renderSliverBoxChildManager);
+  }
+
+  // Make sliver list trigger layout.
+  void markSliverListNeedsLayout() {
+    _renderSliverList.markNeedsLayout();
   }
 
   /// Child count should rely on element's childNodes, the real
@@ -232,7 +240,7 @@ class RenderSliverListLayout extends RenderLayoutBox {
       // Ignore detached render object.
       if (!child.attached) continue;
 
-      final ContainerBoxParentData childParentData = child.parentData as ContainerBoxParentData;
+      final ContainerBoxParentData childParentData = child.parentData as ContainerBoxParentData<RenderBox>;
       final bool isHit = result.addWithPaintOffset(
         offset: childParentData.offset + currentOffset,
         position: position,

--- a/kraken/lib/src/rendering/sliver_list.dart
+++ b/kraken/lib/src/rendering/sliver_list.dart
@@ -21,7 +21,7 @@ class RenderSliverListLayout extends RenderLayoutBox {
   late RenderViewport _renderViewport;
 
   // The sliver list render object reference.
-  late RenderSliverList _renderSliverList;
+  RenderSliverList? _renderSliverList;
 
   // The scrollable context to handle gestures.
   late KrakenScrollable scrollable;
@@ -56,12 +56,12 @@ class RenderSliverListLayout extends RenderLayoutBox {
         break;
     }
 
-    _renderSliverList = _buildRenderSliverList();
+    RenderSliverList renderSliverList = _renderSliverList = _buildRenderSliverList();
     _renderViewport = RenderViewport(
       offset: scrollable.position!,
       axisDirection: scrollable.axisDirection,
       crossAxisDirection: getCrossAxisDirection(axis),
-      children: [_renderSliverList],
+      children: [renderSliverList],
     );
     manager.setupSliverListLayout(this);
     super.insert(_renderViewport);
@@ -90,7 +90,7 @@ class RenderSliverListLayout extends RenderLayoutBox {
   // Insert render box child as sliver child.
   void insertSliverChild(RenderBox child, { RenderBox? after }) {
     setupParentData(child);
-    _renderSliverList.insert(child, after: after);
+    _renderSliverList?.insert(child, after: after);
   }
 
   @override
@@ -98,20 +98,19 @@ class RenderSliverListLayout extends RenderLayoutBox {
     if (child == _renderViewport) {
       super.remove(child);
     } else if (child.parent == _renderSliverList) {
-      _renderSliverList.remove(child);
+      _renderSliverList?.remove(child);
     }
   }
 
   @override
   void removeAll() {
-    _renderSliverList.removeAll();
+    _renderSliverList?.removeAll();
   }
 
   @override
   void move(RenderBox child, {RenderBox? after}) {
     if (child.parent == _renderSliverList) {
-      remove(child);
-      insertSliverChild(child, after: after);
+      _renderSliverList?.move(child, after: after);
     }
   }
 
@@ -135,9 +134,11 @@ class RenderSliverListLayout extends RenderLayoutBox {
     return _renderSliverList = RenderSliverList(childManager: _renderSliverBoxChildManager);
   }
 
-  // Make sliver list trigger layout.
-  void markSliverListNeedsLayout() {
-    _renderSliverList.markNeedsLayout();
+  // Trigger sliver list to rebuild children.
+  @override
+  void markNeedsLayout() {
+    super.markNeedsLayout();
+    _renderSliverList?.markNeedsLayout();
   }
 
   /// Child count should rely on element's childNodes, the real


### PR DESCRIPTION
1. 修复 sliver 在延迟触发加载的时候，RenderViewport 的 relayoutboundary 阻挡了 RenderSliverList 触发 performLayout 导致节点未同步的问题, 同时修复这种情况下滚动监听器被覆盖的问题
2. 修复 img 的尺寸计算中宽高有可能为 resolved auto, 从而产生 infinity 的问题 cc @temper357 
3. 修复 placeholder 有可能未上树 (sliver 或者其它 widget 场景下), 计算 offset 异常的问题
4. 其它类型 cast 修复