### PR TITLE
fix: avoid canvas painting flash

### DIFF
--- a/kraken/lib/src/dom/elements/canvas/canvas.dart
+++ b/kraken/lib/src/dom/elements/canvas/canvas.dart
@@ -27,16 +27,6 @@ class RenderCanvasPaint extends RenderCustomPaint {
           foregroundPainter: null, // Ignore foreground painter
           preferredSize: preferredSize,
         );
-
-  @override
-  void markNeedsPaint() {
-    CustomPainter? canvasPainter = painter;
-    if (canvasPainter != null
-        && canvasPainter.shouldRepaint(canvasPainter)) {
-      super.markNeedsPaint();
-    }
-    // Avoid unnecessary mark of repaint.
-  }
 }
 
 class CanvasElement extends Element {

--- a/kraken/lib/src/dom/elements/canvas/canvas.dart
+++ b/kraken/lib/src/dom/elements/canvas/canvas.dart
@@ -27,6 +27,16 @@ class RenderCanvasPaint extends RenderCustomPaint {
           foregroundPainter: null, // Ignore foreground painter
           preferredSize: preferredSize,
         );
+
+  @override
+  void markNeedsPaint() {
+    CustomPainter? canvasPainter = painter;
+    if (canvasPainter != null
+        && canvasPainter.shouldRepaint(canvasPainter)) {
+      super.markNeedsPaint();
+    }
+    // Avoid unnecessary mark of repaint.
+  }
 }
 
 class CanvasElement extends Element {

--- a/kraken/lib/src/dom/elements/canvas/canvas_painter.dart
+++ b/kraken/lib/src/dom/elements/canvas/canvas_painter.dart
@@ -72,8 +72,9 @@ class CanvasPainter extends CustomPainter {
     }
 
     // Paint new actions
+    List<CanvasAction>? actions;
     if (_shouldPainting) {
-      context!.performActions(recordCanvas, size);
+      actions = context!.performActions(recordCanvas, size);
     }
 
     // Must pair each call to save()/saveLayer() with a later matching call to restore().
@@ -90,8 +91,8 @@ class CanvasPainter extends CustomPainter {
     // Dispose the used picture.
     picture.dispose();
     // Clear actions after snapshot was created, or next frame call may empty.
-    if (_shouldPainting) {
-      context!.clearActions();
+    if (actions != null) {
+      context!.clearActions(actions);
     }
   }
 


### PR DESCRIPTION
The PR is aimed to fix the white-flash of canvas painting.

## Background

The white flash appears because our canvas painter saved the prev frame snapshot into `ui.Image`, but this process is async, see `CanvasPainter.paint()`
```dart
 _snapshot = await picture.toImage(size.width.toInt(), size.height.toInt());
```

If the next frame comes faster than snapshot was generated, the next group of actions is added to action list, and removed immediately after image has created, makes canvas flash.  

<img width="1084" alt="image" src="https://user-images.githubusercontent.com/3922719/162897372-d6546046-8fb4-4be9-b925-32f782779ab6.png">

## Solution

`CanvasPainter` keeps `_actions` and `_pendingActions`, if `performActions()` is called, mark `_actions` as `_pendingActions`, make `_actions` to the new list, clear pending actions after snapshot is created by `clearActions`.

## Relation

Close #1314 

## Consequent

https://user-images.githubusercontent.com/3922719/162897895-6bb5f016-04f2-4708-8d2a-58396df7a984.mp4


https://user-images.githubusercontent.com/3922719/162897970-493f2e8a-e65f-46b1-bae8-dc39b63ecdb9.mp4


