### PR TITLE
fix: DataBundle string with non latin

### DIFF
--- a/kraken/lib/src/foundation/bundle.dart
+++ b/kraken/lib/src/foundation/bundle.dart
@@ -3,6 +3,7 @@
  * Author: Kraken Team.
  */
 import 'dart:async';
+import 'dart:convert';
 import 'dart:core';
 import 'dart:io';
 import 'dart:typed_data';
@@ -164,7 +165,8 @@ class DataBundle extends KrakenBundle {
   }
 
   DataBundle.fromString(String content, String url, { ContentType? contentType }) : super(url) {
-    data = Uint8List.fromList(content.codeUnits);
+    // Encode string to data by utf8.
+    data = Uint8List.fromList(utf8.encode(content));
     this.contentType = contentType ?? ContentType.text;
   }
 

--- a/kraken/test/src/foundation/bundle.dart
+++ b/kraken/test/src/foundation/bundle.dart
@@ -39,6 +39,14 @@ void main() {
       expect(utf8.decode(bundle.data!), content);
     });
 
+    test('DataBundle with non-latin string', () async {
+      var content = '你好,世界😈';
+      var bundle = DataBundle.fromString(content, 'about:blank');
+      await bundle.resolve(1);
+      expect(bundle.isResolved, true);
+      expect(utf8.decode(bundle.data!), content);
+    });
+
     test('DataBundle data', () async {
       Uint8List bytecode = Uint8List.fromList(List.generate(10, (index) => index, growable: false));
       var bundle = DataBundle(bytecode, 'about:blank');


### PR DESCRIPTION
Close #1262 

- 修复 KrakenBundle.fromString 包含中文字符异常问题