### PR TITLE
fix: request options not pass through

### DIFF
--- a/kraken/lib/src/foundation/http_client_request.dart
+++ b/kraken/lib/src/foundation/http_client_request.dart
@@ -225,6 +225,14 @@ class ProxyHttpClientRequest extends HttpClientRequest {
     _httpHeaders.forEach(backendRequest.headers.set);
     _httpHeaders.clear();
 
+    // Assign configs for backend request.
+    backendRequest
+        ..bufferOutput = bufferOutput
+        ..contentLength = contentLength
+        ..followRedirects = followRedirects
+        ..persistentConnection = persistentConnection
+        ..maxRedirects = maxRedirects;
+
     _backendRequest = backendRequest;
     return backendRequest;
   }

--- a/kraken/test/fixtures/GET_301
+++ b/kraken/test/fixtures/GET_301
@@ -1,0 +1,15 @@
+HTTP/1.1 301 Moved Permanently
+Content-Type: text/html
+Content-Length: 262
+Connection: keep-alive
+Location: https://www.taobao.com/
+Timing-Allow-Origin: *
+
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
+<html>
+<head><title>301 Moved Permanently</title></head>
+<body>
+<h1>301 Moved Permanently</h1>
+<p>The requested resource has been assigned a new permanent URI.</p>
+<hr/>Powered by Tengine</body>
+</html>

--- a/kraken/test/src/foundation/http_cache.dart
+++ b/kraken/test/src/foundation/http_cache.dart
@@ -197,5 +197,14 @@ void main() {
       expect(response!.headers.value('cache-hits'), 'HIT');
       expect(response.headers.value('x-custom-header'), 'hello-world');
     });
+
+    test('Work with followRedirects: false', () async {
+      var req = await httpClient.openUrl('GET',
+          server.getUri('301'));
+      req.followRedirects = false;
+      var res = await req.close();
+
+      expect(res.statusCode, 301);
+    });
   });
 }


### PR DESCRIPTION
Close #978

- 修复未透传 HttpClientRequest 的 5 个可选参数的问题, 会导致如果设置了这几个参数后被忽略的问题