### PR TITLE
fix: file protocol and test cases

### DIFF
--- a/kraken/lib/src/dom/element.dart
+++ b/kraken/lib/src/dom/element.dart
@@ -1558,8 +1558,6 @@ abstract class Element
   }
 
   Future<Uint8List> toBlob({ double? devicePixelRatio }) {
-    devicePixelRatio ??= window.devicePixelRatio;
-
     Completer<Uint8List> completer = Completer();
     forceToRepaintBoundary = true;
     renderBoxModel!.owner!.flushLayout();
@@ -1568,16 +1566,11 @@ abstract class Element
       Uint8List captured;
       RenderBoxModel _renderBoxModel = renderBoxModel!;
 
-      // If prev flush paint with error, render object keeps NEEDS-PAINT flag,
-      // will cause layer not exists.
-      assert(!_renderBoxModel.debugNeedsPaint, () {
-        debugPrint('Failed toBlob at $this, flush painting may raise error.');
-      });
       if (_renderBoxModel.hasSize && _renderBoxModel.size.isEmpty) {
         // Return a blob with zero length.
         captured = Uint8List(0);
       } else {
-        Image image = await _renderBoxModel.toImage(pixelRatio: devicePixelRatio!);
+        Image image = await _renderBoxModel.toImage(pixelRatio: devicePixelRatio ?? window.devicePixelRatio);
         ByteData? byteData = await image.toByteData(format: ImageByteFormat.png);
         captured = byteData!.buffer.asUint8List();
       }

--- a/kraken/lib/src/dom/elements/head.dart
+++ b/kraken/lib/src/dom/elements/head.dart
@@ -117,7 +117,7 @@ class LinkElement extends Element {
       try {
         KrakenBundle bundle = KrakenBundle.fromUrl(url);
         await bundle.resolve(contextId);
-        bundle.eval(contextId);
+        await bundle.eval(contextId);
 
         // Successful load.
         SchedulerBinding.instance!.addPostFrameCallback((_) {
@@ -278,7 +278,7 @@ class ScriptElement extends Element {
       try {
         KrakenBundle bundle = KrakenBundle.fromUrl(src.toString());
         await bundle.resolve(contextId);
-        bundle.eval(contextId);
+        await bundle.eval(contextId);
         // Successful load.
         SchedulerBinding.instance!.addPostFrameCallback((_) {
           dispatchEvent(Event(EVENT_LOAD));
@@ -309,7 +309,7 @@ class ScriptElement extends Element {
         if (controller != null) {
           KrakenBundle bundle = KrakenBundle.fromContent(script, url: controller.url);
           await bundle.resolve(contextId);
-          bundle.eval(contextId);
+          await bundle.eval(contextId);
         }
       }
     }

--- a/kraken/lib/src/launcher/bundle.dart
+++ b/kraken/lib/src/launcher/bundle.dart
@@ -231,7 +231,7 @@ class NetworkBundle extends KrakenBundle {
   }
 }
 
-Future<String> _resolveStringFromData(List<int> data, { Codec codec = utf8 }) {
+Future<String> _resolveStringFromData(List<int> data, { Codec codec = utf8 }) async {
   // Utf8 decode is fast enough with dart 2.10
   // reference: https://github.com/flutter/flutter/blob/master/packages/flutter/lib/src/services/asset_bundle.dart#L71
   // 50 KB of data should take 2-3 ms to parse on a Moto G4, and about 400 μs

--- a/kraken/lib/src/launcher/bundle.dart
+++ b/kraken/lib/src/launcher/bundle.dart
@@ -86,16 +86,11 @@ abstract class KrakenBundle {
   // The bundle data of raw.
   Uint8List? data;
 
-  // Indicate the bundle is resolve.
-  bool get isResolved => _uri != null;
+  // Indicate the bundle is resolved.
+  bool get isResolved => _uri != null && data != null;
 
   // Content type for data.
   ContentType contentType = ContentType.binary;
-
-  // Indicate the bundle is empty.
-  bool get isEmpty => data == null || data!.isEmpty;
-
-  bool get isNotEmpty => !isEmpty;
 
   @mustCallSuper
   Future<void> resolve(int? contextId) async {
@@ -143,7 +138,7 @@ abstract class KrakenBundle {
       PerformanceTiming.instance().mark(PERF_JS_BUNDLE_EVAL_START);
     }
 
-    if (contextId != null && !isEmpty) {
+    if (contextId != null) {
       Uint8List data = this.data!;
       if (_isHTML) {
         // parse html.

--- a/kraken/lib/src/launcher/bundle.dart
+++ b/kraken/lib/src/launcher/bundle.dart
@@ -22,16 +22,13 @@ const String ENABLE_DEBUG = 'KRAKEN_ENABLE_DEBUG';
 const String ENABLE_PERFORMANCE_OVERLAY = 'KRAKEN_ENABLE_PERFORMANCE_OVERLAY';
 const String DEFAULT_URL = 'about:blank';
 
-const String _cssMimeType = 'text/css';
+final ContentType _cssContentType = ContentType('text', 'css', charset: 'utf-8');
 // MIME types suits JavaScript: https://mathiasbynens.be/demo/javascript-mime-type
-const String _javascriptMimeType = 'text/javascript';
-const String _javascriptApplicationMimeType = 'application/javascript';
-const String _xJavascriptMimeType = 'application/x-javascript';
-const String _krakenBc1MimeType = 'application/vnd.kraken.bc1';
+final ContentType _javascriptContentType = ContentType('text', 'javascript', charset: 'utf-8');
+final ContentType _javascriptApplicationContentType = ContentType('application', 'javascript', charset: 'utf-8');
+final ContentType _xJavascriptContentType = ContentType('application', 'x-javascript', charset: 'utf-8');
+final ContentType _krakenBc1ContentType = ContentType('application', 'vnd.kraken.bc1');
 
-final ContentType _javascriptContentType = ContentType.parse(_javascriptMimeType);
-final ContentType _cssContentType = ContentType.parse(_cssMimeType);
-final ContentType _krakenBc1ContentType = ContentType.parse(_krakenBc1MimeType);
 
 String? getBundleURLFromEnv() {
   return Platform.environment[BUNDLE_URL];
@@ -168,11 +165,11 @@ abstract class KrakenBundle {
   }
 
   bool get _isHTML => contentType.mimeType == ContentType.html.mimeType || _isUriExt('.html');
-  bool get _isCSS => contentType.mimeType == _cssMimeType || _isUriExt('.css');
-  bool get _isJavascript => contentType.mimeType == _javascriptMimeType ||
-                          contentType.mimeType == _javascriptApplicationMimeType ||
-                          contentType.mimeType == _xJavascriptMimeType ||
-                          _isUriExt('.js');
+  bool get _isCSS => contentType.mimeType == _cssContentType.mimeType || _isUriExt('.css');
+  bool get _isJavascript => contentType.mimeType == _javascriptContentType.mimeType ||
+                            contentType.mimeType == _javascriptApplicationContentType.mimeType ||
+                            contentType.mimeType == _xJavascriptContentType.mimeType ||
+                            _isUriExt('.js');
   bool get _isBytecode => _isBytecodeSupported(contentType.mimeType, _uri!);
 
   bool _isUriExt(String ext) {

--- a/kraken/lib/src/launcher/bundle.dart
+++ b/kraken/lib/src/launcher/bundle.dart
@@ -47,7 +47,7 @@ String getAcceptHeader() {
   return 'text/html,application/javascript,$krakenKbcAccept';
 }
 
-bool _isSchemeAsset(String path) {
+bool _isSchemeAssets(String path) {
   return path.startsWith('assets:');
 }
 
@@ -119,12 +119,12 @@ abstract class KrakenBundle {
   }
 
   static KrakenBundle fromUrl(String url, { Map<String, String>? additionalHttpHeaders }) {
-    if (_isSchemeAsset(url)) {
+    if (_isSchemeHttp(url)) {
+      return NetworkBundle(url, additionalHttpHeaders: additionalHttpHeaders);
+    } else if (_isSchemeAssets(url)) {
       return AssetsBundle(url);
     } else if (_isSchemeFile(url)) {
       return FileBundle(url);
-    } else if (_isSchemeHttp(url)) {
-      return NetworkBundle(url, additionalHttpHeaders: additionalHttpHeaders);
     } else if (_isSchemeAbout(url)) {
       return _EmptyBundle(url);
     } else {

--- a/kraken/lib/src/launcher/bundle.dart
+++ b/kraken/lib/src/launcher/bundle.dart
@@ -22,12 +22,16 @@ const String ENABLE_DEBUG = 'KRAKEN_ENABLE_DEBUG';
 const String ENABLE_PERFORMANCE_OVERLAY = 'KRAKEN_ENABLE_PERFORMANCE_OVERLAY';
 const String DEFAULT_URL = 'about:blank';
 
-final ContentType _cssMimeType = ContentType('text', 'css', charset: 'utf-8');
+const String _cssMimeType = 'text/css';
 // MIME types suits JavaScript: https://mathiasbynens.be/demo/javascript-mime-type
-final ContentType _javascriptMimeType = ContentType('text', 'javascript', charset: 'utf-8');
-final ContentType _javascriptApplicationMimeType = ContentType('application', 'javascript', charset: 'utf-8');
-final ContentType _xJavascriptMimeType = ContentType('application', 'x-javascript', charset: 'utf-8');
-final ContentType _krakenBc1MimeType = ContentType('application', 'vnd.kraken.bc1');
+const String _javascriptMimeType = 'text/javascript';
+const String _javascriptApplicationMimeType = 'application/javascript';
+const String _xJavascriptMimeType = 'application/x-javascript';
+const String _krakenBc1MimeType = 'application/vnd.kraken.bc1';
+
+final ContentType _javascriptContentType = ContentType.parse(_javascriptMimeType);
+final ContentType _cssContentType = ContentType.parse(_cssMimeType);
+final ContentType _krakenBc1ContentType = ContentType.parse(_krakenBc1MimeType);
 
 String? getBundleURLFromEnv() {
   return Platform.environment[BUNDLE_URL];
@@ -114,18 +118,18 @@ abstract class KrakenBundle {
     } else if (_isFileScheme(url)) {
       return FileBundle(url);
     } else if (_isDefaultUrl(url)) {
-      return DataBundle.fromString('', url, contentType: _javascriptMimeType);
+      return DataBundle.fromString('', url, contentType: _javascriptContentType);
     } else {
       throw FlutterError('Unsupported url. $url');
     }
   }
 
   static KrakenBundle fromContent(String content, { String url = DEFAULT_URL }) {
-    return DataBundle.fromString(content, url, contentType: _javascriptMimeType);
+    return DataBundle.fromString(content, url, contentType: _javascriptContentType);
   }
 
   static KrakenBundle fromBytecode(Uint8List data, { String url = DEFAULT_URL }) {
-    return DataBundle(data, url, contentType: _krakenBc1MimeType);
+    return DataBundle(data, url, contentType: _javascriptContentType);
   }
 
   Future<void> eval(int? contextId) async {
@@ -164,10 +168,10 @@ abstract class KrakenBundle {
   }
 
   bool get _isHTML => contentType.mimeType == ContentType.html.mimeType || _isUriExt('.html');
-  bool get _isCSS => contentType.mimeType == _cssMimeType.mimeType || _isUriExt('.css');
-  bool get _isJavascript => contentType.mimeType == _javascriptMimeType.mimeType ||
-                          contentType.mimeType == _javascriptApplicationMimeType.mimeType ||
-                          contentType.mimeType == _xJavascriptMimeType.mimeType ||
+  bool get _isCSS => contentType.mimeType == _cssMimeType || _isUriExt('.css');
+  bool get _isJavascript => contentType.mimeType == _javascriptMimeType ||
+                          contentType.mimeType == _javascriptApplicationMimeType ||
+                          contentType.mimeType == _xJavascriptMimeType ||
                           _isUriExt('.js');
   bool get _isBytecode => _isBytecodeSupported(contentType.mimeType, _uri!);
 
@@ -294,12 +298,12 @@ class FileBundle extends KrakenBundle {
       if (_isHTML) {
         contentType = ContentType.html;
       } else if (_isBytecode) {
-        contentType = _krakenBc1MimeType;
+        contentType = _krakenBc1ContentType;
       } else if (_isCSS) {
-        contentType = _cssMimeType;
+        contentType = _cssContentType;
       } else {
         // Fallback to javascript.
-        contentType = _javascriptMimeType;
+        contentType = _javascriptContentType;
       }
     } else {
       _failedToResolveBundle(url);

--- a/kraken/lib/src/launcher/bundle.dart
+++ b/kraken/lib/src/launcher/bundle.dart
@@ -119,7 +119,7 @@ abstract class KrakenBundle {
     } else if (_isFileScheme(url)) {
       return FileBundle(url);
     } else if (_isDefaultUrl(url)) {
-      return DataBundle.fromString('', url);
+      return DataBundle.fromString('', url, contentType: javascript);
     } else {
       throw FlutterError('Unsupported url. $url');
     }

--- a/kraken/lib/src/launcher/bundle.dart
+++ b/kraken/lib/src/launcher/bundle.dart
@@ -22,12 +22,12 @@ const String ENABLE_DEBUG = 'KRAKEN_ENABLE_DEBUG';
 const String ENABLE_PERFORMANCE_OVERLAY = 'KRAKEN_ENABLE_PERFORMANCE_OVERLAY';
 const String DEFAULT_URL = 'about:blank';
 
-final ContentType css = ContentType('text', 'css', charset: 'utf-8');
+final ContentType _cssMimeType = ContentType('text', 'css', charset: 'utf-8');
 // https://mathiasbynens.be/demo/javascript-mime-type
-final ContentType javascript = ContentType('text', 'javascript', charset: 'utf-8');
-final ContentType applicationJavascript = ContentType('application', 'javascript', charset: 'utf-8');
-final ContentType applicationXJavascript = ContentType('application', 'x-javascript', charset: 'utf-8');
-final ContentType bytecode1 = ContentType('application', 'vnd.kraken.bc1');
+final ContentType _javascriptMimeType = ContentType('text', 'javascript', charset: 'utf-8');
+final ContentType _javascriptApplicationMimeType = ContentType('application', 'javascript', charset: 'utf-8');
+final ContentType _xJavascriptMimeType = ContentType('application', 'x-javascript', charset: 'utf-8');
+final ContentType _krakenBc1MimeType = ContentType('application', 'vnd.kraken.bc1');
 
 String? getBundleURLFromEnv() {
   return Platform.environment[BUNDLE_URL];
@@ -114,18 +114,18 @@ abstract class KrakenBundle {
     } else if (_isFileScheme(url)) {
       return FileBundle(url);
     } else if (_isDefaultUrl(url)) {
-      return DataBundle.fromString('', url, contentType: javascript);
+      return DataBundle.fromString('', url, contentType: _javascriptMimeType);
     } else {
       throw FlutterError('Unsupported url. $url');
     }
   }
 
   static KrakenBundle fromContent(String content, { String url = DEFAULT_URL }) {
-    return DataBundle.fromString(content, url, contentType: javascript);
+    return DataBundle.fromString(content, url, contentType: _javascriptMimeType);
   }
 
   static KrakenBundle fromBytecode(Uint8List data, { String url = DEFAULT_URL }) {
-    return DataBundle(data, url, contentType: bytecode1);
+    return DataBundle(data, url, contentType: _krakenBc1MimeType);
   }
 
   Future<void> eval(int? contextId) async {
@@ -164,10 +164,10 @@ abstract class KrakenBundle {
   }
 
   bool get _isHTML => contentType.mimeType == ContentType.html.mimeType || _isUriExt('.html');
-  bool get _isCSS => contentType.mimeType == css.mimeType || _isUriExt('.css');
-  bool get _isJavascript => contentType.mimeType == javascript.mimeType ||
-                          contentType.mimeType == applicationJavascript.mimeType ||
-                          contentType.mimeType == applicationXJavascript.mimeType ||
+  bool get _isCSS => contentType.mimeType == _cssMimeType.mimeType || _isUriExt('.css');
+  bool get _isJavascript => contentType.mimeType == _javascriptMimeType.mimeType ||
+                          contentType.mimeType == _javascriptApplicationMimeType.mimeType ||
+                          contentType.mimeType == _xJavascriptMimeType.mimeType ||
                           _isUriExt('.js');
   bool get _isBytecode => _isBytecodeSupported(contentType.mimeType, _uri!);
 
@@ -294,12 +294,12 @@ class FileBundle extends KrakenBundle {
       if (_isHTML) {
         contentType = ContentType.html;
       } else if (_isBytecode) {
-        contentType = bytecode1;
+        contentType = _krakenBc1MimeType;
       } else if (_isCSS) {
-        contentType = css;
+        contentType = _cssMimeType;
       } else {
         // Fallback to javascript.
-        contentType = javascript;
+        contentType = _javascriptMimeType;
       }
     } else {
       _failedToResolveBundle(url);

--- a/kraken/lib/src/launcher/bundle.dart
+++ b/kraken/lib/src/launcher/bundle.dart
@@ -231,18 +231,20 @@ class NetworkBundle extends KrakenBundle {
   }
 }
 
-Future<String> _resolveStringFromData(List<int> data, { Codec codec = utf8 }) async {
+Future<String> _resolveStringFromData(final List<int> data) async {
   // Utf8 decode is fast enough with dart 2.10
   // reference: https://github.com/flutter/flutter/blob/master/packages/flutter/lib/src/services/asset_bundle.dart#L71
   // 50 KB of data should take 2-3 ms to parse on a Moto G4, and about 400 μs
   // on a Pixel 4.
   if (data.length < 50 * 1024) {
-    return codec.decode(data);
+    return utf8.decode(data);
   }
   // For strings larger than 50 KB, run the computation in an isolate to
   // avoid causing main thread jank.
-  return compute((data) => codec.decode(data), data);
+  return compute(_utf8decode, data);
 }
+
+String _utf8decode(List<int> data) => utf8.decode(data);
 
 class AssetsBundle extends KrakenBundle {
   AssetsBundle(String url) : super(url);

--- a/kraken/lib/src/launcher/bundle.dart
+++ b/kraken/lib/src/launcher/bundle.dart
@@ -39,7 +39,7 @@ String? getBundlePathFromEnv() {
 
 List<String> _supportedByteCodeVersions = ['1'];
 
-bool _isByteCodeSupported(String mimeType, Uri uri) {
+bool _isBytecodeSupported(String mimeType, Uri uri) {
   for (int i = 0; i < _supportedByteCodeVersions.length; i ++) {
     if (mimeType.contains('application/vnd.kraken.bc' + _supportedByteCodeVersions[i])) return true;
     if (uri.path.endsWith('.kbc' + _supportedByteCodeVersions[i])) return true;
@@ -143,9 +143,9 @@ abstract class KrakenBundle {
       if (_isHTML) {
         // parse html.
         parseHTML(contextId, await _resolveStringFromData(data));
-      } else if (_isJSString) {
+      } else if (_isJavascript) {
         evaluateScripts(contextId, await _resolveStringFromData(data), url, 0);
-      } else if (_isJSBytecode) {
+      } else if (_isBytecode) {
         evaluateQuickjsByteCode(contextId, data);
       } else if (_isCSS) {
         _addCSSStyleSheet(await _resolveStringFromData(data), contextId: contextId);
@@ -165,11 +165,11 @@ abstract class KrakenBundle {
 
   bool get _isHTML => contentType.mimeType == ContentType.html.mimeType || _isUriExt('.html');
   bool get _isCSS => contentType.mimeType == css.mimeType || _isUriExt('.css');
-  bool get _isJSString => contentType.mimeType == javascript.mimeType ||
+  bool get _isJavascript => contentType.mimeType == javascript.mimeType ||
                           contentType.mimeType == applicationJavascript.mimeType ||
                           contentType.mimeType == applicationXJavascript.mimeType ||
                           _isUriExt('.js');
-  bool get _isJSBytecode => _isByteCodeSupported(contentType.mimeType, _uri!);
+  bool get _isBytecode => _isBytecodeSupported(contentType.mimeType, _uri!);
 
   bool _isUriExt(String ext) {
     Uri? uri = resolvedUri;
@@ -293,7 +293,7 @@ class FileBundle extends KrakenBundle {
       data = await file.readAsBytes();
       if (_isHTML) {
         contentType = ContentType.html;
-      } else if (_isJSBytecode) {
+      } else if (_isBytecode) {
         contentType = bytecode1;
       } else if (_isCSS) {
         contentType = css;

--- a/kraken/lib/src/launcher/controller.dart
+++ b/kraken/lib/src/launcher/controller.dart
@@ -1153,7 +1153,7 @@ class KrakenController {
   }
 
   // Execute the content from entrypoint bundle.
-  void _evaluateEntrypoint({ AnimationController? animationController }) {
+  void _evaluateEntrypoint({ AnimationController? animationController }) async {
     // @HACK: Execute JavaScript scripts will block the Flutter UI Threads.
     // Listen for animationController listener to make sure to execute Javascript after route transition had completed.
     if (animationController != null) {
@@ -1167,7 +1167,7 @@ class KrakenController {
 
     assert(!_view._disposed, 'Kraken have already disposed');
     if (_entrypoint != null) {
-      _entrypoint!.eval(_view.contextId);
+      await _entrypoint!.eval(_view.contextId);
       // trigger DOMContentLoaded event
       module.requestAnimationFrame((_) {
         Event event = Event(EVENT_DOM_CONTENT_LOADED);

--- a/kraken/lib/src/launcher/controller.dart
+++ b/kraken/lib/src/launcher/controller.dart
@@ -5,6 +5,7 @@
 
 import 'dart:async';
 import 'dart:collection';
+import 'dart:convert';
 import 'dart:ffi';
 import 'dart:io';
 import 'dart:typed_data';
@@ -1054,8 +1055,8 @@ class KrakenController {
   }
 
   String? getResourceContent(String? url) {
-    if (url == this.url) {
-      return _entrypoint?.content;
+    if (url == this.url && _entrypoint != null && !_entrypoint!.isEmpty) {
+      return utf8.decode(_entrypoint!.data!);
     }
   }
 

--- a/kraken/lib/src/launcher/controller.dart
+++ b/kraken/lib/src/launcher/controller.dart
@@ -1141,6 +1141,8 @@ class KrakenController {
       if (onLoadError != null) {
         onLoadError!(FlutterError(e.toString()), stack);
       }
+      // Not to dismiss this error.
+      rethrow;
     }
 
     if (kProfileMode) {

--- a/kraken/lib/src/launcher/controller.dart
+++ b/kraken/lib/src/launcher/controller.dart
@@ -1055,8 +1055,9 @@ class KrakenController {
   }
 
   String? getResourceContent(String? url) {
-    if (url == this.url && _entrypoint != null && !_entrypoint!.isEmpty) {
-      return utf8.decode(_entrypoint!.data!);
+    KrakenBundle? entrypoint = _entrypoint;
+    if (url == this.url && entrypoint != null && entrypoint.isNotEmpty) {
+      return utf8.decode(entrypoint.data!);
     }
   }
 

--- a/kraken/lib/src/launcher/controller.dart
+++ b/kraken/lib/src/launcher/controller.dart
@@ -1056,7 +1056,7 @@ class KrakenController {
 
   String? getResourceContent(String? url) {
     KrakenBundle? entrypoint = _entrypoint;
-    if (url == this.url && entrypoint != null && entrypoint.isNotEmpty) {
+    if (url == this.url && entrypoint != null && entrypoint.isResolved) {
       return utf8.decode(entrypoint.data!);
     }
   }
@@ -1131,8 +1131,8 @@ class KrakenController {
     }
 
     KrakenBundle? bundleToLoad = _entrypoint;
-    if (bundleToLoad == null || bundleToLoad.isEmpty) {
-      // Do nothing if bundle is empty.
+    if (bundleToLoad == null) {
+      // Do nothing if bundle is null.
       return;
     }
 

--- a/kraken/lib/src/module/history.dart
+++ b/kraken/lib/src/module/history.dart
@@ -40,7 +40,7 @@ class HistoryModule extends BaseModule {
   }
 
   void _addItem(HistoryItem historyItem) {
-    if (_previousStack.isNotEmpty && historyItem.bundle.src == _previousStack.first.bundle.src) return;
+    if (_previousStack.isNotEmpty && historyItem.bundle.url == _previousStack.first.bundle.url) return;
 
     _previousStack.addFirst(historyItem);
 
@@ -57,7 +57,7 @@ class HistoryModule extends BaseModule {
       _previousStack.removeFirst();
       _nextStack.addFirst(currentItem);
 
-      await _goTo(_previousStack.first.bundle.src);
+      await _goTo(_previousStack.first.bundle.url);
 
       dynamic state = _previousStack.first.state;
       _dispatchPopStateEvent(state);
@@ -70,7 +70,7 @@ class HistoryModule extends BaseModule {
       _nextStack.removeFirst();
       _previousStack.addFirst(currentItem);
 
-      _goTo(currentItem.bundle.src);
+      _goTo(currentItem.bundle.url);
       _dispatchPopStateEvent(currentItem.state);
     }
   }
@@ -99,7 +99,7 @@ class HistoryModule extends BaseModule {
       }
     }
 
-    _goTo(_previousStack.first.bundle.src);
+    _goTo(_previousStack.first.bundle.url);
     _dispatchPopStateEvent(_previousStack.first.state);
   }
 
@@ -122,7 +122,7 @@ class HistoryModule extends BaseModule {
     if (params[2] != null) {
       url = params[2];
 
-      String currentUrl = _previousStack.first.bundle.src;
+      String currentUrl = _previousStack.first.bundle.url;
       Uri currentUri = Uri.parse(currentUrl);
 
       Uri uri = Uri.parse(url!);
@@ -148,7 +148,7 @@ class HistoryModule extends BaseModule {
     if (params[2] != null) {
       url = params[2];
 
-      String currentUrl = _previousStack.first.bundle.src;
+      String currentUrl = _previousStack.first.bundle.url;
       Uri currentUri = Uri.parse(currentUrl);
 
       Uri uri = Uri.parse(url!);

--- a/kraken/test/kraken_test.dart
+++ b/kraken/test/kraken_test.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 import 'package:flutter/widgets.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:kraken/bridge.dart';
 import 'package:kraken/foundation.dart';
 
 import 'local_http_server.dart';
@@ -33,6 +34,9 @@ void main() {
   LocalHttpServer.basePath = 'test/fixtures';
   var httpServer = LocalHttpServer.getInstance();
   print('Local HTTP Server started at ${httpServer.getUri()}');
+
+  // Work with bridge path.
+  KrakenDynamicLibrary.dynamicLibraryPath = '${Directory.current.path}/macos';
 
   // Work around with path_provider.
   Directory tempDirectory = Directory('./temp');

--- a/kraken/test/kraken_test.dart
+++ b/kraken/test/kraken_test.dart
@@ -3,7 +3,6 @@ import 'dart:io';
 import 'package:flutter/widgets.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:kraken/bridge.dart';
 import 'package:kraken/foundation.dart';
 
 import 'local_http_server.dart';
@@ -34,9 +33,6 @@ void main() {
   LocalHttpServer.basePath = 'test/fixtures';
   var httpServer = LocalHttpServer.getInstance();
   print('Local HTTP Server started at ${httpServer.getUri()}');
-
-  // Work with bridge path.
-  KrakenDynamicLibrary.dynamicLibraryPath = '${Directory.current.path}/macos';
 
   // Work around with path_provider.
   Directory tempDirectory = Directory('./temp');

--- a/kraken/test/kraken_test.dart
+++ b/kraken/test/kraken_test.dart
@@ -4,6 +4,7 @@ import 'package:flutter/widgets.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:kraken/foundation.dart';
+import 'package:kraken/kraken.dart';
 
 import 'local_http_server.dart';
 
@@ -33,6 +34,9 @@ void main() {
   LocalHttpServer.basePath = 'test/fixtures';
   var httpServer = LocalHttpServer.getInstance();
   print('Local HTTP Server started at ${httpServer.getUri()}');
+
+  // Inject a custom user agent, to avoid reading from bridge.
+  NavigatorModule.setCustomUserAgent('kraken/test');
 
   // Work around with path_provider.
   Directory tempDirectory = Directory('./temp');

--- a/kraken/test/src/launcher/bundle.dart
+++ b/kraken/test/src/launcher/bundle.dart
@@ -29,7 +29,6 @@ void main() {
       await bundle.resolve(1);
 
       expect(bundle.isResolved, true);
-      expect(bundle.isEmpty, false);
     });
 
     test('DataBundle string', () async {

--- a/kraken/test/src/launcher/bundle.dart
+++ b/kraken/test/src/launcher/bundle.dart
@@ -1,5 +1,6 @@
 import 'dart:convert';
 import 'dart:typed_data';
+import 'dart:io';
 
 import 'package:kraken/launcher.dart';
 import 'package:test/test.dart';
@@ -10,14 +11,41 @@ void main() {
   var server = LocalHttpServer.getInstance();
 
   group('Bundle', () {
-    test('NetworkAssetsBundle basic', () async {
+    test('NetworkBundle basic', () async {
       Uri uri = server.getUri('js_over_128k');
+      var bundle = NetworkBundle(uri.toString());
       // Using contextId to active cache.
-      var bundle = NetworkAssetBundle(uri, contextId: 1);
-      ByteData data = await bundle.load(uri.toString());
+      await bundle.resolve(1);
+      ByteData data = await bundle.rawBundle!;
       var code = utf8.decode(data.buffer.asUint8List(data.offsetInBytes, data.lengthInBytes));
 
+      expect(bundle.isResolved, true);
       expect(code.length > 128 * 1024, true);
+    });
+
+    test('FileBundle basic', () async {
+      var filename = '${Directory.current.path}/example/assets/bundle.js';
+      var bundle = FileBundle('file://$filename');
+      await bundle.resolve(1);
+
+      expect(bundle.isResolved, true);
+      expect(bundle.content!.isNotEmpty, true);
+    });
+
+    test('RawBundle string', () async {
+      var content = 'hello world';
+      var bundle = RawBundle.fromString(content, 'about:blank');
+      await bundle.resolve(1);
+      expect(bundle.isResolved, true);
+      expect(bundle.content, content);
+    });
+
+    test('RawBundle bytecode', () async {
+      Uint8List bytecode = Uint8List.fromList(List.generate(10, (index) => index, growable: false));
+      var bundle = RawBundle.fromBytecode(bytecode, 'about:blank');
+      await bundle.resolve(1);
+      expect(bundle.isResolved, true);
+      expect(bundle.bytecode, bytecode);
     });
   });
 }

--- a/kraken/test/src/launcher/bundle.dart
+++ b/kraken/test/src/launcher/bundle.dart
@@ -16,8 +16,8 @@ void main() {
       var bundle = NetworkBundle(uri.toString());
       // Using contextId to active cache.
       await bundle.resolve(1);
-      ByteData data = await bundle.rawBundle!;
-      var code = utf8.decode(data.buffer.asUint8List(data.offsetInBytes, data.lengthInBytes));
+      Uint8List data = await bundle.data!;
+      var code = utf8.decode(data);
 
       expect(bundle.isResolved, true);
       expect(code.length > 128 * 1024, true);
@@ -29,23 +29,23 @@ void main() {
       await bundle.resolve(1);
 
       expect(bundle.isResolved, true);
-      expect(bundle.content!.isNotEmpty, true);
+      expect(bundle.isEmpty, false);
     });
 
-    test('RawBundle string', () async {
+    test('DataBundle string', () async {
       var content = 'hello world';
-      var bundle = RawBundle.fromString(content, 'about:blank');
+      var bundle = DataBundle.fromString(content, 'about:blank');
       await bundle.resolve(1);
       expect(bundle.isResolved, true);
-      expect(bundle.content, content);
+      expect(utf8.decode(bundle.data!), content);
     });
 
-    test('RawBundle bytecode', () async {
+    test('DataBundle data', () async {
       Uint8List bytecode = Uint8List.fromList(List.generate(10, (index) => index, growable: false));
-      var bundle = RawBundle.fromBytecode(bytecode, 'about:blank');
+      var bundle = DataBundle(bytecode, 'about:blank');
       await bundle.resolve(1);
       expect(bundle.isResolved, true);
-      expect(bundle.bytecode, bytecode);
+      expect(bundle.data, bytecode);
     });
   });
 }


### PR DESCRIPTION
- 修复 KrakenBundle 不支持 file:// 协议的问题
  - 配套测试
- 移除了 NetworkAssetBundle, 这个类不是 KrakenBundle 而是 flutter/service 的 AssetBundle, 起的作用是封装 Http 请求, 理论上无必要, 且每次都新建一个 HttpClient, 本次改动改成复用同一个 HttpClient, 逻辑收敛到 NetworkBundle 类上. 
  - 后续会把图片的 httpClient 与这个 httpClient 共享