### PR TITLE
fix: animation timeline lifecycle, to avoid memory leak.

### DIFF
--- a/bridge/foundation/logging.cc
+++ b/bridge/foundation/logging.cc
@@ -93,7 +93,6 @@ void pipeMessageToInspector(JSGlobalContextRef ctx, const std::string message, c
 };
 #endif
 
-
 void printLog(int32_t contextId, std::stringstream& stream, std::string level, void* ctx) {
   MessageLevel _log_level = MessageLevel::Info;
   switch (level[0]) {
@@ -128,7 +127,6 @@ void printLog(int32_t contextId, std::stringstream& stream, std::string level, v
   if (kraken::getDartMethod()->onJsLog != nullptr) {
     kraken::getDartMethod()->onJsLog(contextId, static_cast<int>(_log_level), stream.str().c_str());
   }
-
 }
 
 }  // namespace foundation

--- a/kraken/lib/css.dart
+++ b/kraken/lib/css.dart
@@ -4,6 +4,7 @@
  * Copyright (C) 2019-present The Kraken authors. All rights reserved.
  */
 
+export 'src/css/animation.dart';
 export 'src/css/background.dart';
 export 'src/css/border_radius.dart';
 export 'src/css/box.dart';

--- a/kraken/lib/src/css/animation.dart
+++ b/kraken/lib/src/css/animation.dart
@@ -123,8 +123,6 @@ class AnimationTimeline {
   }
 }
 
-AnimationTimeline _documentTimeline = AnimationTimeline();
-
 class Animation {
   double? _startTime;
   double _currentTime = 0;
@@ -155,12 +153,7 @@ class Animation {
   // For transitionstart event
   Function? onstart;
 
-  Animation(KeyframeEffect effect, [AnimationTimeline? timeline]) {
-    if (timeline == null) {
-      _timeline = _documentTimeline;
-    }
-    _effect = effect;
-  }
+  Animation(KeyframeEffect effect, AnimationTimeline timeline) : _effect = effect, _timeline = timeline;
 
   void _setInEffect(bool flag) {
     if (_inEffect == false && flag == true && onstart != null) {

--- a/kraken/lib/src/css/transition.dart
+++ b/kraken/lib/src/css/transition.dart
@@ -7,7 +7,6 @@ import 'dart:ui';
 import 'package:flutter/animation.dart' show Curve;
 import 'package:kraken/css.dart';
 import 'package:kraken/dom.dart';
-import 'package:kraken/src/css/animation.dart';
 import 'package:vector_math/vector_math_64.dart';
 
 // CSS Transitions: https://drafts.csswg.org/css-transitions/

--- a/kraken/lib/src/css/transition.dart
+++ b/kraken/lib/src/css/transition.dart
@@ -342,7 +342,7 @@ mixin CSSTransitionMixin on RenderStyle {
       Keyframe(propertyName, end, 1, LINEAR),
     ];
     KeyframeEffect effect = KeyframeEffect(this, target, keyframes, options);
-    Animation animation = Animation(effect);
+    Animation animation = Animation(effect, target.ownerDocument.animationTimeline);
     _propertyRunningTransition[propertyName] = animation;
 
     animation.onstart = () {

--- a/kraken/lib/src/dom/document.dart
+++ b/kraken/lib/src/dom/document.dart
@@ -14,6 +14,7 @@ import 'package:kraken/widget.dart';
 
 class Document extends Node {
   final KrakenController controller;
+  final AnimationTimeline animationTimeline = AnimationTimeline();
   RenderViewportBox? _viewport;
   GestureListener? gestureListener;
   WidgetDelegate? widgetDelegate;


### PR DESCRIPTION
This PR is aimed to fix the memory leak from AnimationTimeline.

## Background

The original `_documentTimeline` instance is a wild global object, so if we dispose the kraken page, it always exists. Further more, the `AnimationTimeline` keeps lists of `Animation`, `Animation` keeps reference of `KeyframeEffect`, the `KeyframeEffect` keeps reference of `Element` and `RenderStyle`, making memory leaks widely!

Also, if more than one instance of kraken page created, the documentTimeline is still the common one, causing state shared by pages, that's what we don't wanna see.  

## Solution

The `Document` object will keep a final member `animationTimeline`, each node can visit it by `ownerDocument.animationTimeline`. It will be dispose when document object is disposed.

