### PR TITLE
fix: memory leaks from window

### DIFF
--- a/kraken/lib/src/dom/window.dart
+++ b/kraken/lib/src/dom/window.dart
@@ -16,11 +16,7 @@ class Window extends EventTarget {
   final Screen screen;
 
   Window(BindingContext? context, this.document)
-      : screen = Screen(context), super(context) {
-    window.onPlatformBrightnessChanged = () {
-      dispatchEvent(ColorSchemeChangeEvent(colorScheme));
-    };
-  }
+      : screen = Screen(context), super(context);
 
   @override
   EventTarget? get parentEventTarget => null;

--- a/kraken/lib/src/launcher/controller.dart
+++ b/kraken/lib/src/launcher/controller.dart
@@ -160,6 +160,7 @@ class KrakenViewController
     window = Window(
         BindingContext(_contextId, windowNativePtrMap[_contextId]!),
         document);
+    _registerPlatformBrightnessChange();
     _setEventTarget(WINDOW_ID, window);
 
     // Listeners need to be registered to window in order to dispatch events on demand.
@@ -252,6 +253,7 @@ class KrakenViewController
     debugDOMTreeChanged = null;
 
     _teardownObserver();
+    _unregisterPlatformBrightnessChange();
 
     // Should clear previous page cached ui commands
     clearUICommand(_contextId);
@@ -263,6 +265,25 @@ class KrakenViewController
     document.dispose();
     window.dispose();
     _disposed = true;
+  }
+
+  VoidCallback? _originalOnPlatformBrightnessChanged;
+
+  void _registerPlatformBrightnessChange() {
+    _originalOnPlatformBrightnessChanged = ui.window.onPlatformBrightnessChanged;
+    ui.window.onPlatformBrightnessChanged = _onPlatformBrightnessChanged;
+  }
+
+  void _unregisterPlatformBrightnessChange() {
+    ui.window.onPlatformBrightnessChanged = _originalOnPlatformBrightnessChanged;
+    _originalOnPlatformBrightnessChanged = null;
+  }
+
+  void _onPlatformBrightnessChanged() {
+    if (_originalOnPlatformBrightnessChanged != null) {
+      _originalOnPlatformBrightnessChanged!();
+    }
+    window.dispatchEvent(ColorSchemeChangeEvent(window.colorScheme));
   }
 
   Map<int, EventTarget> _eventTargets = <int, EventTarget>{};

--- a/kraken/lib/src/module/navigator.dart
+++ b/kraken/lib/src/module/navigator.dart
@@ -49,7 +49,7 @@ class NavigatorModule extends BaseModule {
   }
 
   static String getLanguages() {
-    // Strinfiy the list of languages to JSON format.
+    // Stringify the list of languages to JSON format.
     return '[' +  PlatformDispatcher.instance.locales.map(((locale) => '"${locale.toLanguageTag()}"')).join(',') + ']';
   }
 


### PR DESCRIPTION
修复 ui.window 上的回调函数的闭包内引用 dom.window 导致 kraken 销毁时无法释放完整的 DOM 树的问题  

**修复前创建 - 销毁 Kraken 实例可以看到仍有 Kraken 相关的对象实例存在**

<img width="926" alt="E6E0A82D-E4CA-4681-B64B-097E22702DEB" src="https://user-images.githubusercontent.com/3922719/161375098-5e95df31-552e-479c-9c17-91148157ca38.png">


**修复后增量内存不含 Kraken 对象**
<img width="793" alt="image" src="https://user-images.githubusercontent.com/3922719/161374031-ba24eeed-fe73-4820-adf2-a758cd284458.png">
