### PR TITLE
fix: large file content may fail

### DIFF
--- a/kraken/lib/src/foundation/http_client_request.dart
+++ b/kraken/lib/src/foundation/http_client_request.dart
@@ -170,8 +170,10 @@ class ProxyHttpClientRequest extends HttpClientRequest {
 
       request = await _createBackendClientRequest();
       // Send the real data to backend client.
-      await request.addStream(Stream.value(_data));
-      _data.clear();
+      if (_data.isNotEmpty) {
+        await request.addStream(Stream.value(_data));
+        _data.clear();
+      }
 
       // Step 4: Lifecycle of shouldInterceptRequest
       HttpClientResponse? response;
@@ -223,8 +225,10 @@ class ProxyHttpClientRequest extends HttpClientRequest {
     } else {
       request = await _createBackendClientRequest();
       // Not using request.add, because large data will cause core exception.
-      await request.addStream(Stream.value(_data));
-      _data.clear();
+      if (_data.isNotEmpty) {
+        await request.addStream(Stream.value(_data));
+        _data.clear();
+      }
     }
 
     return _requestQueue.add(request.close);

--- a/kraken/lib/src/foundation/http_client_request.dart
+++ b/kraken/lib/src/foundation/http_client_request.dart
@@ -170,7 +170,7 @@ class ProxyHttpClientRequest extends HttpClientRequest {
 
       request = await _createBackendClientRequest();
       // Send the real data to backend client.
-      request.add(_data);
+      await request.addStream(Stream.value(_data));
       _data.clear();
 
       // Step 4: Lifecycle of shouldInterceptRequest
@@ -222,7 +222,8 @@ class ProxyHttpClientRequest extends HttpClientRequest {
 
     } else {
       request = await _createBackendClientRequest();
-      request.add(_data);
+      // Not using request.add, because large data will cause core exception.
+      await request.addStream(Stream.value(_data));
       _data.clear();
     }
 

--- a/kraken/test/local_http_server.dart
+++ b/kraken/test/local_http_server.dart
@@ -43,7 +43,7 @@ class LocalHttpServer {
           data.addAll(chunk);
 
           if (data.length >= 4) {
-            var lastFour = data.sublist(chunk.length - 4, chunk.length);
+            var lastFour = data.sublist(data.length - 4, data.length);
 
             // Ends with \r\n\r\n or
             // @TODO: content-length.

--- a/kraken/test/src/foundation/http_client.dart
+++ b/kraken/test/src/foundation/http_client.dart
@@ -80,5 +80,19 @@ void main() {
 
       assert(request.headers.value('referer') != null);
     });
+
+    test('Large content', () async {
+      var request = await httpClient.openUrl('POST',
+          server.getUri('plain_text'));
+      KrakenHttpOverrides.setContextHeader(request.headers, contextId);
+      // Mocked 3M file.
+      var data = List<int>.generate(3034764, (i) => i);
+      request.headers.set(HttpHeaders.contentLengthHeader, data.length);
+      await request.addStream(Stream.value(data));
+      request.add([13, 10, 13, 10]); // End of file, double CRLF.
+      await request.close();
+
+      // No error is ok.
+    });
   });
 }


### PR DESCRIPTION
Fix #1171

当 data 过大的时候, 直接使用 add 接口会导致异常, 此时需要使用 addStream 分批发送数据