### PR TITLE
refactor: imporove opacity 0

### DIFF
--- a/integration_tests/pubspec.yaml
+++ b/integration_tests/pubspec.yaml
@@ -28,7 +28,7 @@ dependencies:
   kraken: 0.8.0-dev.1
   image: ^3.0.2
   kraken_video_player: ^2.0.0-dev.0
-  kraken_websocket: ^1.0.0
+  kraken_websocket: ^2.0.0
   kraken_webview: ^2.0.0-dev.0
   waterfall_flow: ^3.0.1
 

--- a/kraken/lib/src/css/visibility.dart
+++ b/kraken/lib/src/css/visibility.dart
@@ -21,9 +21,7 @@ mixin CSSVisibilityMixin on RenderStyle {
   @override
   Visibility get visibility => _visibility;
 
-  bool get isVisibilityHidden {
-    return _visibility == Visibility.hidden;
-  }
+  bool get isVisibilityHidden => _visibility == Visibility.hidden;
 
   static Visibility resolveVisibility(String value) {
     switch(value) {

--- a/kraken/lib/src/rendering/box_model.dart
+++ b/kraken/lib/src/rendering/box_model.dart
@@ -1059,13 +1059,16 @@ class RenderBoxModel extends RenderBox
     throw FlutterError('Please impl performPaint of $runtimeType.');
   }
 
+  bool get shouldPaint => !renderStyle.isVisibilityHidden;
+
   @override
   void paint(PaintingContext context, Offset offset) {
     if (kProfileMode && PerformanceTiming.enabled()) {
       childPaintDuration = 0;
       PerformanceTiming.instance().mark(PERF_PAINT_START, uniqueId: hashCode);
     }
-    if (renderStyle.isVisibilityHidden) {
+
+    if (!shouldPaint) {
       if (kProfileMode && PerformanceTiming.enabled()) {
         PerformanceTiming.instance().mark(PERF_PAINT_END, uniqueId: hashCode);
       }

--- a/kraken/lib/src/rendering/box_model.dart
+++ b/kraken/lib/src/rendering/box_model.dart
@@ -1104,9 +1104,13 @@ class RenderBoxModel extends RenderBox
     }
   }
 
-  void paintBoxModel(PaintingContext context, Offset offset) {
+  void paintNothing(PaintingContext context, Offset offset) {}
 
-    if (isScrollingContentBox) {
+  void paintBoxModel(PaintingContext context, Offset offset) {
+    // If opacity to zero, only paint intersection observer.
+    if (alpha == 0) {
+      paintIntersectionObserver(context, offset, paintNothing);
+    } else if (isScrollingContentBox) {
       // Scrolling content box should only size painted.
       performPaint(context, offset);
     } else {

--- a/kraken/lib/src/rendering/intrinsic.dart
+++ b/kraken/lib/src/rendering/intrinsic.dart
@@ -129,8 +129,9 @@ class RenderIntrinsic extends RenderBoxModel
   /// override it to layout box model paint.
   @override
   void paint(PaintingContext context, Offset offset) {
-    if (renderStyle.isVisibilityHidden) return;
-    paintBoxModel(context, offset);
+    if (shouldPaint) {
+      paintBoxModel(context, offset);
+    }
   }
 
   @override

--- a/kraken/lib/src/rendering/opacity.dart
+++ b/kraken/lib/src/rendering/opacity.dart
@@ -12,7 +12,6 @@ mixin RenderOpacityMixin on RenderBox {
 
   int alpha = ui.Color.getAlphaFromOpacity(1.0);
 
-
   final LayerHandle<OpacityLayer> _opacityLayer = LayerHandle<OpacityLayer>();
 
   void disposeOpacityLayer() {
@@ -24,6 +23,13 @@ mixin RenderOpacityMixin on RenderBox {
     if (alpha == 255) {
       _opacityLayer.layer = null;
       // No need to keep the layer. We'll create a new one if necessary.
+      callback(context, offset);
+      return;
+    }
+
+    if (alpha == 0) {
+      // Clip to empty, ignoring all drawing in canvas.
+      context.canvas.clipRect(Rect.zero);
       callback(context, offset);
       return;
     }

--- a/kraken/lib/src/rendering/opacity.dart
+++ b/kraken/lib/src/rendering/opacity.dart
@@ -20,16 +20,10 @@ mixin RenderOpacityMixin on RenderBox {
 
   void paintOpacity(PaintingContext context, Offset offset,
       PaintingContextCallback callback) {
+
     if (alpha == 255) {
       _opacityLayer.layer = null;
       // No need to keep the layer. We'll create a new one if necessary.
-      callback(context, offset);
-      return;
-    }
-
-    if (alpha == 0) {
-      // Clip to empty, ignoring all drawing in canvas.
-      context.canvas.clipRect(Rect.zero);
       callback(context, offset);
       return;
     }


### PR DESCRIPTION
Close #1097   

测试用例复用 opacity 原有用例  

opacity 的改变不会影响元素原先的 appear/disappear 行为, 故不能中止 paint, 所以与 visibility: hidden 处理不同