### PR TITLE
hotfix: from bytecode

### DIFF
--- a/kraken/lib/src/launcher/bundle.dart
+++ b/kraken/lib/src/launcher/bundle.dart
@@ -126,7 +126,7 @@ abstract class KrakenBundle {
   }
 
   static KrakenBundle fromBytecode(Uint8List data, { String url = DEFAULT_URL }) {
-    return DataBundle(data, url, contentType: _javascriptContentType);
+    return DataBundle(data, url, contentType: _krakenBc1ContentType);
   }
 
   Future<void> eval(int? contextId) async {

--- a/kraken/pubspec.yaml
+++ b/kraken/pubspec.yaml
@@ -1,6 +1,6 @@
 name: kraken
 description: A high-performance, web standards-compliant rendering engine.
-version: 0.10.3
+version: 0.10.3+1
 homepage: https://openkraken.com
 
 environment:

--- a/kraken/test/src/launcher/bundle.dart
+++ b/kraken/test/src/launcher/bundle.dart
@@ -46,5 +46,12 @@ void main() {
       expect(bundle.isResolved, true);
       expect(bundle.data, bytecode);
     });
+
+    test('KrakenBundle', () async {
+      Uint8List bytecode = Uint8List.fromList(List.generate(10, (index) => index, growable: false));
+      var bundle = KrakenBundle.fromBytecode(bytecode);
+      await bundle.resolve(1);
+      expect(bundle.contentType.mimeType, 'application/vnd.kraken.bc1');
+    });
   });
 }


### PR DESCRIPTION
- 修复 fromBytecode 的 content type 类型, 增加了测试用例
- 申请发布 0.10.3+1