### PR TITLE
[WIP] fix: flex item child not stretch

### DIFF
--- a/kraken/lib/src/css/render_style.dart
+++ b/kraken/lib/src/css/render_style.dart
@@ -633,13 +633,9 @@ class CSSRenderStyle
           RenderStyle parentRenderStyle = renderStyle.parent!;
           RenderBoxModel parent = parentRenderStyle.renderBoxModel!;
 
-          // Use parent's tight constraints if constraints is tight and width not exist.
-          if (parent.hasSize && parent.constraints.hasTightWidth) {
-            logicalWidth = parent.constraints.maxWidth;
-
           // Block element (except replaced element) will stretch to the content width of its parent in flow layout.
           // Replaced element also stretch in flex layout if align-items is stretch.
-          } else if (current is! RenderIntrinsic || parent is RenderFlexLayout) {
+          if (current is! RenderIntrinsic || parent is RenderFlexLayout) {
             RenderStyle? ancestorRenderStyle = _findAncestorWithNoDisplayInline();
             // Should ignore renderStyle of display inline when searching for ancestors to stretch width.
             if (ancestorRenderStyle != null) {
@@ -766,18 +762,12 @@ class CSSRenderStyle
       } else {
         if (renderStyle.parent != null) {
           RenderStyle parentRenderStyle = renderStyle.parent!;
-          RenderBoxModel parent = parentRenderStyle.renderBoxModel!;
 
           if (renderStyle.isHeightStretch) {
-            // Use parent's tight constraints if constraints is tight and height not exist.
-            if (parent.hasSize && parent.constraints.hasTightHeight) {
-              logicalHeight = parent.constraints.maxHeight;
-            } else {
-              logicalHeight = parentRenderStyle.contentBoxLogicalHeight;
-              // Should subtract vertical margin of own from its parent content height.
-              if (logicalHeight != null) {
-                logicalHeight -= renderStyle.margin.vertical;
-              }
+            logicalHeight = parentRenderStyle.contentBoxLogicalHeight;
+            // Should subtract vertical margin of own from its parent content height.
+            if (logicalHeight != null) {
+              logicalHeight -= renderStyle.margin.vertical;
             }
           }
         }
@@ -914,6 +904,11 @@ class CSSRenderStyle
     return _contentBoxLogicalWidth;
   }
 
+  set contentBoxLogicalWidth(double? value) {
+    if (_contentBoxLogicalWidth == value) return;
+    _contentBoxLogicalWidth = value;
+  }
+
   // Content height calculated from renderStyle tree.
   // https://www.w3.org/TR/css-box-3/#valdef-box-content-box
   // Use double.infinity refers to the value is not computed yet.
@@ -926,6 +921,11 @@ class CSSRenderStyle
       computeContentBoxLogicalHeight();
     }
     return _contentBoxLogicalHeight;
+  }
+
+  set contentBoxLogicalHeight(double? value) {
+    if (_contentBoxLogicalHeight == value) return;
+    _contentBoxLogicalHeight = value;
   }
 
   // Padding box width calculated from renderStyle tree.

--- a/kraken/lib/src/css/render_style.dart
+++ b/kraken/lib/src/css/render_style.dart
@@ -101,20 +101,14 @@ abstract class RenderStyle {
   // BoxModel
   double? get borderBoxLogicalWidth;
   double? get borderBoxLogicalHeight;
-  double? get borderBoxConstraintsWidth;
-  double? get borderBoxConstraintsHeight;
   double? get borderBoxWidth;
   double? get borderBoxHeight;
   double? get paddingBoxLogicalWidth;
   double? get paddingBoxLogicalHeight;
-  double? get paddingBoxConstraintsWidth;
-  double? get paddingBoxConstraintsHeight;
   double? get paddingBoxWidth;
   double? get paddingBoxHeight;
   double? get contentBoxLogicalWidth;
   double? get contentBoxLogicalHeight;
-  double? get contentBoxConstraintsWidth;
-  double? get contentBoxConstraintsHeight;
   double? get contentBoxWidth;
   double? get contentBoxHeight;
   CSSPositionType get position;
@@ -1040,72 +1034,6 @@ class CSSRenderStyle
       return null;
     }
     return paddingBoxHeight!
-      - paddingTop.computedValue
-      - paddingBottom.computedValue;
-  }
-
-  // Border box width of renderBoxModel calculated from tight width constraints.
-  @override
-  double? get borderBoxConstraintsWidth {
-    if (renderBoxModel!.hasSize &&
-      renderBoxModel!.constraints.hasTightWidth
-    ) {
-      return renderBoxModel!.constraints.maxWidth;
-    }
-    return null;
-  }
-
-  // Border box height of renderBoxModel calculated from tight height constraints.
-  @override
-  double? get borderBoxConstraintsHeight {
-    if (renderBoxModel!.hasSize &&
-      renderBoxModel!.constraints.hasTightHeight
-    ) {
-      return renderBoxModel!.constraints.maxHeight;
-    }
-    return null;
-  }
-
-  // Padding box width of renderBoxModel calculated from tight width constraints.
-  @override
-  double? get paddingBoxConstraintsWidth {
-    if (borderBoxConstraintsWidth == null) {
-      return null;
-    }
-    return borderBoxConstraintsWidth!
-      - effectiveBorderLeftWidth.computedValue
-      - effectiveBorderRightWidth.computedValue;
-  }
-
-  // Padding box height of renderBoxModel calculated from tight height constraints.
-  @override
-  double? get paddingBoxConstraintsHeight {
-    if (borderBoxConstraintsHeight == null) {
-      return null;
-    }
-    return borderBoxConstraintsHeight!
-      - effectiveBorderTopWidth.computedValue
-      - effectiveBorderBottomWidth.computedValue;
-  }
-
-  // Content box width of renderBoxModel calculated from tight width constraints.
-  @override
-  double? get contentBoxConstraintsWidth {
-    if (paddingBoxConstraintsWidth == null) {
-      return null;
-    }
-    return paddingBoxConstraintsWidth!
-      - paddingLeft.computedValue
-      - paddingRight.computedValue;
-  }
-
-  // Content box height of renderBoxModel calculated from tight height constraints.
-  @override
-  double? get contentBoxConstraintsHeight {
-    if (paddingBoxConstraintsHeight == null) {
-      return null;
-    }
-    return paddingBoxConstraintsHeight!
       - paddingTop.computedValue
       - paddingBottom.computedValue;
   }

--- a/kraken/lib/src/css/values/length.dart
+++ b/kraken/lib/src/css/values/length.dart
@@ -139,24 +139,20 @@ class CSSLengthValue {
             : parentRenderBoxModel.renderStyle;
         }
 
-        // Constraints is calculated before layout, the layouted size is identical to the tight constraints
-        // if constraints is tight, so it's safe to use the tight constraints as the parent size to resolve
-        // the child percentage length to save one extra layout to wait for parent layout complete.
-
-        // Percentage relative width priority: tight constraints width > renderer width > logical width
-        double? parentPaddingBoxWidth = parentRenderStyle?.paddingBoxConstraintsWidth
-          ?? parentRenderStyle?.paddingBoxWidth
-          ?? parentRenderStyle?.paddingBoxLogicalWidth;
-        double? parentContentBoxWidth = parentRenderStyle?.contentBoxConstraintsWidth
-          ?? parentRenderStyle?.contentBoxWidth
-          ?? parentRenderStyle?.contentBoxLogicalWidth;
-        // Percentage relative height priority: tight constraints height > renderer height > logical height
-        double? parentPaddingBoxHeight = parentRenderStyle?.paddingBoxConstraintsHeight
-          ?? parentRenderStyle?.paddingBoxHeight
-          ?? parentRenderStyle?.paddingBoxLogicalHeight;
-        double? parentContentBoxHeight = parentRenderStyle?.contentBoxConstraintsHeight
-          ?? parentRenderStyle?.contentBoxHeight
-          ?? parentRenderStyle?.contentBoxLogicalHeight;
+        // Percentage relative width priority: logical width > renderer width
+        double? parentPaddingBoxWidth =
+          parentRenderStyle?.paddingBoxLogicalWidth
+          ?? parentRenderStyle?.paddingBoxWidth;
+        double? parentContentBoxWidth =
+          parentRenderStyle?.contentBoxLogicalWidth
+          ?? parentRenderStyle?.contentBoxWidth;
+        // Percentage relative height priority: logical height > renderer height
+        double? parentPaddingBoxHeight =
+          parentRenderStyle?.paddingBoxLogicalHeight
+          ?? parentRenderStyle?.paddingBoxHeight;
+        double? parentContentBoxHeight =
+          parentRenderStyle?.contentBoxLogicalHeight
+          ?? parentRenderStyle?.contentBoxHeight;
 
         // Positioned element is positioned relative to the padding box of its containing block
         // while the others relative to the content box.

--- a/kraken/lib/src/rendering/box_model.dart
+++ b/kraken/lib/src/rendering/box_model.dart
@@ -375,6 +375,7 @@ class RenderLayoutBox extends RenderBoxModel
         }
       }
     }
+print('specifiedContentWidth---------- $this $specifiedContentWidth $contentWidth');
 
     if (specifiedContentWidth != null) {
       finalContentWidth = math.max(specifiedContentWidth, contentWidth);

--- a/kraken/lib/src/rendering/box_model.dart
+++ b/kraken/lib/src/rendering/box_model.dart
@@ -362,20 +362,24 @@ class RenderLayoutBox extends RenderBoxModel
     // Size which is specified by sizing styles
     double? specifiedContentWidth = renderStyle.contentBoxLogicalWidth;
     double? specifiedContentHeight = renderStyle.contentBoxLogicalHeight;
-    // Flex basis takes priority over main size in flex item.
+
+    // Flex basis takes priority over main size in flex item when flex-grow or flex-shrink not work.
     if (parent is RenderFlexLayout) {
       RenderBoxModel? parentRenderBoxModel = parent as RenderBoxModel?;
       double? flexBasis = renderStyle.flexBasis == CSSLengthValue.auto ? null : renderStyle.flexBasis?.computedValue;
       if (flexBasis != null) {
         if (CSSFlex.isHorizontalFlexDirection(
             parentRenderBoxModel!.renderStyle.flexDirection)) {
-          specifiedContentWidth = _getContentWidth(flexBasis);
+          if (!hasOverrideContentLogicalWidth) {
+            specifiedContentWidth = _getContentWidth(flexBasis);
+          }
         } else {
-          specifiedContentHeight = _getContentHeight(flexBasis);
+          if (!hasOverrideContentLogicalHeight) {
+            specifiedContentHeight = _getContentHeight(flexBasis);
+          }
         }
       }
     }
-print('specifiedContentWidth---------- $this $specifiedContentWidth $contentWidth');
 
     if (specifiedContentWidth != null) {
       finalContentWidth = math.max(specifiedContentWidth, contentWidth);
@@ -724,6 +728,15 @@ class RenderBoxModel extends RenderBox
     return currentBox.parent is RenderViewportBox;
   }
 
+  // Width/height is overrided by flex-grow or flex-shrink in flex layout.
+  bool hasOverrideContentLogicalWidth = false;
+  bool hasOverrideContentLogicalHeight = false;
+
+  void clearOverrideContentSize() {
+    hasOverrideContentLogicalWidth = false;
+    hasOverrideContentLogicalHeight = false;
+  }
+
   // Auto value for min-width which equals to the total width of children
   // which is in flow (excluding position absolute/fixed).
   double autoMinWidth = 0;
@@ -857,7 +870,8 @@ class RenderBoxModel extends RenderBox
     double maxConstraintHeight = renderStyle.borderBoxLogicalHeight ?? double.infinity;
 
     if (parent is RenderFlexLayout) {
-      double? flexBasis = renderStyle.flexBasis == CSSLengthValue.auto ? null : renderStyle.flexBasis?.computedValue;
+      double? flexBasis = renderStyle.flexBasis == CSSLengthValue.auto
+        ? null : renderStyle.flexBasis?.computedValue;
       RenderBoxModel? parentRenderBoxModel = parent as RenderBoxModel?;
       // In flex layout, flex basis takes priority over width/height if set.
       // Flex-basis cannot be smaller than its content size which happens can not be known
@@ -865,44 +879,40 @@ class RenderBoxModel extends RenderBox
       if (flexBasis != null) {
         if (CSSFlex.isHorizontalFlexDirection(
             parentRenderBoxModel!.renderStyle.flexDirection)) {
-          minConstraintWidth = flexBasis;
-          // Clamp flex-basis by minWidth and maxWidth
-          if (minWidth != null && flexBasis < minWidth) {
-            maxConstraintWidth = minWidth;
-          }
-          if (maxWidth != null && flexBasis > maxWidth) {
-            minConstraintWidth = maxWidth;
-          }
+          minWidth = minWidth != null
+            ? math.max(flexBasis, minWidth) : flexBasis;
         } else {
-          minConstraintHeight = flexBasis;
-          // Clamp flex-basis by minHeight and maxHeight
-          if (minHeight != null && flexBasis < minHeight) {
-            maxConstraintHeight = minHeight;
-          }
-          if (maxHeight != null && flexBasis > maxHeight) {
-            minConstraintHeight = maxHeight;
-          }
+          minHeight = minHeight != null
+            ? math.max(flexBasis, minHeight) : flexBasis;
         }
       }
     }
 
-    // min/max size does not apply for inline element
+    // Clamp constraints by min/max size when display is not inline.
     if (!isDisplayInline) {
       if (minWidth != null) {
-        minConstraintWidth =
-            minConstraintWidth < minWidth ? minWidth : minConstraintWidth;
+        minConstraintWidth = minConstraintWidth < minWidth
+          ? minWidth : minConstraintWidth;
+        maxConstraintWidth = maxConstraintWidth < minWidth
+          ? minWidth : maxConstraintWidth;
       }
       if (maxWidth != null) {
-        maxConstraintWidth =
-            maxConstraintWidth > maxWidth ? maxWidth : maxConstraintWidth;
+        minConstraintWidth = minConstraintWidth > maxWidth
+          ? maxWidth : minConstraintWidth;
+        maxConstraintWidth = maxConstraintWidth > maxWidth
+          ? maxWidth : maxConstraintWidth;
       }
       if (minHeight != null) {
-        minConstraintHeight =
-            minConstraintHeight < minHeight ? minHeight : minConstraintHeight;
+        minConstraintHeight = minConstraintHeight < minHeight
+          ? minHeight : minConstraintHeight;
+        maxConstraintHeight = maxConstraintHeight < minHeight
+          ? minHeight : maxConstraintHeight;
       }
       if (maxHeight != null) {
-        maxConstraintHeight =
-            maxConstraintHeight > maxHeight ? maxHeight : maxConstraintHeight;
+        minConstraintHeight = minConstraintHeight > maxHeight
+          ? maxHeight : minConstraintHeight;
+        maxConstraintHeight = maxConstraintHeight > maxHeight
+          ? maxHeight : maxConstraintHeight;
       }
     }
 


### PR DESCRIPTION
Closes https://github.com/openkraken/kraken/issues/1224

问题原因：当  flex item 有 flex-grow/flex-shrink/align-items stretch 时因 constraints 被设置成 tight，导致形成了 relayoutBoundary child markNeedsLayout 时 dirty 标识无法向上冒泡，从而 flex item 无法触发 layout。

fix: 
* 重构 flex layout 中当 flex-grow/flex-shrink/align-items stretch 存在时，对 child 进行二次 layout constraints 的计算逻辑，应使用设置 contentBoxLogicalLength 方式而不是设置 tight constraints 的方式来将变更后的 length 传递给 child（在 getConstraints 中会向上递归查找）。
* 修复 flex-basis 大于主轴设置的 size 时报错。
* 修复 flex item 为 replaced element 且 cross axis 的 length 未定义时，cross axis length 被用 intrisic ratio 计算的问题。