### PR TITLE
fix: relayout boundary of flex item

### DIFF
--- a/kraken/lib/src/rendering/box_model.dart
+++ b/kraken/lib/src/rendering/box_model.dart
@@ -192,16 +192,6 @@ class RenderLayoutBox extends RenderBoxModel
     _paintingOrder = null;
   }
 
-  @override
-  void markNeedsLayout() {
-    super.markNeedsLayout();
-
-    // FlexItem layout must trigger flex container to layout.
-    if (parent is RenderFlexLayout) {
-      markParentNeedsLayout();
-    }
-  }
-
   // Sort children by zIndex, used for paint and hitTest.
   List<RenderBox>? _paintingOrder;
   List<RenderBox> get paintingOrder {


### PR DESCRIPTION
PR 中删除的代码会使 flex item 的 relayout boundary 失效，即使 flex item 上有设置宽高，还是会继续向上冒脏标识。
这段代码的原始含义是，flex item 的 size 变化时可能影响到 sibling 的 size，如果 flex item 自身是 relayout boundary 那么脏标识不会冒泡到 parent，重构过后的代码中这个逻辑已经在 css 属性的 setter 中处理过了，因此这段逻辑不是必需的。