### PR TITLE
fix: fix image load error cause crash.

### DIFF
--- a/kraken/lib/src/dom/elements/img.dart
+++ b/kraken/lib/src/dom/elements/img.dart
@@ -234,6 +234,7 @@ class ImageElement extends Element {
   }
 
   void _onImageError(Object exception, StackTrace? stackTrace) {
+    print('$exception\n$stackTrace');
     dispatchEvent(Event(EVENT_ERROR));
   }
 
@@ -390,6 +391,9 @@ class ImageElement extends Element {
     if (_frameCount > 2) {
       forceToRepaintBoundary = true;
     }
+
+    // Image may be detached when image frame loaded.
+    if (!isRendererAttached) return;
 
     _attachImage();
     _resizeImage();


### PR DESCRIPTION
不正确的 Image 加载导致 assert，触发了大量 error 事件，由于 Assert 中断了后续操作导致了 Dart Element 进入未定义的状态，进而导致更多的问题。

![image](https://user-images.githubusercontent.com/4409743/155994047-6049eabf-7e3e-46a8-aa4c-5d5133496f61.png)
