### PR TITLE
fix: RenderIntrinsic should only clip when border-radius exist

### DIFF
--- a/kraken/lib/src/rendering/intrinsic.dart
+++ b/kraken/lib/src/rendering/intrinsic.dart
@@ -26,12 +26,18 @@ class RenderIntrinsic extends RenderBoxModel
     return heightDefined ? BoxSizeType.specified : BoxSizeType.intrinsic;
   }
 
-  // Set clipX and clipY to true for background cannot overflow beyond the boundary of replaced element
+  // The content of replaced elements is always trimmed to the content edge curve.
+  // https://www.w3.org/TR/css-backgrounds-3/#corner-clipping
   @override
-  bool get clipX => true;
+  bool get clipX {
+    // Only clip when content of replaced element is loaded.
+    return renderStyle.borderRadius != null && renderStyle.intrinsicRatio != null;
+  }
 
   @override
-  bool get clipY => true;
+  bool get clipY {
+    return renderStyle.borderRadius != null && renderStyle.intrinsicRatio != null;
+  }
 
   @override
   void setupParentData(RenderBox child) {


### PR DESCRIPTION
Closes https://github.com/openkraken/kraken/issues/1075

* 修复图片总会创建 clipRectLayer 导致 paint 性能下降产生滚动卡顿，只当 border-radius 存在且 image load 完成时创建 layer，该 fix 可减少大部分因无 border-radius 的 image 产生的卡顿，更优的方案是 border-radius 的 image 使用 canvas.clipRect 的方案，仍在开发中，见此 PR https://github.com/openkraken/kraken/pull/1076。