### PR TITLE
fix: fix crash when reload page.

### DIFF
--- a/bridge/bindings/qjs/bom/blob.cc
+++ b/bridge/bindings/qjs/bom/blob.cc
@@ -10,8 +10,8 @@ namespace kraken::binding::qjs {
 
 std::once_flag kBlobInitOnceFlag;
 
-void bindBlob(std::unique_ptr<ExecutionContext>& context) {
-  auto* constructor = Blob::instance(context.get());
+void bindBlob(ExecutionContext* context) {
+  auto* constructor = Blob::instance(context);
   context->defineGlobalProperty("Blob", constructor->jsObject);
 }
 

--- a/bridge/bindings/qjs/bom/blob.h
+++ b/bridge/bindings/qjs/bom/blob.h
@@ -13,7 +13,7 @@ namespace kraken::binding::qjs {
 class BlobBuilder;
 class BlobInstance;
 
-void bindBlob(std::unique_ptr<ExecutionContext>& context);
+void bindBlob(ExecutionContext* context);
 
 class Blob : public HostClass {
  public:

--- a/bridge/bindings/qjs/bom/console.cc
+++ b/bridge/bindings/qjs/bom/console.cc
@@ -30,7 +30,7 @@ JSValue print(JSContext* ctx, JSValueConst this_val, int argc, JSValueConst* arg
   return JS_UNDEFINED;
 }
 
-void bindConsole(std::unique_ptr<ExecutionContext>& context) {
+void bindConsole(ExecutionContext* context) {
   QJS_GLOBAL_BINDING_FUNCTION(context, print, "__kraken_print__", 2);
 }
 

--- a/bridge/bindings/qjs/bom/console.h
+++ b/bridge/bindings/qjs/bom/console.h
@@ -10,7 +10,7 @@
 
 namespace kraken::binding::qjs {
 
-void bindConsole(std::unique_ptr<ExecutionContext>& context);
+void bindConsole(ExecutionContext* context);
 
 }
 

--- a/bridge/bindings/qjs/bom/performance.cc
+++ b/bridge/bindings/qjs/bom/performance.cc
@@ -11,8 +11,8 @@
 
 namespace kraken::binding::qjs {
 
-void bindPerformance(std::unique_ptr<ExecutionContext>& context) {
-  auto* performance = Performance::instance(context.get());
+void bindPerformance(ExecutionContext* context) {
+  auto* performance = Performance::instance(context);
   context->defineGlobalProperty("performance", performance->jsObject);
 }
 

--- a/bridge/bindings/qjs/bom/performance.h
+++ b/bridge/bindings/qjs/bom/performance.h
@@ -125,7 +125,7 @@
 
 namespace kraken::binding::qjs {
 
-void bindPerformance(std::unique_ptr<ExecutionContext>& context);
+void bindPerformance(ExecutionContext* context);
 
 struct NativePerformanceEntry {
   NativePerformanceEntry(const std::string& name, const std::string& entryType, int64_t startTime, int64_t duration, int64_t uniqueId) : startTime(startTime), duration(duration), uniqueId(uniqueId) {

--- a/bridge/bindings/qjs/bom/screen.cc
+++ b/bridge/bindings/qjs/bom/screen.cc
@@ -7,8 +7,8 @@
 
 namespace kraken::binding::qjs {
 
-void bindScreen(std::unique_ptr<ExecutionContext>& context) {
-  auto* screen = new Screen(context.get());
+void bindScreen(ExecutionContext* context) {
+  auto* screen = new Screen(context);
   context->defineGlobalProperty("screen", screen->jsObject);
 }
 

--- a/bridge/bindings/qjs/bom/screen.h
+++ b/bridge/bindings/qjs/bom/screen.h
@@ -21,7 +21,7 @@ class Screen : public HostObject {
   DEFINE_READONLY_PROPERTY(height);
 };
 
-void bindScreen(std::unique_ptr<ExecutionContext>& context);
+void bindScreen(ExecutionContext* context);
 
 }  // namespace kraken::binding::qjs
 

--- a/bridge/bindings/qjs/bom/timer.cc
+++ b/bridge/bindings/qjs/bom/timer.cc
@@ -219,7 +219,7 @@ static JSValue clearTimeout(JSContext* ctx, JSValueConst this_val, int argc, JSV
   return JS_NULL;
 }
 
-void bindTimer(std::unique_ptr<ExecutionContext>& context) {
+void bindTimer(ExecutionContext* context) {
   QJS_GLOBAL_BINDING_FUNCTION(context, setTimeout, "setTimeout", 2);
   QJS_GLOBAL_BINDING_FUNCTION(context, setInterval, "setInterval", 2);
   QJS_GLOBAL_BINDING_FUNCTION(context, clearTimeout, "clearTimeout", 1);

--- a/bridge/bindings/qjs/bom/timer.h
+++ b/bridge/bindings/qjs/bom/timer.h
@@ -34,7 +34,7 @@ class DOMTimer : public GarbageCollected<DOMTimer> {
   JSValue m_callback;
 };
 
-void bindTimer(std::unique_ptr<ExecutionContext>& context);
+void bindTimer(ExecutionContext* context);
 
 }  // namespace kraken::binding::qjs
 

--- a/bridge/bindings/qjs/bom/timer_test.cc
+++ b/bridge/bindings/qjs/bom/timer_test.cc
@@ -37,7 +37,7 @@ console.log('1234');
 )";
 
   bridge->evaluateScript(code.c_str(), code.size(), "vm://", 0);
-  TEST_runLoop(bridge->getContext().get());
+  TEST_runLoop(bridge->getContext());
   disposePage(0);
 }
 
@@ -63,6 +63,6 @@ clearTimeout(timer);
 )";
 
   bridge->evaluateScript(code.c_str(), code.size(), "vm://", 0);
-  TEST_runLoop(bridge->getContext().get());
+  TEST_runLoop(bridge->getContext());
   disposePage(0);
 }

--- a/bridge/bindings/qjs/bom/window.cc
+++ b/bridge/bindings/qjs/bom/window.cc
@@ -14,9 +14,9 @@ namespace kraken::binding::qjs {
 
 std::once_flag kWindowInitOnceFlag;
 
-void bindWindow(std::unique_ptr<ExecutionContext>& context) {
+void bindWindow(ExecutionContext* context) {
   // Set globalThis and Window's prototype to EventTarget's prototype to support EventTarget methods in global.
-  auto* windowConstructor = new Window(context.get());
+  auto* windowConstructor = new Window(context);
   JS_SetPrototype(context->ctx(), context->global(), windowConstructor->prototype());
   context->defineGlobalProperty("Window", windowConstructor->jsObject);
 

--- a/bridge/bindings/qjs/bom/window.h
+++ b/bridge/bindings/qjs/bom/window.h
@@ -12,7 +12,7 @@
 
 namespace kraken::binding::qjs {
 
-void bindWindow(std::unique_ptr<ExecutionContext>& context);
+void bindWindow(ExecutionContext* context);
 
 class WindowInstance;
 

--- a/bridge/bindings/qjs/bom/window_test.cc
+++ b/bridge/bindings/qjs/bom/window_test.cc
@@ -19,7 +19,7 @@ TEST(Window, instanceofEventTarget) {
     KRAKEN_LOG(VERBOSE) << errmsg;
     errorCalled = true;
   });
-  auto& context = bridge->getContext();
+  auto context = bridge->getContext();
   const char* code = "console.log(window instanceof EventTarget)";
   bridge->evaluateScript(code, strlen(code), "vm://", 0);
 
@@ -39,7 +39,7 @@ requestAnimationFrame(() => {
 )";
 
   bridge->evaluateScript(code.c_str(), code.size(), "vm://", 0);
-  TEST_runLoop(bridge->getContext().get());
+  TEST_runLoop(bridge->getContext());
 }
 
 TEST(Window, cancelAnimationFrame) {
@@ -55,5 +55,5 @@ cancelAnimationFrame(id);
 )";
 
   bridge->evaluateScript(code.c_str(), code.size(), "vm://", 0);
-  TEST_runLoop(bridge->getContext().get());
+  TEST_runLoop(bridge->getContext());
 }

--- a/bridge/bindings/qjs/dom/comment_node.cc
+++ b/bridge/bindings/qjs/dom/comment_node.cc
@@ -13,8 +13,8 @@ std::once_flag kCommentInitFlag;
 
 JSClassID Comment::kCommentClassId{0};
 
-void bindCommentNode(std::unique_ptr<ExecutionContext>& context) {
-  auto* constructor = Comment::instance(context.get());
+void bindCommentNode(ExecutionContext* context) {
+  auto* constructor = Comment::instance(context);
   context->defineGlobalProperty("Comment", constructor->jsObject);
 }
 

--- a/bridge/bindings/qjs/dom/comment_node.h
+++ b/bridge/bindings/qjs/dom/comment_node.h
@@ -10,7 +10,7 @@
 
 namespace kraken::binding::qjs {
 
-void bindCommentNode(std::unique_ptr<ExecutionContext>& context);
+void bindCommentNode(ExecutionContext* context);
 
 class CommentInstance;
 

--- a/bridge/bindings/qjs/dom/custom_event.cc
+++ b/bridge/bindings/qjs/dom/custom_event.cc
@@ -11,8 +11,8 @@
 
 namespace kraken::binding::qjs {
 
-void bindCustomEvent(std::unique_ptr<ExecutionContext>& context) {
-  auto* constructor = CustomEvent::instance(context.get());
+void bindCustomEvent(ExecutionContext* context) {
+  auto* constructor = CustomEvent::instance(context);
   context->defineGlobalProperty("CustomEvent", constructor->jsObject);
 }
 

--- a/bridge/bindings/qjs/dom/custom_event.h
+++ b/bridge/bindings/qjs/dom/custom_event.h
@@ -10,7 +10,7 @@
 
 namespace kraken::binding::qjs {
 
-void bindCustomEvent(std::unique_ptr<ExecutionContext>& context);
+void bindCustomEvent(ExecutionContext* context);
 
 struct NativeCustomEvent {
   NativeEvent nativeEvent;

--- a/bridge/bindings/qjs/dom/custom_event_test.cc
+++ b/bridge/bindings/qjs/dom/custom_event_test.cc
@@ -19,7 +19,7 @@ TEST(CustomEvent, instanceofEvent) {
     KRAKEN_LOG(VERBOSE) << errmsg;
     errorCalled = true;
   });
-  auto& context = bridge->getContext();
+  auto context = bridge->getContext();
   const char* code =
       "let customEvent = new CustomEvent('abc', { detail: 'helloworld'});"
       "console.log(customEvent instanceof Event);";

--- a/bridge/bindings/qjs/dom/document.cc
+++ b/bridge/bindings/qjs/dom/document.cc
@@ -55,8 +55,8 @@ void traverseNode(NodeInstance* node, TraverseHandler handler) {
 
 std::once_flag kDocumentInitOnceFlag;
 
-void bindDocument(std::unique_ptr<ExecutionContext>& context) {
-  auto* documentConstructor = Document::instance(context.get());
+void bindDocument(ExecutionContext* context) {
+  auto* documentConstructor = Document::instance(context);
   context->defineGlobalProperty("Document", documentConstructor->jsObject);
   JSValue documentInstance = JS_CallConstructor(context->ctx(), documentConstructor->jsObject, 0, nullptr);
   context->defineGlobalProperty("document", documentInstance);

--- a/bridge/bindings/qjs/dom/document.h
+++ b/bridge/bindings/qjs/dom/document.h
@@ -13,7 +13,7 @@
 
 namespace kraken::binding::qjs {
 
-void bindDocument(std::unique_ptr<ExecutionContext>& context);
+void bindDocument(ExecutionContext* context);
 
 using TraverseHandler = std::function<bool(NodeInstance*)>;
 

--- a/bridge/bindings/qjs/dom/document_fragment.cc
+++ b/bridge/bindings/qjs/dom/document_fragment.cc
@@ -9,8 +9,8 @@
 
 namespace kraken::binding::qjs {
 
-void bindDocumentFragment(std::unique_ptr<ExecutionContext>& context) {
-  auto* constructor = DocumentFragment::instance(context.get());
+void bindDocumentFragment(ExecutionContext* context) {
+  auto* constructor = DocumentFragment::instance(context);
   context->defineGlobalProperty("DocumentFragment", constructor->jsObject);
 }
 

--- a/bridge/bindings/qjs/dom/document_fragment.h
+++ b/bridge/bindings/qjs/dom/document_fragment.h
@@ -10,7 +10,7 @@
 
 namespace kraken::binding::qjs {
 
-void bindDocumentFragment(std::unique_ptr<ExecutionContext>& context);
+void bindDocumentFragment(ExecutionContext* context);
 
 class DocumentFragment : public Node {
  public:

--- a/bridge/bindings/qjs/dom/document_test.cc
+++ b/bridge/bindings/qjs/dom/document_test.cc
@@ -19,7 +19,7 @@ TEST(Document, createTextNode) {
     KRAKEN_LOG(VERBOSE) << errmsg;
     errorCalled = true;
   });
-  auto& context = bridge->getContext();
+  auto context = bridge->getContext();
   const char* code =
       "let div = document.createElement('div');"
       "div.setAttribute('hello', 1234);"
@@ -43,7 +43,7 @@ TEST(Document, instanceofNode) {
     KRAKEN_LOG(VERBOSE) << errmsg;
     errorCalled = true;
   });
-  auto& context = bridge->getContext();
+  auto context = bridge->getContext();
   const char* code = "console.log(document instanceof Node, document instanceof Document, document instanceof EventTarget)";
   bridge->evaluateScript(code, strlen(code), "vm://", 0);
   EXPECT_EQ(errorCalled, false);
@@ -59,14 +59,14 @@ TEST(Document, createElementShouldWorkWithMultipleContext) {
 
   {
     auto bridge = TEST_init([](int32_t contextId, const char* errmsg) {});
-    auto& context = bridge->getContext();
+    auto context = bridge->getContext();
     bridge->evaluateScript(code, strlen(code), "vm://", 0);
     bridge1 = bridge.release();
   }
 
   {
     auto bridge = TEST_init([](int32_t contextId, const char* errmsg) {});
-    auto& context = bridge->getContext();
+    auto context = bridge->getContext();
     const char* code = "(() => { let img = document.createElement('img'); document.body.appendChild(img);  })();";
     bridge->evaluateScript(code, strlen(code), "vm://", 0);
   }

--- a/bridge/bindings/qjs/dom/element.cc
+++ b/bridge/bindings/qjs/dom/element.cc
@@ -19,8 +19,8 @@ namespace kraken::binding::qjs {
 
 std::once_flag kElementInitOnceFlag;
 
-void bindElement(std::unique_ptr<ExecutionContext>& context) {
-  auto* constructor = Element::instance(context.get());
+void bindElement(ExecutionContext* context) {
+  auto* constructor = Element::instance(context);
   //  auto* domRectConstructor = BoundingClientRect
   context->defineGlobalProperty("Element", constructor->jsObject);
   context->defineGlobalProperty("HTMLElement", JS_DupValue(context->ctx(), constructor->jsObject));

--- a/bridge/bindings/qjs/dom/element.h
+++ b/bridge/bindings/qjs/dom/element.h
@@ -14,7 +14,7 @@
 
 namespace kraken::binding::qjs {
 
-void bindElement(std::unique_ptr<ExecutionContext>& context);
+void bindElement(ExecutionContext* context);
 
 class ElementInstance;
 

--- a/bridge/bindings/qjs/dom/element_test.cc
+++ b/bridge/bindings/qjs/dom/element_test.cc
@@ -19,7 +19,7 @@ TEST(Element, setAttribute) {
     KRAKEN_LOG(VERBOSE) << errmsg;
     errorCalled = true;
   });
-  auto& context = bridge->getContext();
+  auto context = bridge->getContext();
   const char* code =
       "let div = document.createElement('div');"
       "div.setAttribute('hello', 1234);"
@@ -41,7 +41,7 @@ TEST(Element, getAttribute) {
     KRAKEN_LOG(VERBOSE) << errmsg;
     errorCalled = true;
   });
-  auto& context = bridge->getContext();
+  auto context = bridge->getContext();
   const char* code =
       "let div = document.createElement('div');"
       "let string = 'helloworld';"
@@ -66,7 +66,7 @@ TEST(Element, setAttributeWithHTML) {
     KRAKEN_LOG(VERBOSE) << errmsg;
     errorCalled = true;
   });
-  auto& context = bridge->getContext();
+  auto context = bridge->getContext();
   const char* code =
       "let div = document.createElement('div');"
       "div.innerHTML = '<img src=\"https://miniapp-nikestore-demo.oss-cn-beijing.aliyuncs.com/white_shoes_v1.png\" style=\"width:100%;height:auto;\">';";
@@ -85,7 +85,7 @@ TEST(Element, instanceofNode) {
     KRAKEN_LOG(VERBOSE) << errmsg;
     errorCalled = true;
   });
-  auto& context = bridge->getContext();
+  auto context = bridge->getContext();
   const char* code =
       "let div = document.createElement('div');"
       "console.log(div instanceof Node)";
@@ -106,7 +106,7 @@ TEST(Element, instanceofEventTarget) {
     KRAKEN_LOG(VERBOSE) << errmsg;
     errorCalled = true;
   });
-  auto& context = bridge->getContext();
+  auto context = bridge->getContext();
   const char* code =
       "let div = document.createElement('div');"
       "console.log(div instanceof EventTarget)";
@@ -129,13 +129,13 @@ TEST(Element, stringifyBoundingClientRect) {
     KRAKEN_LOG(VERBOSE) << errmsg;
     errorCalled = true;
   });
-  auto& context = bridge->getContext();
+  auto context = bridge->getContext();
 
   NativeBoundingClientRect nativeRect{
       10.0, 20.0, 30.0, 40.0, 10.0, 20.0, 30.0, 40.0,
   };
 
-  auto* clientRect = new BoundingClientRect(context.get(), &nativeRect);
+  auto* clientRect = new BoundingClientRect(context, &nativeRect);
   context->defineGlobalProperty("boundingClient", clientRect->jsObject);
 
   const char* code = "console.log(JSON.stringify(boundingClient))";

--- a/bridge/bindings/qjs/dom/elements/image_element.cc
+++ b/bridge/bindings/qjs/dom/elements/image_element.cc
@@ -13,8 +13,8 @@ ImageElement::ImageElement(ExecutionContext* context) : Element(context) {
   JS_SetPrototype(m_ctx, m_prototypeObject, Element::instance(m_context)->prototype());
 }
 
-void bindImageElement(std::unique_ptr<ExecutionContext>& context) {
-  auto* constructor = ImageElement::instance(context.get());
+void bindImageElement(ExecutionContext* context) {
+  auto* constructor = ImageElement::instance(context);
   context->defineGlobalProperty("HTMLImageElement", constructor->jsObject);
   context->defineGlobalProperty("Image", JS_DupValue(context->ctx(), constructor->jsObject));
 }

--- a/bridge/bindings/qjs/dom/elements/image_element.h
+++ b/bridge/bindings/qjs/dom/elements/image_element.h
@@ -10,7 +10,7 @@
 
 namespace kraken::binding::qjs {
 
-void bindImageElement(std::unique_ptr<ExecutionContext>& context);
+void bindImageElement(ExecutionContext* context);
 
 class ImageElementInstance;
 class ImageElement : public Element {

--- a/bridge/bindings/qjs/dom/elements/template_element.cc
+++ b/bridge/bindings/qjs/dom/elements/template_element.cc
@@ -14,8 +14,8 @@ TemplateElement::TemplateElement(ExecutionContext* context) : Element(context) {
   JS_SetPrototype(m_ctx, m_prototypeObject, Element::instance(m_context)->prototype());
 }
 
-void bindTemplateElement(std::unique_ptr<ExecutionContext>& context) {
-  auto* constructor = TemplateElement::instance(context.get());
+void bindTemplateElement(ExecutionContext* context) {
+  auto* constructor = TemplateElement::instance(context);
   context->defineGlobalProperty("HTMLTemplateElement", constructor->jsObject);
 }
 

--- a/bridge/bindings/qjs/dom/elements/template_element.h
+++ b/bridge/bindings/qjs/dom/elements/template_element.h
@@ -11,7 +11,7 @@
 
 namespace kraken::binding::qjs {
 
-void bindTemplateElement(std::unique_ptr<ExecutionContext>& context);
+void bindTemplateElement(ExecutionContext* context);
 class TemplateElementInstance;
 
 class TemplateElement : public Element {

--- a/bridge/bindings/qjs/dom/event.cc
+++ b/bridge/bindings/qjs/dom/event.cc
@@ -13,8 +13,8 @@ namespace kraken::binding::qjs {
 
 std::once_flag kEventInitOnceFlag;
 
-void bindEvent(std::unique_ptr<ExecutionContext>& context) {
-  auto* constructor = Event::instance(context.get());
+void bindEvent(ExecutionContext* context) {
+  auto* constructor = Event::instance(context);
   context->defineGlobalProperty("Event", constructor->jsObject);
 }
 

--- a/bridge/bindings/qjs/dom/event.h
+++ b/bridge/bindings/qjs/dom/event.h
@@ -50,7 +50,7 @@ namespace kraken::binding::qjs {
 #define EVENT_LONG_PRESS "longpress"
 #define EVENT_SCALE "scale"
 
-void bindEvent(std::unique_ptr<ExecutionContext>& context);
+void bindEvent(ExecutionContext* context);
 
 class EventInstance;
 

--- a/bridge/bindings/qjs/dom/event_target.cc
+++ b/bridge/bindings/qjs/dom/event_target.cc
@@ -24,8 +24,8 @@ static std::atomic<int32_t> globalEventTargetId{0};
 std::once_flag kEventTargetInitFlag;
 #define GetPropertyCallPreFix "_getProperty_"
 
-void bindEventTarget(std::unique_ptr<ExecutionContext>& context) {
-  auto* constructor = EventTarget::instance(context.get());
+void bindEventTarget(ExecutionContext* context) {
+  auto* constructor = EventTarget::instance(context);
   // Set globalThis and Window's prototype to EventTarget's prototype to support EventTarget methods in global.
   JS_SetPrototype(context->ctx(), context->global(), constructor->jsObject);
   context->defineGlobalProperty("EventTarget", constructor->jsObject);

--- a/bridge/bindings/qjs/dom/event_target.h
+++ b/bridge/bindings/qjs/dom/event_target.h
@@ -26,7 +26,7 @@ class NativeEventTarget;
 class CSSStyleDeclaration;
 class StyleDeclarationInstance;
 
-void bindEventTarget(std::unique_ptr<ExecutionContext>& context);
+void bindEventTarget(ExecutionContext* context);
 
 class EventTarget : public HostClass {
  public:

--- a/bridge/bindings/qjs/dom/event_target_test.cc
+++ b/bridge/bindings/qjs/dom/event_target_test.cc
@@ -19,7 +19,7 @@ TEST(EventTarget, addEventListener) {
     KRAKEN_LOG(VERBOSE) << errmsg;
     errorCalled = true;
   });
-  auto& context = bridge->getContext();
+  auto context = bridge->getContext();
   const char* code = "let div = document.createElement('div'); function f(){ console.log(1234); }; div.addEventListener('click', f); div.dispatchEvent(new Event('click'));";
   bridge->evaluateScript(code, strlen(code), "vm://", 0);
 
@@ -34,7 +34,7 @@ TEST(EventTarget, removeEventListener) {
     KRAKEN_LOG(VERBOSE) << errmsg;
     errorCalled = true;
   });
-  auto& context = bridge->getContext();
+  auto context = bridge->getContext();
   const char* code =
       "let div = document.createElement('div'); function f(){ console.log(1234); }; div.addEventListener('click', f); div.removeEventListener('click', f); div.dispatchEvent(new Event('click'));";
   bridge->evaluateScript(code, strlen(code), "vm://", 0);
@@ -54,7 +54,7 @@ TEST(EventTarget, setNoEventTargetProperties) {
     errorCalled = true;
   });
 
-  auto& context = bridge->getContext();
+  auto context = bridge->getContext();
   const char* code = "let div = document.createElement('div'); div._a = { name: 1}; console.log(div._a); document.body.appendChild(div);";
   bridge->evaluateScript(code, strlen(code), "vm://", 0);
   EXPECT_EQ(errorCalled, false);
@@ -71,7 +71,7 @@ TEST(EventTarget, propertyEventHandler) {
     KRAKEN_LOG(VERBOSE) << errmsg;
     errorCalled = true;
   });
-  auto& context = bridge->getContext();
+  auto context = bridge->getContext();
   const char* code =
       "let div = document.createElement('div'); "
       "div.onclick = function() { return 1234; };"
@@ -91,7 +91,7 @@ TEST(EventTarget, setUnExpectedAttributeEventHandler) {
     KRAKEN_LOG(VERBOSE) << errmsg;
     errorCalled = true;
   });
-  auto& context = bridge->getContext();
+  auto context = bridge->getContext();
   const char* code =
       "let div = document.createElement('div'); "
       "div.onclick = function() { return 1234; };"
@@ -114,7 +114,7 @@ TEST(EventTarget, propertyEventOnWindow) {
     KRAKEN_LOG(VERBOSE) << errmsg;
     errorCalled = true;
   });
-  auto& context = bridge->getContext();
+  auto context = bridge->getContext();
   const char* code =
       "window.onclick = function() { console.log(1234); };"
       "window.dispatchEvent(new Event('click'));";
@@ -134,7 +134,7 @@ TEST(EventTarget, asyncFunctionCallback) {
     KRAKEN_LOG(VERBOSE) << errmsg;
     errorCalled = true;
   });
-  auto& context = bridge->getContext();
+  auto context = bridge->getContext();
   std::string code = R"(
     const img = document.createElement('img');
     img.style.width = '100px';
@@ -176,7 +176,7 @@ TEST(EventTarget, ClassInheritEventTarget) {
     KRAKEN_LOG(VERBOSE) << errmsg;
     errorCalled = true;
   });
-  auto& context = bridge->getContext();
+  auto context = bridge->getContext();
   std::string code = std::string(R"(
 class Sample extends EventTarget {
   constructor() {
@@ -211,7 +211,7 @@ TEST(EventTarget, dispatchEventOnGC) {
     EXPECT_STREQ(message.c_str(), "1234");
   };
   auto bridge = TEST_init([](int32_t contextId, const char* errmsg) { errorCalled = true; });
-  auto& context = bridge->getContext();
+  auto context = bridge->getContext();
   std::string code = std::string(R"(
 {
 // Wrap div in a block scope will be freed by GC
@@ -238,7 +238,7 @@ setTimeout(() => {});
   // Run gc to trigger eventTarget been disposed by GC.
   JS_RunGC(context->runtime());
 
-  TEST_runLoop(context.get());
+  TEST_runLoop(context);
 
   EXPECT_EQ(errorCalled, false);
   EXPECT_EQ(logCalled, true);

--- a/bridge/bindings/qjs/dom/event_test.cc
+++ b/bridge/bindings/qjs/dom/event_test.cc
@@ -16,7 +16,7 @@ TEST(MouseEvent, init) {
     logCalled = true;
   };
   auto bridge = TEST_init([](int32_t contextId, const char* errmsg) { errorCalled = true; });
-  auto& context = bridge->getContext();
+  auto context = bridge->getContext();
   const char* code = "let mouseEvent = new MouseEvent('click', {clientX: 10, clientY: 20}); console.log(mouseEvent.clientX);";
   bridge->evaluateScript(code, strlen(code), "vm://", 0);
 

--- a/bridge/bindings/qjs/dom/events/touch_event.cc
+++ b/bridge/bindings/qjs/dom/events/touch_event.cc
@@ -9,8 +9,8 @@
 
 namespace kraken::binding::qjs {
 
-void bindTouchEvent(std::unique_ptr<ExecutionContext>& context) {
-  auto* constructor = TouchEvent::instance(context.get());
+void bindTouchEvent(ExecutionContext* context) {
+  auto* constructor = TouchEvent::instance(context);
   context->defineGlobalProperty("TouchEvent", constructor->jsObject);
 }
 

--- a/bridge/bindings/qjs/dom/events/touch_event.h
+++ b/bridge/bindings/qjs/dom/events/touch_event.h
@@ -10,7 +10,7 @@
 
 namespace kraken::binding::qjs {
 
-void bindTouchEvent(std::unique_ptr<ExecutionContext>& context);
+void bindTouchEvent(ExecutionContext* context);
 
 struct NativeTouch {
   int64_t identifier;

--- a/bridge/bindings/qjs/dom/node.cc
+++ b/bridge/bindings/qjs/dom/node.cc
@@ -14,8 +14,8 @@
 
 namespace kraken::binding::qjs {
 
-void bindNode(std::unique_ptr<ExecutionContext>& context) {
-  auto* constructor = Node::instance(context.get());
+void bindNode(ExecutionContext* context) {
+  auto* constructor = Node::instance(context);
   context->defineGlobalProperty("Node", constructor->jsObject);
 }
 

--- a/bridge/bindings/qjs/dom/node.h
+++ b/bridge/bindings/qjs/dom/node.h
@@ -13,7 +13,7 @@
 
 namespace kraken::binding::qjs {
 
-void bindNode(std::unique_ptr<ExecutionContext>& context);
+void bindNode(ExecutionContext* context);
 
 enum NodeType { ELEMENT_NODE = 1, TEXT_NODE = 3, COMMENT_NODE = 8, DOCUMENT_NODE = 9, DOCUMENT_TYPE_NODE = 10, DOCUMENT_FRAGMENT_NODE = 11 };
 

--- a/bridge/bindings/qjs/dom/node_test.cc
+++ b/bridge/bindings/qjs/dom/node_test.cc
@@ -16,7 +16,7 @@ TEST(Node, appendChild) {
     logCalled = true;
   };
   auto bridge = TEST_init([](int32_t contextId, const char* errmsg) { errorCalled = true; });
-  auto& context = bridge->getContext();
+  auto context = bridge->getContext();
   const char* code =
       "let div = document.createElement('div');"
       "document.body.appendChild(div);"
@@ -35,7 +35,7 @@ TEST(Node, childNodes) {
     logCalled = true;
   };
   auto bridge = TEST_init([](int32_t contextId, const char* errmsg) { errorCalled = true; });
-  auto& context = bridge->getContext();
+  auto context = bridge->getContext();
   const char* code =
       "let div1 = document.createElement('div');"
       "let div2 = document.createElement('div');"
@@ -60,7 +60,7 @@ TEST(Node, textContent) {
     logCalled = true;
   };
   auto bridge = TEST_init([](int32_t contextId, const char* errmsg) { errorCalled = true; });
-  auto& context = bridge->getContext();
+  auto context = bridge->getContext();
   const char* code =
       "let text1 = document.createTextNode('1234');"
       "let text2 = document.createTextNode('helloworld');"
@@ -82,7 +82,7 @@ TEST(Node, setTextContent) {
     logCalled = true;
   };
   auto bridge = TEST_init([](int32_t contextId, const char* errmsg) { errorCalled = true; });
-  auto& context = bridge->getContext();
+  auto context = bridge->getContext();
   const char* code =
       "let div = document.createElement('div');"
       "div.textContent = '1234';"
@@ -101,7 +101,7 @@ TEST(Node, ensureDetached) {
     logCalled = true;
   };
   auto bridge = TEST_init([](int32_t contextId, const char* errmsg) { errorCalled = true; });
-  auto& context = bridge->getContext();
+  auto context = bridge->getContext();
   const char* code =
       "let div = document.createElement('div');"
       "document.body.appendChild(div);"
@@ -123,7 +123,7 @@ TEST(Node, replaceBody) {
     KRAKEN_LOG(VERBOSE) << errmsg;
     errorCalled = true;
   });
-  auto& context = bridge->getContext();
+  auto context = bridge->getContext();
   const char* code = "document.body = document.createElement('body');";
   bridge->evaluateScript(code, strlen(code), "vm://", 0);
 
@@ -158,7 +158,7 @@ console.log(div.style.width == div2.style.height, div.getAttribute('id') == '123
     KRAKEN_LOG(VERBOSE) << errmsg;
     errorCalled = true;
   });
-  auto& context = bridge->getContext();
+  auto context = bridge->getContext();
   bridge->evaluateScript(code.c_str(), code.size(), "vm://", 0);
 
   EXPECT_EQ(errorCalled, false);
@@ -206,7 +206,7 @@ console.log(
     KRAKEN_LOG(VERBOSE) << errmsg;
     errorCalled = true;
   });
-  auto& context = bridge->getContext();
+  auto context = bridge->getContext();
   bridge->evaluateScript(code.c_str(), code.size(), "vm://", 0);
 
   EXPECT_EQ(errorCalled, false);

--- a/bridge/bindings/qjs/dom/style_declaration.cc
+++ b/bridge/bindings/qjs/dom/style_declaration.cc
@@ -11,8 +11,8 @@ namespace kraken::binding::qjs {
 
 std::once_flag kinitCSSStyleDeclarationFlag;
 
-void bindCSSStyleDeclaration(std::unique_ptr<ExecutionContext>& context) {
-  auto style = CSSStyleDeclaration::instance(context.get());
+void bindCSSStyleDeclaration(ExecutionContext* context) {
+  auto style = CSSStyleDeclaration::instance(context);
   context->defineGlobalProperty("CSSStyleDeclaration", style->jsObject);
 }
 

--- a/bridge/bindings/qjs/dom/style_declaration.h
+++ b/bridge/bindings/qjs/dom/style_declaration.h
@@ -11,7 +11,7 @@
 namespace kraken::binding::qjs {
 
 class EventTargetInstance;
-void bindCSSStyleDeclaration(std::unique_ptr<ExecutionContext>& context);
+void bindCSSStyleDeclaration(ExecutionContext* context);
 
 template <typename CharacterType>
 inline bool isASCIILower(CharacterType character) {

--- a/bridge/bindings/qjs/dom/text_node.cc
+++ b/bridge/bindings/qjs/dom/text_node.cc
@@ -11,8 +11,8 @@ namespace kraken::binding::qjs {
 
 std::once_flag kTextNodeInitFlag;
 
-void bindTextNode(std::unique_ptr<ExecutionContext>& context) {
-  auto* constructor = TextNode::instance(context.get());
+void bindTextNode(ExecutionContext* context) {
+  auto* constructor = TextNode::instance(context);
   context->defineGlobalProperty("Text", constructor->jsObject);
 }
 

--- a/bridge/bindings/qjs/dom/text_node.h
+++ b/bridge/bindings/qjs/dom/text_node.h
@@ -12,7 +12,7 @@ namespace kraken::binding::qjs {
 
 class TextNodeInstance;
 
-void bindTextNode(std::unique_ptr<ExecutionContext>& context);
+void bindTextNode(ExecutionContext* context);
 
 class TextNode : public Node {
  public:

--- a/bridge/bindings/qjs/dom/text_node_test.cc
+++ b/bridge/bindings/qjs/dom/text_node_test.cc
@@ -19,7 +19,7 @@ TEST(TextNode, instanceofNode) {
     KRAKEN_LOG(VERBOSE) << errmsg;
     errorCalled = true;
   });
-  auto& context = bridge->getContext();
+  auto context = bridge->getContext();
   const char* code =
       "let text = document.createTextNode('1234');"
       "console.log(text instanceof Node, text instanceof Text);";

--- a/bridge/bindings/qjs/executing_context.cc
+++ b/bridge/bindings/qjs/executing_context.cc
@@ -44,7 +44,6 @@ JSClassID ExecutionContextGCTracker::contextGcTrackerClassId{0};
 ExecutionContext::ExecutionContext(int32_t contextId, const JSExceptionHandler& handler, void* owner)
     : contextId(contextId), _handler(handler), owner(owner), ctxInvalid_(false), uniqueId(context_unique_id++) {
   // @FIXME: maybe contextId will larger than MAX_JS_CONTEXT
-  KRAKEN_LOG(VERBOSE) << "Create new ExectionContext " << this;
   valid_contexts[contextId] = true;
   if (contextId > running_context_list)
     running_context_list = contextId;
@@ -149,7 +148,6 @@ ExecutionContext::~ExecutionContext() {
   }
 #endif
   m_ctx = nullptr;
-  KRAKEN_LOG(VERBOSE) << "Free ExectionContext " << this;
 }
 
 bool ExecutionContext::evaluateJavaScript(const uint16_t* code, size_t codeLength, const char* sourceURL, int startLine) {

--- a/bridge/bindings/qjs/executing_context.cc
+++ b/bridge/bindings/qjs/executing_context.cc
@@ -44,6 +44,7 @@ JSClassID ExecutionContextGCTracker::contextGcTrackerClassId{0};
 ExecutionContext::ExecutionContext(int32_t contextId, const JSExceptionHandler& handler, void* owner)
     : contextId(contextId), _handler(handler), owner(owner), ctxInvalid_(false), uniqueId(context_unique_id++) {
   // @FIXME: maybe contextId will larger than MAX_JS_CONTEXT
+  KRAKEN_LOG(VERBOSE) << "Create new ExectionContext " << this;
   valid_contexts[contextId] = true;
   if (contextId > running_context_list)
     running_context_list = contextId;
@@ -148,6 +149,7 @@ ExecutionContext::~ExecutionContext() {
   }
 #endif
   m_ctx = nullptr;
+  KRAKEN_LOG(VERBOSE) << "Free ExectionContext " << this;
 }
 
 bool ExecutionContext::evaluateJavaScript(const uint16_t* code, size_t codeLength, const char* sourceURL, int startLine) {

--- a/bridge/bindings/qjs/host_class_test.cc
+++ b/bridge/bindings/qjs/host_class_test.cc
@@ -72,9 +72,9 @@ TEST(HostClass, newInstance) {
     KRAKEN_LOG(VERBOSE) << errmsg;
     errorCalled = true;
   });
-  auto& context = bridge->getContext();
-  auto* sampleObject = new SampleClass(context.get());
-  auto* parentObject = ParentClass::instance(context.get());
+  auto context = bridge->getContext();
+  auto* sampleObject = new SampleClass(context);
+  auto* parentObject = ParentClass::instance(context);
   context->defineGlobalProperty("SampleClass", sampleObject->jsObject);
   context->defineGlobalProperty("ParentClass", parentObject->jsObject);
   const char* code = "let obj = new SampleClass(1,2,3,4); console.log(obj.f())";
@@ -95,9 +95,9 @@ TEST(HostClass, instanceOf) {
     errorCalled = true;
     KRAKEN_LOG(VERBOSE) << errmsg;
   });
-  auto& context = bridge->getContext();
-  auto* sampleObject = new SampleClass(context.get());
-  auto* parentObject = ParentClass::instance(context.get());
+  auto context = bridge->getContext();
+  auto* sampleObject = new SampleClass(context);
+  auto* parentObject = ParentClass::instance(context);
   // Test for C API
   context->defineGlobalProperty("SampleClass", sampleObject->jsObject);
   context->defineGlobalProperty("ParentClass", parentObject->jsObject);
@@ -126,10 +126,10 @@ TEST(HostClass, inheritance) {
     errorCalled = true;
     KRAKEN_LOG(VERBOSE) << errmsg;
   });
-  auto& context = bridge->getContext();
-  auto* sampleObject = new SampleClass(context.get());
+  auto context = bridge->getContext();
+  auto* sampleObject = new SampleClass(context);
 
-  auto* parentObject = ParentClass::instance(context.get());
+  auto* parentObject = ParentClass::instance(context);
   context->defineGlobalProperty("ParentClass", parentObject->jsObject);
 
   context->defineGlobalProperty("SampleClass", sampleObject->jsObject);
@@ -154,10 +154,10 @@ TEST(HostClass, inherintanceInJavaScript) {
     errorCalled = true;
     KRAKEN_LOG(VERBOSE) << errmsg;
   });
-  auto& context = bridge->getContext();
-  auto* sampleObject = new SampleClass(context.get());
+  auto context = bridge->getContext();
+  auto* sampleObject = new SampleClass(context);
 
-  auto* parentObject = ParentClass::instance(context.get());
+  auto* parentObject = ParentClass::instance(context);
   context->defineGlobalProperty("ParentClass", parentObject->jsObject);
 
   context->defineGlobalProperty("SampleClass", sampleObject->jsObject);
@@ -193,8 +193,8 @@ TEST(HostClass, haveFunctionProtoMethods) {
     errorCalled = true;
     KRAKEN_LOG(VERBOSE) << errmsg;
   });
-  auto& context = bridge->getContext();
-  auto* parentObject = ParentClass::instance(context.get());
+  auto context = bridge->getContext();
+  auto* parentObject = ParentClass::instance(context);
   context->defineGlobalProperty("ParentClass", parentObject->jsObject);
 
   const char* code = R"(
@@ -222,14 +222,14 @@ TEST(HostClass, multipleInstance) {
     errorCalled = true;
     KRAKEN_LOG(VERBOSE) << errmsg;
   });
-  auto& context = bridge->getContext();
+  auto context = bridge->getContext();
 
-  auto* parentObject = ParentClass::instance(context.get());
+  auto* parentObject = ParentClass::instance(context);
   context->defineGlobalProperty("ParentClass", parentObject->jsObject);
 
   // Test for C API 1
   {
-    auto* sampleObject = new SampleClass(context.get());
+    auto* sampleObject = new SampleClass(context);
     context->defineGlobalProperty("SampleClass1", sampleObject->jsObject);
     JSValue args[] = {};
     JSValue object = JS_CallConstructor(context->ctx(), sampleObject->jsObject, 0, args);
@@ -240,7 +240,7 @@ TEST(HostClass, multipleInstance) {
 
   // Test for C API 2
   {
-    auto* sampleObject = new SampleClass(context.get());
+    auto* sampleObject = new SampleClass(context);
     context->defineGlobalProperty("SampleClass2", sampleObject->jsObject);
     JSValue args[] = {};
     JSValue object = JS_CallConstructor(context->ctx(), sampleObject->jsObject, 0, args);
@@ -250,7 +250,7 @@ TEST(HostClass, multipleInstance) {
   }
 
   {
-    auto* sampleObject = new SampleClass(context.get());
+    auto* sampleObject = new SampleClass(context);
     context->defineGlobalProperty("SampleClass3", sampleObject->jsObject);
     JSValue args[] = {};
     JSValue object = JS_CallConstructor(context->ctx(), sampleObject->jsObject, 0, args);
@@ -260,7 +260,7 @@ TEST(HostClass, multipleInstance) {
   }
 
   {
-    auto* sampleObject = new SampleClass(context.get());
+    auto* sampleObject = new SampleClass(context);
     context->defineGlobalProperty("SampleClass4", sampleObject->jsObject);
     JSValue args[] = {};
     JSValue object = JS_CallConstructor(context->ctx(), sampleObject->jsObject, 0, args);
@@ -367,8 +367,8 @@ TEST(HostClass, exoticClass) {
     EXPECT_STREQ(message.c_str(), "10");
   };
 
-  auto& context = bridge->getContext();
-  auto* constructor = new ExoticClass(context.get());
+  auto context = bridge->getContext();
+  auto* constructor = new ExoticClass(context);
   context->defineGlobalProperty("ExoticClass", constructor->jsObject);
 
   std::string code =
@@ -395,8 +395,8 @@ TEST(HostClass, setExoticClassProperty) {
     EXPECT_STREQ(message.c_str(), "200");
   };
 
-  auto& context = bridge->getContext();
-  auto* constructor = new ExoticClass(context.get());
+  auto context = bridge->getContext();
+  auto* constructor = new ExoticClass(context);
   context->defineGlobalProperty("ExoticClass", constructor->jsObject);
 
   std::string code =

--- a/bridge/bindings/qjs/host_object_test.cc
+++ b/bridge/bindings/qjs/host_object_test.cc
@@ -54,8 +54,8 @@ TEST(HostObject, defineProperty) {
     EXPECT_STREQ(message.c_str(), "{f: ƒ (), foo: 1}");
   };
   auto bridge = TEST_init([](int32_t contextId, const char* errmsg) { errorCalled = true; });
-  auto& context = bridge->getContext();
-  auto* sampleObject = new SampleObject(context.get());
+  auto context = bridge->getContext();
+  auto* sampleObject = new SampleObject(context);
   JSValue object = sampleObject->jsObject;
   context->defineGlobalProperty("o", object);
   const char* code = "o.foo++; console.log(o);";
@@ -76,8 +76,8 @@ TEST(ObjectProperty, worksWithProxy) {
     KRAKEN_LOG(VERBOSE) << errmsg;
     errorCalled = true;
   });
-  auto& context = bridge->getContext();
-  auto* sampleObject = new SampleObject(context.get());
+  auto context = bridge->getContext();
+  auto* sampleObject = new SampleObject(context);
   JSValue object = sampleObject->jsObject;
   context->defineGlobalProperty("o", object);
   std::string code = std::string(R"(
@@ -105,8 +105,8 @@ TEST(HostObject, defineFunction) {
     KRAKEN_LOG(VERBOSE) << errmsg;
     errorCalled = true;
   });
-  auto& context = bridge->getContext();
-  auto* sampleObject = new SampleObject(context.get());
+  auto context = bridge->getContext();
+  auto* sampleObject = new SampleObject(context);
   JSValue object = sampleObject->jsObject;
   context->defineGlobalProperty("o", object);
   const char* code = "console.log(o.f(10))";
@@ -146,8 +146,8 @@ TEST(ExoticHostObject, overriteGetterSetter) {
     KRAKEN_LOG(VERBOSE) << errmsg;
     errorCalled = true;
   });
-  auto& context = bridge->getContext();
-  auto* sampleObject = new SampleExoticHostObject(context.get());
+  auto context = bridge->getContext();
+  auto* sampleObject = new SampleExoticHostObject(context);
   JSValue object = sampleObject->jsObject;
   context->defineGlobalProperty("o", object);
   const char* code = "console.log(o.abc)";

--- a/bridge/bindings/qjs/module_manager.cc
+++ b/bridge/bindings/qjs/module_manager.cc
@@ -162,7 +162,7 @@ JSValue flushUICommand(JSContext* ctx, JSValueConst this_val, int argc, JSValueC
   return JS_NULL;
 }
 
-void bindModuleManager(std::unique_ptr<ExecutionContext>& context) {
+void bindModuleManager(ExecutionContext* context) {
   QJS_GLOBAL_BINDING_FUNCTION(context, krakenModuleListener, "__kraken_module_listener__", 1);
   QJS_GLOBAL_BINDING_FUNCTION(context, krakenInvokeModule, "__kraken_invoke_module__", 3);
   QJS_GLOBAL_BINDING_FUNCTION(context, flushUICommand, "__kraken_flush_ui_command__", 0);

--- a/bridge/bindings/qjs/module_manager.h
+++ b/bridge/bindings/qjs/module_manager.h
@@ -16,7 +16,7 @@ struct ModuleContext {
   list_head link;
 };
 
-void bindModuleManager(std::unique_ptr<ExecutionContext>& context);
+void bindModuleManager(ExecutionContext* context);
 void handleInvokeModuleUnexpectedCallback(void* callbackContext, int32_t contextId, NativeString* errmsg, NativeString* json);
 }  // namespace kraken::binding::qjs
 

--- a/bridge/bindings/qjs/module_manager_test.cc
+++ b/bridge/bindings/qjs/module_manager_test.cc
@@ -20,7 +20,7 @@ TEST(ModuleManager, shouldThrowErrorWhenBadJSON) {
   });
   kraken::KrakenPage::consoleMessageHandler = [](void* ctx, const std::string& message, int logLevel) {};
 
-  auto& context = bridge->getContext();
+  auto context = bridge->getContext();
 
   std::string code = std::string(R"(
 let object = {

--- a/bridge/kraken_bridge.cc
+++ b/bridge/kraken_bridge.cc
@@ -107,9 +107,8 @@ void disposePage(int32_t contextId) {
     return;
 
   auto* page = static_cast<kraken::KrakenPage*>(kraken::KrakenPage::pageContextPool[contextId]);
-  // In order to avoid accessing pageContextPool when the page is being released. We need to clear the value in pageContextPool before releasing.
-  kraken::KrakenPage::pageContextPool[contextId] = nullptr;
   delete page;
+  kraken::KrakenPage::pageContextPool[contextId] = nullptr;
 }
 
 int32_t allocateNewPage(int32_t targetContextId) {
@@ -142,7 +141,7 @@ bool checkPage(int32_t contextId, void* context) {
   if (kraken::KrakenPage::pageContextPool[contextId] == nullptr)
     return false;
   auto* page = static_cast<kraken::KrakenPage*>(getPage(contextId));
-  return page->getContext().get() == context;
+  return page->getContext() == context;
 }
 
 void evaluateScripts(int32_t contextId, NativeString* code, const char* bundleFilename, int startLine) {

--- a/bridge/page.h
+++ b/bridge/page.h
@@ -43,7 +43,7 @@ class KrakenPage final {
   uint8_t* dumpByteCode(const char* script, size_t length, const char* url, size_t* byteLength);
   void evaluateByteCode(uint8_t* bytes, size_t byteLength);
 
-  [[nodiscard]] const std::unique_ptr<kraken::binding::qjs::ExecutionContext>& getContext() const { return m_context; }
+  [[nodiscard]] kraken::binding::qjs::ExecutionContext* getContext() const { return m_context; }
 
   void invokeModuleEvent(NativeString* moduleName, const char* eventType, void* event, NativeString* extra);
   void reportError(const char* errmsg);
@@ -55,7 +55,9 @@ class KrakenPage final {
   JSBridgeDisposeCallback disposeCallback{nullptr};
 #endif
  private:
-  std::unique_ptr<binding::qjs::ExecutionContext> m_context;
+  // FIXME: we must to use raw pointer instead of unique_ptr because we needs to access m_context when dispose page.
+  // TODO: Raw pointer is dangerous and just works but it's fragile. We needs refactor this for more stable and maintainable.
+  binding::qjs::ExecutionContext* m_context;
   JSExceptionHandler m_handler;
 };
 

--- a/bridge/page_test.cc
+++ b/bridge/page_test.cc
@@ -266,7 +266,7 @@ void KrakenPageTest::invokeExecuteTest(ExecuteCallback executeCallback) {
     callbackContext->executeCallback(callbackContext->context->getContextId(), status.get());
     return JS_NULL;
   };
-  auto* callbackContext = new ExecuteCallbackContext(m_page_context.get(), executeCallback);
+  auto* callbackContext = new ExecuteCallbackContext(m_page_context, executeCallback);
   executeTestProxyObject = JS_NewObject(m_page_context->ctx());
   JS_SetOpaque(executeTestProxyObject, callbackContext);
   JSValue callbackData[]{executeTestProxyObject};

--- a/bridge/page_test.h
+++ b/bridge/page_test.h
@@ -54,7 +54,7 @@ class KrakenPageTest final {
   /// the pointer of bridge, ownership belongs to JSBridge
   KrakenPage* m_page;
   /// the pointer of JSContext, overship belongs to JSContext
-  const std::unique_ptr<binding::qjs::ExecutionContext>& m_page_context;
+  binding::qjs::ExecutionContext* m_page_context;
 };
 
 }  // namespace kraken

--- a/bridge/scripts/code_generator/src/generate_header.ts
+++ b/bridge/scripts/code_generator/src/generate_header.ts
@@ -111,7 +111,7 @@ ${addIndent(nativeStructPropsCode.join('\n'), 2)}
   }
 
   let constructorHeader = `\n
-void bind${object.name}(std::unique_ptr<ExecutionContext> &context);
+void bind${object.name}(ExecutionContext *context);
 
 class ${object.name}Instance;
 

--- a/bridge/scripts/code_generator/src/genereate_source.ts
+++ b/bridge/scripts/code_generator/src/genereate_source.ts
@@ -424,8 +424,8 @@ ${object.name}::${object.name}(ExecutionContext *context) : ${object.type}(conte
   ${classInheritCode}
 }
 
-void bind${object.name}(std::unique_ptr<ExecutionContext> &context) {
-  auto *constructor = ${object.name}::instance(context.get());
+void bind${object.name}(ExecutionContext* context) {
+  auto *constructor = ${object.name}::instance(context);
   context->defineGlobalProperty("${globalBindingName}", constructor->jsObject);
   ${specialBind}
 }

--- a/bridge/test/kraken_test_env.cc
+++ b/bridge/test/kraken_test_env.cc
@@ -122,14 +122,14 @@ uint32_t TEST_requestAnimationFrame(FrameCallback* frameCallback, int32_t contex
 
 void TEST_cancelAnimationFrame(int32_t contextId, int32_t id) {
   auto* page = static_cast<kraken::KrakenPage*>(getPage(contextId));
-  auto* context = page->getContext().get();
+  auto* context = page->getContext();
   JSThreadState* ts = static_cast<JSThreadState*>(JS_GetRuntimeOpaque(context->runtime()));
   ts->os_frameCallbacks.erase(id);
 }
 
 void TEST_clearTimeout(int32_t contextId, int32_t timerId) {
   auto* page = static_cast<kraken::KrakenPage*>(getPage(contextId));
-  auto* context = page->getContext().get();
+  auto* context = page->getContext();
   JSThreadState* ts = static_cast<JSThreadState*>(JS_GetRuntimeOpaque(context->runtime()));
   ts->os_timers.erase(timerId);
 }
@@ -178,7 +178,7 @@ std::unique_ptr<kraken::KrakenPage> TEST_init(OnJSError onJsError) {
   });
   initTestFramework(contextId);
   auto* page = static_cast<kraken::KrakenPage*>(getPage(contextId));
-  auto* context = page->getContext().get();
+  auto* context = page->getContext();
   JSThreadState* th = new JSThreadState();
   JS_SetRuntimeOpaque(context->runtime(), th);
 

--- a/kraken/lib/src/launcher/controller.dart
+++ b/kraken/lib/src/launcher/controller.dart
@@ -945,16 +945,14 @@ class KrakenController {
 
   Future<void> unload() async {
     assert(!_view._disposed, 'Kraken have already disposed');
-    _module.dispose();
-    _view.dispose();
-
     // Should clear previous page cached ui commands
     clearUICommand(_view.contextId);
 
     // Wait for next microtask to make sure C++ native Elements are GC collected.
     Completer completer = Completer();
     Future.microtask(() {
-      disposePage(_view.contextId);
+      _module.dispose();
+      _view.dispose();
 
       allocateNewPage(_view.contextId);
 
@@ -963,7 +961,10 @@ class KrakenController {
           enableDebug: _view.enableDebug,
           contextId: _view.contextId,
           rootController: this,
-          navigationDelegate: _view.navigationDelegate);
+          navigationDelegate: _view.navigationDelegate,
+          gestureListener: _view.gestureListener,
+          widgetDelegate: _view.widgetDelegate
+      );
 
       _module = KrakenModuleController(this, _view.contextId);
 


### PR DESCRIPTION
Fixed #1100

https://github.com/openkraken/kraken/pull/1081/files#diff-a21b93f4669388bbfdaff8b8f333f82a26d15b2b7212b990314296c47d1fe93eR111 设置为 nullptr 会导致销毁页面过程中，调用 flushUICommand() 所依赖的 getUICommandItems() 返回为 nullptr， 从而使得 JS 侧 eventTarget 已经被销毁，而 Dart 没有收到指令无法销毁，进行双方不一致导致 crash。