### PR TITLE
chore: remove android cmake

### DIFF
--- a/kraken/android/CMakeLists.txt
+++ b/kraken/android/CMakeLists.txt
@@ -1,3 +1,0 @@
-cmake_minimum_required(VERSION 3.6)
-
-project(app)

--- a/kraken/android/build.gradle
+++ b/kraken/android/build.gradle
@@ -47,15 +47,4 @@ android {
             jniLibs.srcDirs = ['jniLibs']
         }
     }
-
-    // Encapsulates your external native build configurations.
-    externalNativeBuild {
-
-        // Encapsulates your CMake build configurations.
-        cmake {
-
-            // Provides a relative path to your CMake build script.
-            path "CMakeLists.txt"
-        }
-    }
 }


### PR DESCRIPTION
1. Remove android integrate cmake