### PR TITLE
Fix/referer and origin

### DIFF
--- a/kraken/lib/src/foundation/http_client_request.dart
+++ b/kraken/lib/src/foundation/http_client_request.dart
@@ -34,7 +34,7 @@ class ProxyHttpClientRequest extends HttpClientRequest {
   final HttpHeaders _httpHeaders = createHttpHeaders();
 
   ProxyHttpClientRequest(String method, Uri uri, KrakenHttpOverrides httpOverrides, HttpClient nativeHttpClient) :
-    _method = method.toLowerCase(),
+    _method = method.toUpperCase(),
     _uri = uri,
     _httpOverrides = httpOverrides,
     _nativeHttpClient = nativeHttpClient;
@@ -130,7 +130,7 @@ class ProxyHttpClientRequest extends HttpClientRequest {
       // `if request’s method is neither `GET` nor `HEAD`, then follow referrer policy to append origin.`
       // @TODO: Apply referrer policy.
       String origin = getOrigin(referrer);
-      if (method != 'get' && method != 'head') {
+      if (method != 'GET' && method != 'HEAD') {
         headers.set(_HttpHeadersOrigin, origin);
       }
 

--- a/kraken/lib/src/foundation/http_client_request.dart
+++ b/kraken/lib/src/foundation/http_client_request.dart
@@ -34,7 +34,7 @@ class ProxyHttpClientRequest extends HttpClientRequest {
   final HttpHeaders _httpHeaders = createHttpHeaders();
 
   ProxyHttpClientRequest(String method, Uri uri, KrakenHttpOverrides httpOverrides, HttpClient nativeHttpClient) :
-    _method = method,
+    _method = method.toLowerCase(),
     _uri = uri,
     _httpOverrides = httpOverrides,
     _nativeHttpClient = nativeHttpClient;
@@ -113,11 +113,26 @@ class ProxyHttpClientRequest extends HttpClientRequest {
     HttpClientRequest request = this;
 
     if (contextId != null) {
-      // Set the default origin and referrer.
+      // Standard reference: https://datatracker.ietf.org/doc/html/rfc7231#section-5.5.2
+      //   Most general-purpose user agents do not send the
+      //   Referer header field when the referring resource is a local "file" or
+      //   "data" URI.  A user agent MUST NOT send a Referer header field in an
+      //   unsecured HTTP request if the referring page was received with a
+      //   secure protocol.
       Uri referrer = getReferrer(contextId);
-      headers.set(HttpHeaders.refererHeader, referrer.toString());
+      bool isUnsafe = referrer.isScheme('https') && !uri.isScheme('https');
+      bool isLocalRequest = uri.isScheme('file') || uri.isScheme('data') || uri.isScheme('assets');
+      if (!isUnsafe && !isLocalRequest) {
+        headers.set(HttpHeaders.refererHeader, referrer.toString());
+      }
+
+      // Standard reference: https://fetch.spec.whatwg.org/#origin-header
+      // `if request’s method is neither `GET` nor `HEAD`, then follow referrer policy to append origin.`
+      // @TODO: Apply referrer policy.
       String origin = getOrigin(referrer);
-      headers.set(_HttpHeadersOrigin, origin);
+      if (method != 'get' && method != 'head') {
+        headers.set(_HttpHeadersOrigin, origin);
+      }
 
       HttpClientInterceptor? clientInterceptor;
       if (_httpOverrides.hasInterceptor(contextId)) {

--- a/kraken/test/src/foundation/http_cache.dart
+++ b/kraken/test/src/foundation/http_cache.dart
@@ -51,7 +51,7 @@ void main() {
       var res = await req.close();
       expect(String.fromCharCodes(await consolidateHttpClientResponseBytes(res)), 'CachedData');
 
-      HttpCacheController cacheController = HttpCacheController.instance(req.headers.value('origin')!);
+      HttpCacheController cacheController = HttpCacheController.instance('local');
       var cacheObject = await cacheController.getCacheObject(req.uri);
       await cacheObject.read();
 
@@ -81,7 +81,7 @@ void main() {
       expect(res2.headers.value(HttpHeaders.lastModifiedHeader), httpDateNow);
 
       // Check cache object updated.
-      HttpCacheController cacheController = HttpCacheController.instance(req.headers.value('origin')!);
+      HttpCacheController cacheController = HttpCacheController.instance('local');
       var cacheObject = await cacheController.getCacheObject(req.uri);
       assert(cacheObject.lastModified != null);
       // Difference <= 1ms.
@@ -98,7 +98,7 @@ void main() {
       var res = await req.close();
       expect(String.fromCharCodes(await consolidateHttpClientResponseBytes(res)), 'CachedData');
 
-      HttpCacheController cacheController = HttpCacheController.instance(req.headers.value('origin')!);
+      HttpCacheController cacheController = HttpCacheController.instance('local');
       var cacheObject = await cacheController.getCacheObject(req.uri);
       await cacheObject.read();
 
@@ -165,7 +165,7 @@ void main() {
       expect(bytes.lengthInBytes, res.contentLength);
 
       // Assert cache object.
-      HttpCacheController cacheController = HttpCacheController.instance(req.headers.value('origin')!);
+      HttpCacheController cacheController = HttpCacheController.instance('local');
       var cacheObject = await cacheController.getCacheObject(req.uri);
       await cacheObject.read();
       assert(cacheObject.valid);
@@ -187,7 +187,7 @@ void main() {
       expect(String.fromCharCodes(await consolidateHttpClientResponseBytes(res)), 'CachedData');
 
       // Assert cache object.
-      HttpCacheController cacheController = HttpCacheController.instance(req.headers.value('origin')!);
+      HttpCacheController cacheController = HttpCacheController.instance('local');
       var cacheObject = await cacheController.getCacheObject(req.uri);
       await cacheObject.read();
       assert(cacheObject.valid);

--- a/kraken/test/src/foundation/http_client.dart
+++ b/kraken/test/src/foundation/http_client.dart
@@ -3,6 +3,8 @@ import 'dart:io';
 import 'package:test/test.dart';
 import 'package:kraken/foundation.dart';
 
+import '../../local_http_server.dart';
+
 void main() {
 
   group('HttpHeaders', () {
@@ -51,6 +53,32 @@ void main() {
       headers.add('content-type', 'another-value');
 
       expect(headers['content-type'], ['x-application/vnd.foo', 'another-value']);
+    });
+  });
+
+  group('HttpRequest', () {
+    var server = LocalHttpServer.getInstance();
+    int contextId = 3;
+    HttpOverrides.global = null;
+    setupHttpOverrides(null, contextId: contextId);
+    HttpClient httpClient = HttpClient();
+
+    test('Origin', () async {
+      var request = await httpClient.openUrl('POST',
+          server.getUri('plain_text'));
+      KrakenHttpOverrides.setContextHeader(request.headers, contextId);
+      await request.close();
+
+      assert(request.headers.value('origin') != null);
+    });
+
+    test('Referrer', () async {
+      var request = await httpClient.openUrl('POST',
+          server.getUri('plain_text'));
+      KrakenHttpOverrides.setContextHeader(request.headers, contextId);
+      await request.close();
+
+      assert(request.headers.value('referer') != null);
     });
   });
 }


### PR DESCRIPTION
1. 修复 HTTP 请求发出时 Origin 字段添加的条件，遵循 https://fetch.spec.whatwg.org/#origin-header 简单的说 
<img width="845" alt="image" src="https://user-images.githubusercontent.com/3922719/155079877-76f5de84-cb3c-4aeb-9ae1-a914a2966181.png">

2. 修复 HTTP 请求发出时 Referer 字段添加的条件，遵循 https://datatracker.ietf.org/doc/html/rfc7231#section-5.5.2 简单的说 
<img width="717" alt="image" src="https://user-images.githubusercontent.com/3922719/155079849-9aafe03b-9823-490f-9937-59b4af57f2f9.png">
