### PR TITLE
fix: fix page reload.

### DIFF
--- a/kraken/lib/src/bridge/from_native.dart
+++ b/kraken/lib/src/bridge/from_native.dart
@@ -132,11 +132,11 @@ final Pointer<NativeFunction<NativeInvokeModule>> _nativeInvokeModule = Pointer.
 // Register reloadApp
 typedef NativeReloadApp = Void Function(Int32 contextId);
 
-void _reloadApp(int contextId) {
+void _reloadApp(int contextId) async {
   KrakenController controller = KrakenController.getControllerOfJSContextId(contextId)!;
 
   try {
-    controller.reload();
+    await controller.reload();
   } catch (e, stack) {
     print('Dart Error: $e\n$stack');
   }

--- a/kraken/lib/src/dom/element.dart
+++ b/kraken/lib/src/dom/element.dart
@@ -706,10 +706,6 @@ class Element extends Node
 
     willDetachRenderer();
 
-    for (Node child in childNodes) {
-      child.disposeRenderObject();
-    }
-
     didDetachRenderer();
 
     // Call dispose method of renderBoxModel when it is detached from tree.

--- a/kraken/lib/src/dom/element.dart
+++ b/kraken/lib/src/dom/element.dart
@@ -701,10 +701,17 @@ class Element extends Node
 
   /// Release any resources held by [renderBoxModel].
   @override
-  void disposeRenderObject() {
+  void disposeRenderObject({ bool deep = false }) {
     if (renderBoxModel == null) return;
 
     willDetachRenderer();
+
+    // Dispose all renderObject when deep.
+    if (deep) {
+      for (Node child in childNodes) {
+        child.disposeRenderObject(deep: true);
+      }
+    }
 
     didDetachRenderer();
 

--- a/kraken/lib/src/dom/node.dart
+++ b/kraken/lib/src/dom/node.dart
@@ -141,7 +141,7 @@ abstract class Node extends EventTarget implements RenderObjectNode, LifecycleCa
   void attachTo(Element parent, {RenderBox? after}) {}
 
   /// Release any resources held by referenced render object.
-  void disposeRenderObject() {}
+  void disposeRenderObject({ bool deep = false}) {}
 
   /// Release any resources held by this node.
   @override

--- a/kraken/lib/src/dom/sliver_manager.dart
+++ b/kraken/lib/src/dom/sliver_manager.dart
@@ -98,7 +98,7 @@ class RenderSliverElementChildManager implements RenderSliverBoxChildManager {
       if (index < renderNodes.length) {
         renderNodes
             .elementAt(index)
-            .disposeRenderObject();
+            .disposeRenderObject(deep: true);
         return;
       }
     }

--- a/kraken/lib/src/dom/text_node.dart
+++ b/kraken/lib/src/dom/text_node.dart
@@ -97,7 +97,7 @@ class TextNode extends Node {
 
   // Detach renderObject of current node from parent
   @override
-  void disposeRenderObject() {
+  void disposeRenderObject({ bool deep = false }) {
     detach();
     _renderTextBox = null;
   }

--- a/kraken/lib/src/launcher/controller.dart
+++ b/kraken/lib/src/launcher/controller.dart
@@ -111,6 +111,8 @@ class KrakenViewController
     this.navigationDelegate,
     this.gestureListener,
     this.widgetDelegate,
+    // Viewport won't change when kraken page reload, should reuse previous page's viewportBox.
+    RenderViewportBox? originalViewport
   }) {
     if (enableDebug) {
       debugDefaultTargetPlatformOverride = TargetPlatform.fuchsia;
@@ -128,11 +130,18 @@ class KrakenViewController
       PerformanceTiming.instance().mark(PERF_CREATE_VIEWPORT_START);
     }
 
-    viewport = RenderViewportBox(
+    if (originalViewport != null) {
+      // Should update to newlast controller.
+      originalViewport.controller = rootController;
+      viewport = originalViewport;
+    } else {
+      viewport = RenderViewportBox(
         background: background,
         viewportSize: Size(viewportWidth, viewportHeight),
         gestureListener: gestureListener,
-        controller: rootController);
+        controller: rootController
+      );
+    }
 
     if (kProfileMode) {
       PerformanceTiming.instance().mark(PERF_CREATE_VIEWPORT_END);
@@ -957,13 +966,14 @@ class KrakenController {
       allocateNewPage(_view.contextId);
 
       _view = KrakenViewController(view.viewportWidth, view.viewportHeight,
-          background: _view.background,
-          enableDebug: _view.enableDebug,
-          contextId: _view.contextId,
-          rootController: this,
-          navigationDelegate: _view.navigationDelegate,
-          gestureListener: _view.gestureListener,
-          widgetDelegate: _view.widgetDelegate
+        background: _view.background,
+        enableDebug: _view.enableDebug,
+        contextId: _view.contextId,
+        rootController: this,
+        navigationDelegate: _view.navigationDelegate,
+        gestureListener: _view.gestureListener,
+        widgetDelegate: _view.widgetDelegate,
+        originalViewport: _view.viewport
       );
 
       _module = KrakenModuleController(this, _view.contextId);


### PR DESCRIPTION
修复页面刷新，RenderViewport 的挂载问题。

Kraken 刷新页面，不会触发 Kraken 外层 Flutter Widget 树的更新。因此需要保留上一个页面 RenderViewportBox，把内部的 RenderObject 都删除，待页面刷新完成，再将新的页面内容，挂载到原先的 RenderViewportBox 下面。

缺乏测试基建，暂时无法写测试，测试基建搭建 @andycall 