### PR TITLE
fix: input hotkey and delete command fail due to flutter 2.5 upgrade

### DIFF
--- a/kraken/lib/src/dom/elements/input.dart
+++ b/kraken/lib/src/dom/elements/input.dart
@@ -810,7 +810,7 @@ class InputElement extends Element implements TextInputClient, TickerProvider {
     WidgetDelegate? widgetDelegate = ownerDocument.widgetDelegate;
 
     if (_selectionControls == null) {
-      _selectionOverlay?.hide();
+      _selectionOverlay?.dispose();
       _selectionOverlay = null;
     } else if (widgetDelegate != null) {
       if (_selectionOverlay == null) {

--- a/kraken/lib/src/widget/kraken.dart
+++ b/kraken/lib/src/widget/kraken.dart
@@ -251,6 +251,15 @@ class _KrakenState extends State<Kraken> with RouteAware {
       NextFocusIntent: CallbackAction<NextFocusIntent>(onInvoke: _handleNextFocus),
       PreviousFocusIntent: CallbackAction<PreviousFocusIntent>(onInvoke: _handlePreviousFocus),
 
+      // Action to delete text.
+      DeleteTextIntent: CallbackAction<DeleteTextIntent>(onInvoke: _handleDeleteText),
+
+      // Action of hot keys control/command + (X, C, V, A).
+      SelectAllTextIntent: CallbackAction<SelectAllTextIntent>(onInvoke: _handleSelectAllText),
+      CopySelectionTextIntent: CallbackAction<CopySelectionTextIntent>(onInvoke: _handleCopySelectionText),
+      CutSelectionTextIntent: CallbackAction<CutSelectionTextIntent>(onInvoke: _handleCutSelectionText),
+      PasteTextIntent: CallbackAction<PasteTextIntent>(onInvoke: _handlePasteText),
+
       // Action of mouse move hotkeys.
       MoveSelectionRightByLineTextIntent: CallbackAction<MoveSelectionRightByLineTextIntent>(onInvoke: _handleMoveSelectionRightByLineText),
       MoveSelectionLeftByLineTextIntent: CallbackAction<MoveSelectionLeftByLineTextIntent>(onInvoke: _handleMoveSelectionLeftByLineText),
@@ -542,6 +551,56 @@ class _KrakenState extends State<Kraken> with RouteAware {
       // None editable exists, focus the previous widget.
     } else {
       _focusNode.previousFocus();
+    }
+  }
+
+  void _handleDeleteText(DeleteTextIntent intent) {
+    dom.Element? focusedElement = _findFocusedElement();
+    if (focusedElement != null) {
+      RenderEditable? focusedRenderEditable = (focusedElement as dom.InputElement).renderEditable;
+      if (focusedRenderEditable != null) {
+        focusedRenderEditable.delete(SelectionChangedCause.keyboard);
+      }
+    }
+  }
+
+  void _handleSelectAllText(SelectAllTextIntent intent) {
+    dom.Element? focusedElement = _findFocusedElement();
+    if (focusedElement != null) {
+      RenderEditable? focusedRenderEditable = (focusedElement as dom.InputElement).renderEditable;
+      if (focusedRenderEditable != null) {
+        focusedRenderEditable.selectAll(SelectionChangedCause.keyboard);
+      }
+    }
+  }
+
+  void _handleCopySelectionText(CopySelectionTextIntent intent) {
+    dom.Element? focusedElement = _findFocusedElement();
+    if (focusedElement != null) {
+      RenderEditable? focusedRenderEditable = (focusedElement as dom.InputElement).renderEditable;
+      if (focusedRenderEditable != null) {
+        focusedRenderEditable.copySelection();
+      }
+    }
+  }
+
+  void _handleCutSelectionText(CutSelectionTextIntent intent) {
+    dom.Element? focusedElement = _findFocusedElement();
+    if (focusedElement != null) {
+      RenderEditable? focusedRenderEditable = (focusedElement as dom.InputElement).renderEditable;
+      if (focusedRenderEditable != null) {
+        focusedRenderEditable.cutSelection(SelectionChangedCause.keyboard);
+      }
+    }
+  }
+
+  void _handlePasteText(PasteTextIntent intent) {
+    dom.Element? focusedElement = _findFocusedElement();
+    if (focusedElement != null) {
+      RenderEditable? focusedRenderEditable = (focusedElement as dom.InputElement).renderEditable;
+      if (focusedRenderEditable != null) {
+        focusedRenderEditable.pasteText(SelectionChangedCause.keyboard);
+      }
     }
   }
 


### PR DESCRIPTION
Closes https://github.com/openkraken/kraken/issues/1092

1. 在 Kraken 的 widget 中 override 系统的 action，补充 RenderEditable 在 Flutter 2.5 版本中被移除的 delete 及 hotKey 对应的 action。
2. 通过 diff Flutter 2.2 与 2.5 版本的 editable_text.dart （对应 Kraken 拷贝出来修改的 input.dart），发现一处 _selectionOverlay 相关的逻辑变更，同步到 Kraken。 