### PR TITLE
fix: Unable to handle Asset scheme

### DIFF
--- a/kraken/lib/src/painting/image_provider_factory.dart
+++ b/kraken/lib/src/painting/image_provider_factory.dart
@@ -419,10 +419,12 @@ ImageProvider? defaultBlobProviderFactory(Uri uri, ImageProviderParams params) {
 
 /// default ImageProviderFactory implementation of [ImageType.assets].
 ImageProvider defaultAssetsProvider(Uri uri, ImageProviderParams params) {
+  String localPath = uri.replace(scheme: '').toString()
+      .replaceFirst('//', '');
   return KrakenResizeImage.resizeIfNeeded(
     params.cachedWidth,
     params.cachedHeight,
     params.objectFit,
-    AssetImage(uri.toString())
+    AssetImage(localPath)
   );
 }


### PR DESCRIPTION
我在本地 html 加载 asset 图片时，发现加载图片一直失败，发现 AssetImage  使用 assets://xxx 初始化失败
尝试修复，麻烦 review 下