### PR TITLE
fix: fix linux dynamic rpath

### DIFF
--- a/scripts/tasks.js
+++ b/scripts/tasks.js
@@ -601,6 +601,10 @@ task('build-linux-kraken-lib', (done) => {
     stdio: 'inherit'
   });
 
+  const libkrakenPath = path.join(paths.bridge, 'build/linux/lib/libkraken.so');
+  // Patch libkraken.so's runtime path.
+  execSync(`chrpath --replace \\$ORIGIN ${libkrakenPath}`, { stdio: 'inherit' });
+
   done();
 });
 


### PR DESCRIPTION
修复 linux binary rpath 路径问题。

使用相对路径可以让 libkraken.so 可以找到 libquickjs.so.