### PR TITLE
fix: fix native event memory align on 32 bit devices.

### DIFF
--- a/bridge/CMakeLists.txt
+++ b/bridge/CMakeLists.txt
@@ -302,6 +302,11 @@ list(APPEND BRIDGE_LINK_LIBS gumbo_parse_static)
 
 if (${IS_ANDROID})
   find_library(log-lib log)
+
+  if (${ANDROID_ABI} MATCHES "armeabi-v7a" OR ${ANDROID_ABI} MATCHES "x86")
+    add_definitions(-DANDROID_32_BIT=1)
+  endif()
+
   add_definitions(-DIS_ANDROID=1)
   list(APPEND BRIDGE_LINK_LIBS ${log-lib})
 endif ()

--- a/bridge/bindings/qjs/bom/window_test.cc
+++ b/bridge/bindings/qjs/bom/window_test.cc
@@ -79,9 +79,7 @@ window.postMessage({
     EXPECT_EQ(logCalled, true);
   }
   // Use block scope to release previous page, and allocate new page.
-  {
-    TEST_init();
-  }
+  { TEST_init(); }
 }
 
 TEST(Window, location) {

--- a/bridge/bindings/qjs/dom/custom_event.cc
+++ b/bridge/bindings/qjs/dom/custom_event.cc
@@ -27,7 +27,7 @@ JSValue CustomEvent::initCustomEvent(JSContext* ctx, JSValue this_val, int argc,
   }
 
   JSValue typeValue = argv[0];
-  eventInstance->nativeEvent->type = jsValueToNativeString(ctx, typeValue).release();
+  eventInstance->setType(jsValueToNativeString(ctx, typeValue).release());
 
   if (argc <= 2) {
     bool canBubble = JS_ToBool(ctx, argv[1]);
@@ -83,8 +83,9 @@ CustomEventInstance::CustomEventInstance(CustomEvent* jsCustomEvent, JSAtom cust
 
 CustomEventInstance::CustomEventInstance(CustomEvent* jsCustomEvent, NativeCustomEvent* nativeCustomEvent)
     : nativeCustomEvent(nativeCustomEvent), EventInstance(jsCustomEvent, reinterpret_cast<NativeEvent*>(nativeCustomEvent)) {
-  JSValue newDetail = JS_NewUnicodeString(jsCustomEvent->context()->runtime(), jsCustomEvent->context()->ctx(), nativeCustomEvent->detail->string, nativeCustomEvent->detail->length);
-  nativeCustomEvent->detail->free();
+  auto* detail = reinterpret_cast<NativeString*>(nativeCustomEvent->detail);
+  JSValue newDetail = JS_NewUnicodeString(jsCustomEvent->context()->runtime(), jsCustomEvent->context()->ctx(), detail->string, detail->length);
+  detail->free();
   m_detail.value(newDetail);
   JS_FreeValue(m_ctx, newDetail);
 }

--- a/bridge/bindings/qjs/dom/custom_event.h
+++ b/bridge/bindings/qjs/dom/custom_event.h
@@ -14,7 +14,7 @@ void bindCustomEvent(ExecutionContext* context);
 
 struct NativeCustomEvent {
   NativeEvent nativeEvent;
-  NativeString* detail{nullptr};
+  int64_t detail{0};
 };
 
 class CustomEventInstance;

--- a/bridge/bindings/qjs/dom/document.cc
+++ b/bridge/bindings/qjs/dom/document.cc
@@ -151,7 +151,11 @@ JSValue Document::createEvent(JSContext* ctx, JSValue this_val, int argc, JSValu
   std::string eventType = std::string(c_eventType);
   if (eventType == "Event") {
     std::unique_ptr<NativeString> nativeEventType = jsValueToNativeString(ctx, eventTypeValue);
+#if ANDROID_32_BIT
     auto nativeEvent = new NativeEvent{reinterpret_cast<int64_t>(nativeEventType.release())};
+#else
+    auto nativeEvent = new NativeEvent{nativeEventType.release()};
+#endif
 
     auto document = static_cast<DocumentInstance*>(JS_GetOpaque(this_val, Document::classId()));
     auto e = Event::buildEventInstance(eventType, document->context(), nativeEvent, false);

--- a/bridge/bindings/qjs/dom/document.cc
+++ b/bridge/bindings/qjs/dom/document.cc
@@ -151,7 +151,7 @@ JSValue Document::createEvent(JSContext* ctx, JSValue this_val, int argc, JSValu
   std::string eventType = std::string(c_eventType);
   if (eventType == "Event") {
     std::unique_ptr<NativeString> nativeEventType = jsValueToNativeString(ctx, eventTypeValue);
-    auto nativeEvent = new NativeEvent{nativeEventType.release()};
+    auto nativeEvent = new NativeEvent{reinterpret_cast<int64_t>(nativeEventType.release())};
 
     auto document = static_cast<DocumentInstance*>(JS_GetOpaque(this_val, Document::classId()));
     auto e = Event::buildEventInstance(eventType, document->context(), nativeEvent, false);

--- a/bridge/bindings/qjs/dom/elements/image_element.cc
+++ b/bridge/bindings/qjs/dom/elements/image_element.cc
@@ -105,7 +105,7 @@ ImageElementInstance::ImageElementInstance(ImageElement* element) : ElementInsta
 }
 
 bool ImageElementInstance::dispatchEvent(EventInstance* event) {
-  std::u16string u16EventType = std::u16string(reinterpret_cast<const char16_t*>(event->nativeEvent->type->string), event->nativeEvent->type->length);
+  std::u16string u16EventType = std::u16string(reinterpret_cast<const char16_t*>(event->type()->string), event->type()->length);
   std::string eventType = toUTF8(u16EventType);
   bool result = EventTargetInstance::dispatchEvent(event);
 

--- a/bridge/bindings/qjs/dom/event.h
+++ b/bridge/bindings/qjs/dom/event.h
@@ -150,7 +150,7 @@ class EventInstance : public Instance {
 #endif
   };
   void setType(NativeString* type) const;
-  FORCE_INLINE EventTargetInstance* target() {return reinterpret_cast<EventTargetInstance*>(nativeEvent->target);}
+  FORCE_INLINE EventTargetInstance* target() { return reinterpret_cast<EventTargetInstance*>(nativeEvent->target); }
   void setTarget(EventTargetInstance* target) const;
   FORCE_INLINE EventTargetInstance* currentTarget() { return reinterpret_cast<EventTargetInstance*>(nativeEvent->currentTarget); }
   void setCurrentTarget(EventTargetInstance* target) const;

--- a/bridge/bindings/qjs/dom/event.h
+++ b/bridge/bindings/qjs/dom/event.h
@@ -97,6 +97,8 @@ class Event : public HostClass {
   friend EventInstance;
 };
 
+// Dart generated nativeEvent member are force align to 64-bit system. So all members in NativeEvent should have 64 bit width.
+#if ANDROID_32_BIT
 struct NativeEvent {
   int64_t type{0};
   int64_t bubbles{0};
@@ -108,6 +110,20 @@ struct NativeEvent {
   // The pointer address of current target EventTargetInstance object.
   int64_t currentTarget{0};
 };
+#else
+// Use pointer instead of int64_t on 64 bit system can help compiler to choose best register for better running performance.
+struct NativeEvent {
+  NativeString* type{nullptr};
+  int64_t bubbles{0};
+  int64_t cancelable{0};
+  int64_t timeStamp{0};
+  int64_t defaultPrevented{0};
+  // The pointer address of target EventTargetInstance object.
+  void* target{nullptr};
+  // The pointer address of current target EventTargetInstance object.
+  void* currentTarget{nullptr};
+};
+#endif
 
 struct RawEvent {
   uint64_t* bytes;
@@ -122,15 +138,21 @@ class EventInstance : public Instance {
   static EventInstance* fromNativeEvent(Event* event, NativeEvent* nativeEvent);
   NativeEvent* nativeEvent{nullptr};
 
-  inline const bool propagationStopped() { return m_propagationStopped; }
-  inline const bool cancelled() { return m_cancelled; }
-  inline void cancelled(bool v) { m_cancelled = v; }
-  inline const bool propagationImmediatelyStopped() { return m_propagationImmediatelyStopped; }
-  inline NativeString* type() { return reinterpret_cast<NativeString*>(nativeEvent->type); };
+  FORCE_INLINE const bool propagationStopped() { return m_propagationStopped; }
+  FORCE_INLINE const bool cancelled() { return m_cancelled; }
+  FORCE_INLINE void cancelled(bool v) { m_cancelled = v; }
+  FORCE_INLINE const bool propagationImmediatelyStopped() { return m_propagationImmediatelyStopped; }
+  FORCE_INLINE NativeString* type() {
+#if ANDROID_32_BIT
+    return reinterpret_cast<NativeString*>(nativeEvent->type);
+#else
+    return nativeEvent->type;
+#endif
+  };
   void setType(NativeString* type) const;
-  inline EventTargetInstance* target() { return reinterpret_cast<EventTargetInstance*>(nativeEvent->target); }
+  FORCE_INLINE EventTargetInstance* target() {return reinterpret_cast<EventTargetInstance*>(nativeEvent->target);}
   void setTarget(EventTargetInstance* target) const;
-  inline EventTargetInstance* currentTarget() { return reinterpret_cast<EventTargetInstance*>(nativeEvent->currentTarget); }
+  FORCE_INLINE EventTargetInstance* currentTarget() { return reinterpret_cast<EventTargetInstance*>(nativeEvent->currentTarget); }
   void setCurrentTarget(EventTargetInstance* target) const;
 
  protected:

--- a/bridge/bindings/qjs/dom/event.h
+++ b/bridge/bindings/qjs/dom/event.h
@@ -53,6 +53,7 @@ namespace kraken::binding::qjs {
 void bindEvent(ExecutionContext* context);
 
 class EventInstance;
+class EventTargetInstance;
 
 using EventCreator = EventInstance* (*)(ExecutionContext* context, void* nativeEvent);
 
@@ -97,15 +98,15 @@ class Event : public HostClass {
 };
 
 struct NativeEvent {
-  NativeString* type{nullptr};
+  int64_t type{0};
   int64_t bubbles{0};
   int64_t cancelable{0};
   int64_t timeStamp{0};
   int64_t defaultPrevented{0};
   // The pointer address of target EventTargetInstance object.
-  void* target{nullptr};
+  int64_t target{0};
   // The pointer address of current target EventTargetInstance object.
-  void* currentTarget{nullptr};
+  int64_t currentTarget{0};
 };
 
 struct RawEvent {
@@ -125,6 +126,12 @@ class EventInstance : public Instance {
   inline const bool cancelled() { return m_cancelled; }
   inline void cancelled(bool v) { m_cancelled = v; }
   inline const bool propagationImmediatelyStopped() { return m_propagationImmediatelyStopped; }
+  inline NativeString* type() { return reinterpret_cast<NativeString*>(nativeEvent->type); };
+  void setType(NativeString* type) const;
+  inline EventTargetInstance* target() { return reinterpret_cast<EventTargetInstance*>(nativeEvent->target); }
+  void setTarget(EventTargetInstance* target) const;
+  inline EventTargetInstance* currentTarget() { return reinterpret_cast<EventTargetInstance*>(nativeEvent->currentTarget); }
+  void setCurrentTarget(EventTargetInstance* target) const;
 
  protected:
   explicit EventInstance(Event* jsEvent, JSAtom eventType, JSValue eventInit);

--- a/bridge/bindings/qjs/dom/event_target.cc
+++ b/bridge/bindings/qjs/dom/event_target.cc
@@ -149,7 +149,11 @@ JSValue EventTarget::dispatchEvent(JSContext* ctx, JSValue this_val, int argc, J
 
   JSValue eventValue = argv[0];
   auto eventInstance = reinterpret_cast<EventInstance*>(JS_GetOpaque(eventValue, EventTarget::classId(eventValue)));
+#if ANDROID_32_BIT
   eventInstance->nativeEvent->target = reinterpret_cast<int64_t>(eventTargetInstance);
+#else
+  eventInstance->nativeEvent->target = eventTargetInstance;
+#endif
   return JS_NewBool(ctx, eventTargetInstance->dispatchEvent(eventInstance));
 }
 

--- a/bridge/bindings/qjs/dom/event_target.cc
+++ b/bridge/bindings/qjs/dom/event_target.cc
@@ -149,12 +149,14 @@ JSValue EventTarget::dispatchEvent(JSContext* ctx, JSValue this_val, int argc, J
 
   JSValue eventValue = argv[0];
   auto eventInstance = reinterpret_cast<EventInstance*>(JS_GetOpaque(eventValue, EventTarget::classId(eventValue)));
-  eventInstance->nativeEvent->target = eventTargetInstance;
+  eventInstance->nativeEvent->target = reinterpret_cast<int64_t>(eventTargetInstance);
   return JS_NewBool(ctx, eventTargetInstance->dispatchEvent(eventInstance));
 }
 
 bool EventTargetInstance::dispatchEvent(EventInstance* event) {
-  std::u16string u16EventType = std::u16string(reinterpret_cast<const char16_t*>(event->nativeEvent->type->string), event->nativeEvent->type->length);
+  auto* pEventType = reinterpret_cast<NativeString*>(event->nativeEvent->type);
+
+  std::u16string u16EventType = std::u16string(reinterpret_cast<const char16_t*>(pEventType->string), pEventType->length);
   std::string eventType = toUTF8(u16EventType);
 
   // protect this util event trigger finished.
@@ -184,12 +186,12 @@ bool EventTargetInstance::dispatchEvent(EventInstance* event) {
 }
 
 bool EventTargetInstance::internalDispatchEvent(EventInstance* eventInstance) {
-  std::u16string u16EventType = std::u16string(reinterpret_cast<const char16_t*>(eventInstance->nativeEvent->type->string), eventInstance->nativeEvent->type->length);
+  std::u16string u16EventType = std::u16string(reinterpret_cast<const char16_t*>(eventInstance->type()->string), eventInstance->type()->length);
   std::string eventTypeStr = toUTF8(u16EventType);
   JSAtom eventType = JS_NewAtom(m_ctx, eventTypeStr.c_str());
 
   // Modify the currentTarget to this.
-  eventInstance->nativeEvent->currentTarget = this;
+  eventInstance->setCurrentTarget(this);
 
   // Dispatch event listeners writen by addEventListener
   auto _dispatchEvent = [&eventInstance, this](JSValue handler) {
@@ -496,7 +498,7 @@ void NativeEventTarget::dispatchEventImpl(int32_t contextId, NativeEventTarget* 
   // So we can reinterpret_cast raw bytes pointer to NativeEvent type directly.
   auto* nativeEvent = reinterpret_cast<NativeEvent*>(raw->bytes);
   EventInstance* eventInstance = Event::buildEventInstance(eventType, context, nativeEvent, isCustomEvent == 1);
-  eventInstance->nativeEvent->target = eventTargetInstance;
+  eventInstance->setTarget(eventTargetInstance);
   eventTargetInstance->dispatchEvent(eventInstance);
   JS_FreeValue(context->ctx(), eventInstance->jsObject);
 }

--- a/bridge/bindings/qjs/dom/events/touch_event.cc
+++ b/bridge/bindings/qjs/dom/events/touch_event.cc
@@ -117,7 +117,7 @@ JSValue TouchEvent::instanceConstructor(JSContext* ctx, JSValue func_obj, JSValu
   }
 
   auto* nativeEvent = new NativeTouchEvent();
-  nativeEvent->nativeEvent.type = jsValueToNativeString(ctx, eventTypeValue).release();
+  nativeEvent->nativeEvent.type = reinterpret_cast<int64_t>(jsValueToNativeString(ctx, eventTypeValue).release());
 
   if (JS_IsObject(eventInit)) {
     JSAtom touchesAtom = JS_NewAtom(m_ctx, "touches");

--- a/bridge/bindings/qjs/dom/events/touch_event.cc
+++ b/bridge/bindings/qjs/dom/events/touch_event.cc
@@ -117,7 +117,11 @@ JSValue TouchEvent::instanceConstructor(JSContext* ctx, JSValue func_obj, JSValu
   }
 
   auto* nativeEvent = new NativeTouchEvent();
+#if ANDROID_32_BIT
   nativeEvent->nativeEvent.type = reinterpret_cast<int64_t>(jsValueToNativeString(ctx, eventTypeValue).release());
+#else
+  nativeEvent->nativeEvent.type = jsValueToNativeString(ctx, eventTypeValue).release();
+#endif
 
   if (JS_IsObject(eventInit)) {
     JSAtom touchesAtom = JS_NewAtom(m_ctx, "touches");

--- a/bridge/bindings/qjs/executing_context.cc
+++ b/bridge/bindings/qjs/executing_context.cc
@@ -347,7 +347,7 @@ void ExecutionContext::dispatchGlobalErrorEvent(ExecutionContext* context, JSVal
     }
 
     auto* errorEvent = static_cast<EventInstance*>(JS_GetOpaque(errorEventValue, Event::kEventClassID));
-    errorEvent->nativeEvent->target = window;
+    errorEvent->setTarget(window);
     context->dispatchErrorEvent(errorEvent);
 
     JS_FreeValue(ctx, errorEventConstructor);
@@ -378,7 +378,7 @@ static void dispatchPromiseRejectionEvent(const char* eventType, ExecutionContex
     }
 
     auto* rejectEvent = static_cast<EventInstance*>(JS_GetOpaque(rejectEventValue, Event::kEventClassID));
-    rejectEvent->nativeEvent->target = window;
+    rejectEvent->setTarget(window);
     window->dispatchEvent(rejectEvent);
 
     JS_FreeValue(ctx, errorType);

--- a/bridge/scripts/code_generator/src/genereate_source.ts
+++ b/bridge/scripts/code_generator/src/genereate_source.ts
@@ -311,7 +311,7 @@ function generateEventConstructorCode(object: ClassObject) {
   }
 
   auto *nativeEvent = new Native${object.name}();
-  nativeEvent->nativeEvent.type = jsValueToNativeString(ctx, eventTypeValue).release();
+  nativeEvent->nativeEvent.type = reinterpret_cast<int64_t>(jsValueToNativeString(ctx, eventTypeValue).release());
 
   ${generateEventInstanceConstructorCode(object)}
 

--- a/bridge/scripts/code_generator/src/genereate_source.ts
+++ b/bridge/scripts/code_generator/src/genereate_source.ts
@@ -311,7 +311,11 @@ function generateEventConstructorCode(object: ClassObject) {
   }
 
   auto *nativeEvent = new Native${object.name}();
+#if ANDROID_32_BIT
   nativeEvent->nativeEvent.type = reinterpret_cast<int64_t>(jsValueToNativeString(ctx, eventTypeValue).release());
+#else
+  nativeEvent->nativeEvent.type = jsValueToNativeString(ctx, eventTypeValue).release();
+#endif
 
   ${generateEventInstanceConstructorCode(object)}
 

--- a/bridge/test/kraken_test_env.cc
+++ b/bridge/test/kraken_test_env.cc
@@ -161,7 +161,9 @@ void TEST_initWindow(int32_t contextId, void* nativePtr) {}
 void TEST_initDocument(int32_t contextId, void* nativePtr) {}
 
 #if ENABLE_PROFILE
-NativePerformanceEntryList* TEST_getPerformanceEntries(int32_t) {}
+NativePerformanceEntryList* TEST_getPerformanceEntries(int32_t) {
+  return nullptr;
+}
 #endif
 
 std::once_flag testInitOnceFlag;
@@ -258,7 +260,7 @@ void TEST_dispatchEvent(int32_t contextId, EventTargetInstance* eventTarget, con
   auto nativeEventType = stringToNativeString(type);
   NativeString* rawEventType = nativeEventType.release();
 
-  NativeEvent* nativeEvent = new NativeEvent{rawEventType};
+  NativeEvent* nativeEvent = new NativeEvent{reinterpret_cast<int64_t>(rawEventType)};
 
   RawEvent* rawEvent = new RawEvent{reinterpret_cast<uint64_t*>(nativeEvent)};
 

--- a/bridge/test/kraken_test_env.cc
+++ b/bridge/test/kraken_test_env.cc
@@ -260,7 +260,11 @@ void TEST_dispatchEvent(int32_t contextId, EventTargetInstance* eventTarget, con
   auto nativeEventType = stringToNativeString(type);
   NativeString* rawEventType = nativeEventType.release();
 
+#if ANDROID_32_BIT
   NativeEvent* nativeEvent = new NativeEvent{reinterpret_cast<int64_t>(rawEventType)};
+#else
+  NativeEvent* nativeEvent = new NativeEvent{rawEventType};
+#endif
 
   RawEvent* rawEvent = new RawEvent{reinterpret_cast<uint64_t*>(nativeEvent)};
 

--- a/kraken/android/jniLibs/x86/libc++_shared.so
+++ b/kraken/android/jniLibs/x86/libc++_shared.so
@@ -1,0 +1,1 @@
+../../../../bridge/build/android/lib/x86/libc++_shared.so

--- a/kraken/android/jniLibs/x86/libkraken.so
+++ b/kraken/android/jniLibs/x86/libkraken.so
@@ -1,0 +1,1 @@
+../../../../bridge/build/android/lib/x86/libkraken.so

--- a/kraken/android/jniLibs/x86/libquickjs.so
+++ b/kraken/android/jniLibs/x86/libquickjs.so
@@ -1,0 +1,1 @@
+../../../../bridge/build/android/lib/x86/libquickjs.so

--- a/scripts/tasks.js
+++ b/scripts/tasks.js
@@ -578,7 +578,7 @@ task('build-ios-frameworks', (done) => {
 task('build-linux-kraken-lib', (done) => {
   const buildType = buildMode == 'Release' ? 'Release' : 'Relwithdebinfo';
   const cmakeGeneratorTemplate = platform == 'win32' ? 'Ninja' : 'Unix Makefiles';
- 
+
   const soBinaryDirectory = path.join(paths.bridge, `build/linux/lib/`);
   const bridgeCmakeDir = path.join(paths.bridge, 'cmake-build-linux');
   // generate project
@@ -630,10 +630,11 @@ task('build-android-kraken-lib', (done) => {
     }
   }
 
-  const archs = ['arm64-v8a', 'armeabi-v7a'];
+  const archs = ['arm64-v8a', 'armeabi-v7a', 'x86'];
   const toolChainMap = {
     'arm64-v8a': 'aarch64-linux-android',
-    'armeabi-v7a': 'arm-linux-androideabi'
+    'armeabi-v7a': 'arm-linux-androideabi',
+    'x86': 'i686-linux-android'
   };
   const buildType = (buildMode === 'Release' || buildMode == 'Relwithdebinfo') ? 'Relwithdebinfo' : 'Debug';
   let externCmakeArgs = [];


### PR DESCRIPTION
修复 nativeEvent 在 32位机器上的内存对齐问题。

Dart 发送给 Native 的事件都是按照 64位机器的规则进行内存布局。因此需要避免在 Native 测的 NativeEvent 声明中使用指针类型，因为它会导致在 32位机器上，按照 32 位的规则来进行偏移。