### PR TITLE
fix: fix exception leak cause globalObject not fully freed.

### DIFF
--- a/bridge/bindings/qjs/bom/window.cc
+++ b/bridge/bindings/qjs/bom/window.cc
@@ -70,10 +70,7 @@ JSValue Window::postMessage(JSContext* ctx, JSValue this_val, int argc, JSValue*
   JS_SetPropertyStr(ctx, messageEventInitValue, "origin", messageOriginValue);
 
   JSValue messageType = JS_NewString(ctx, "message");
-  JSValue arguments[] = {
-    messageType,
-    messageEventInitValue
-  };
+  JSValue arguments[] = {messageType, messageEventInitValue};
 
   JSValue messageEventValue = JS_CallConstructor(ctx, MessageEvent::instance(window->m_context)->jsObject, 2, arguments);
   auto* event = static_cast<MessageEventInstance*>(JS_GetOpaque(messageEventValue, Event::kEventClassID));

--- a/bridge/bindings/qjs/bom/window.cc
+++ b/bridge/bindings/qjs/bom/window.cc
@@ -58,14 +58,16 @@ JSValue Window::scrollBy(JSContext* ctx, JSValue this_val, int argc, JSValue* ar
 
 JSValue Window::postMessage(JSContext* ctx, JSValue this_val, int argc, JSValue* argv) {
   JSValue messageValue = argv[0];
-  // TODO: convert originValue to current src.
-  JSValue originValue = argv[1];
   JSValue globalObjectValue = JS_GetGlobalObject(ctx);
   auto* window = static_cast<WindowInstance*>(JS_GetOpaque(globalObjectValue, Window::classId()));
 
   JSValue messageEventInitValue = JS_NewObject(ctx);
+
+  // TODO: convert originValue to current src.
+  JSValue messageOriginValue = JS_NewString(ctx, "");
+
   JS_SetPropertyStr(ctx, messageEventInitValue, "data", JS_DupValue(ctx, messageValue));
-  JS_SetPropertyStr(ctx, messageEventInitValue, "origin", JS_DupValue(ctx, originValue));
+  JS_SetPropertyStr(ctx, messageEventInitValue, "origin", messageOriginValue);
 
   JSValue messageType = JS_NewString(ctx, "message");
   JSValue arguments[] = {
@@ -81,6 +83,7 @@ JSValue Window::postMessage(JSContext* ctx, JSValue this_val, int argc, JSValue*
   JS_FreeValue(ctx, messageEventValue);
   JS_FreeValue(ctx, messageEventInitValue);
   JS_FreeValue(ctx, globalObjectValue);
+  JS_FreeValue(ctx, messageOriginValue);
   return JS_NULL;
 }
 

--- a/bridge/bindings/qjs/bom/window.cc
+++ b/bridge/bindings/qjs/bom/window.cc
@@ -58,18 +58,26 @@ JSValue Window::scrollBy(JSContext* ctx, JSValue this_val, int argc, JSValue* ar
 
 JSValue Window::postMessage(JSContext* ctx, JSValue this_val, int argc, JSValue* argv) {
   JSValue messageValue = argv[0];
+  // TODO: convert originValue to current src.
   JSValue originValue = argv[1];
   JSValue globalObjectValue = JS_GetGlobalObject(ctx);
   auto* window = static_cast<WindowInstance*>(JS_GetOpaque(globalObjectValue, Window::classId()));
 
   JSValue messageEventInitValue = JS_NewObject(ctx);
   JS_SetPropertyStr(ctx, messageEventInitValue, "data", JS_DupValue(ctx, messageValue));
-  JS_SetPropertyStr(ctx, originValue, "origin", JS_DupValue(ctx, originValue));
+  JS_SetPropertyStr(ctx, messageEventInitValue, "origin", JS_DupValue(ctx, originValue));
 
-  JSValue messageEventValue = JS_CallConstructor(ctx, MessageEvent::instance(window->m_context)->jsObject, 1, &messageEventInitValue);
+  JSValue messageType = JS_NewString(ctx, "message");
+  JSValue arguments[] = {
+    messageType,
+    messageEventInitValue
+  };
+
+  JSValue messageEventValue = JS_CallConstructor(ctx, MessageEvent::instance(window->m_context)->jsObject, 2, arguments);
   auto* event = static_cast<MessageEventInstance*>(JS_GetOpaque(messageEventValue, Event::kEventClassID));
   window->dispatchEvent(event);
 
+  JS_FreeValue(ctx, messageType);
   JS_FreeValue(ctx, messageEventValue);
   JS_FreeValue(ctx, messageEventInitValue);
   JS_FreeValue(ctx, globalObjectValue);

--- a/bridge/bindings/qjs/bom/window_test.cc
+++ b/bridge/bindings/qjs/bom/window_test.cc
@@ -57,3 +57,23 @@ cancelAnimationFrame(id);
   bridge->evaluateScript(code.c_str(), code.size(), "vm://", 0);
   TEST_runLoop(bridge->getContext());
 }
+
+TEST(Window, postMessage) {
+  auto bridge = TEST_init();
+  static bool logCalled = false;
+  kraken::KrakenPage::consoleMessageHandler = [](void* ctx, const std::string& message, int logLevel) {
+    logCalled = true;
+    EXPECT_STREQ(message.c_str(), "{\"data\":1234} ");
+  };
+
+  std::string code = std::string(R"(
+window.onmessage = (message) => {
+  console.log(JSON.stringify(message.data), message.origin);
+};
+window.postMessage({
+  data: 1234
+}, '*');
+)");
+  bridge->evaluateScript(code.c_str(), code.size(), "vm://", 0);
+  EXPECT_EQ(logCalled, true);
+}

--- a/bridge/bindings/qjs/dom/element.cc
+++ b/bridge/bindings/qjs/dom/element.cc
@@ -320,6 +320,8 @@ JSValue Element::toBlob(JSContext* ctx, JSValue this_val, int argc, JSValue* arg
         promiseContext->context->handleException(&blobValue);
       } else {
         JSValue ret = JS_Call(ctx, promiseContext->resolveFunc, promiseContext->promise, 1, &blobValue);
+        promiseContext->context->handleException(&ret);
+        promiseContext->context->drainPendingPromiseJobs();
         JS_FreeValue(ctx, ret);
       }
 
@@ -332,6 +334,8 @@ JSValue Element::toBlob(JSContext* ctx, JSValue this_val, int argc, JSValue* arg
       JSValue errorMessage = JS_NewString(ctx, error);
       JS_SetPropertyStr(ctx, errorObject, "message", errorMessage);
       JSValue ret = JS_Call(ctx, promiseContext->rejectFunc, promiseContext->promise, 1, &errorObject);
+      promiseContext->context->handleException(&ret);
+      promiseContext->context->drainPendingPromiseJobs();
       JS_FreeValue(ctx, errorObject);
       JS_FreeValue(ctx, ret);
     }

--- a/bridge/bindings/qjs/dom/event_target.cc
+++ b/bridge/bindings/qjs/dom/event_target.cc
@@ -232,8 +232,9 @@ bool EventTargetInstance::internalDispatchEvent(EventInstance* eventInstance) {
         JSValue columnValue = JS_NewUint32(m_ctx, 0);
 
         JSValue args[]{messageValue, fileNameValue, lineNumberValue, columnValue, error};
-        JS_Call(m_ctx, handler, eventInstance->jsObject, 5, args);
+        JSValue returnValue = JS_Call(m_ctx, handler, eventInstance->jsObject, 5, args);
         m_context->drainPendingPromiseJobs();
+        m_context->handleException(&returnValue);
 
         JS_FreeValue(m_ctx, error);
         JS_FreeValue(m_ctx, messageValue);

--- a/bridge/bindings/qjs/dom/events/message_event.d.ts
+++ b/bridge/bindings/qjs/dom/events/message_event.d.ts
@@ -3,6 +3,6 @@ type int64 = number;
 
 interface MessageEvent extends Event {
   // @ts-ignore
-  readonly data: string;
+  readonly data: any;
   readonly origin: string;
 }

--- a/bridge/bindings/qjs/dom/frame_request_callback_collection.cc
+++ b/bridge/bindings/qjs/dom/frame_request_callback_collection.cc
@@ -22,6 +22,8 @@ void FrameCallback::fire(double highResTimeStamp) {
   JSValue arguments[] = {JS_NewFloat64(m_ctx, highResTimeStamp)};
 
   JSValue returnValue = JS_Call(m_ctx, m_callback, JS_UNDEFINED, 1, arguments);
+
+  context->drainPendingPromiseJobs();
   JS_FreeValue(m_ctx, m_callback);
 
   if (JS_IsException(returnValue)) {

--- a/bridge/bindings/qjs/executing_context.cc
+++ b/bridge/bindings/qjs/executing_context.cc
@@ -135,6 +135,11 @@ ExecutionContext::~ExecutionContext() {
     }
   }
 
+  // Should free unhandled pending exceptions.
+  JSValue exception = JS_GetException(m_ctx);
+  handleException(&exception);
+  JS_FreeValue(m_ctx, exception);
+
   JS_FreeValue(m_ctx, globalObject);
   JS_FreeContext(m_ctx);
 

--- a/bridge/bindings/qjs/executing_context.cc
+++ b/bridge/bindings/qjs/executing_context.cc
@@ -135,10 +135,13 @@ ExecutionContext::~ExecutionContext() {
     }
   }
 
-  // Should free unhandled pending exceptions.
+  // Check if current context have unhandled exceptions.
   JSValue exception = JS_GetException(m_ctx);
-  handleException(&exception);
-  JS_FreeValue(m_ctx, exception);
+  if (JS_IsObject(exception) || JS_IsException(exception)) {
+    // There must be bugs in native functions from call stack frame. Someone needs to fix it if throws.
+    reportError(exception);
+    assert_m(false, "Unhandled exception found when dispose JSContext.");
+  }
 
   JS_FreeValue(m_ctx, globalObject);
   JS_FreeContext(m_ctx);

--- a/bridge/bindings/qjs/html_parser.cc
+++ b/bridge/bindings/qjs/html_parser.cc
@@ -141,7 +141,9 @@ void HTMLParser::parseProperty(ElementInstance* element, GumboElement* gumboElem
       JSValue setAttributeFunc = JS_GetPropertyStr(ctx, element->jsObject, "setAttribute");
       JSValue arguments[] = {key, value};
 
-      JS_Call(ctx, setAttributeFunc, element->jsObject, 2, arguments);
+      JSValue returnValue = JS_Call(ctx, setAttributeFunc, element->jsObject, 2, arguments);
+      context->drainPendingPromiseJobs();
+      context->handleException(&returnValue);
 
       JS_FreeValue(ctx, setAttributeFunc);
       JS_FreeValue(ctx, key);

--- a/bridge/bindings/qjs/js_context_test.cc
+++ b/bridge/bindings/qjs/js_context_test.cc
@@ -17,7 +17,7 @@ TEST(Context, postMessage) {
   static bool logCalled = false;
   kraken::KrakenPage::consoleMessageHandler = [](void* ctx, const std::string& message, int logLevel) {
     logCalled = true;
-    EXPECT_STREQ(message.c_str(), "{\"data\":1234} *");
+    EXPECT_STREQ(message.c_str(), "{\"data\":1234} ");
   };
 
   std::string code = std::string(R"(

--- a/bridge/bindings/qjs/js_context_test.cc
+++ b/bridge/bindings/qjs/js_context_test.cc
@@ -12,26 +12,6 @@ TEST(Context, isValid) {
   EXPECT_EQ(bridge->getContext()->isValid(), true);
 }
 
-TEST(Context, postMessage) {
-  auto bridge = TEST_init();
-  static bool logCalled = false;
-  kraken::KrakenPage::consoleMessageHandler = [](void* ctx, const std::string& message, int logLevel) {
-    logCalled = true;
-    EXPECT_STREQ(message.c_str(), "{\"data\":1234} ");
-  };
-
-  std::string code = std::string(R"(
-window.onmessage = (message) => {
-  console.log(JSON.stringify(message.data), message.origin);
-};
-window.postMessage({
-  data: 1234
-}, '*');
-)");
-  bridge->evaluateScript(code.c_str(), code.size(), "vm://", 0);
-  EXPECT_EQ(logCalled, true);
-}
-
 TEST(Context, evalWithError) {
   static bool errorHandlerExecuted = false;
   auto errorHandler = [](int32_t contextId, const char* errmsg) {

--- a/bridge/bindings/qjs/native_value.cc
+++ b/bridge/bindings/qjs/native_value.cc
@@ -174,6 +174,7 @@ void anonymousAsyncCallback(void* callbackContext, NativeValue* nativeValue, int
     JSValue value = nativeValueToJSValue(promiseContext->context, *nativeValue);
     JSValue returnValue = JS_Call(context->ctx(), promiseContext->resolveFunc, context->global(), 1, &value);
     context->drainPendingPromiseJobs();
+    context->handleException(&returnValue);
     JS_FreeValue(context->ctx(), value);
     JS_FreeValue(context->ctx(), returnValue);
   } else if (errmsg != nullptr) {
@@ -181,6 +182,7 @@ void anonymousAsyncCallback(void* callbackContext, NativeValue* nativeValue, int
     JS_DefinePropertyValueStr(context->ctx(), error, "message", JS_NewString(context->ctx(), errmsg), JS_PROP_WRITABLE | JS_PROP_CONFIGURABLE);
     JSValue returnValue = JS_Call(context->ctx(), promiseContext->rejectFunc, context->global(), 1, &error);
     context->drainPendingPromiseJobs();
+    context->handleException(&returnValue);
     JS_FreeValue(context->ctx(), error);
     JS_FreeValue(context->ctx(), returnValue);
   }


### PR DESCRIPTION
Fixed #1099

没有释放的 Exception 会导致 globalObject 没有被释放，globalObject 没有释放会导致 GC Tracker 没有释放，GC tracker 没有释放会导致当销毁一个 ExecutionContext 时，基于 JSContext 所创建的对象并没有完全被清空，依然会残留在 GC 的队列里。

待下次执行 GC 的时候，就从没有被回收的对象访问到已经被释放的 JSContext，导致 Crash。

TODO: test