### PR TITLE
fix: exception in paragraph paint in some edge cases

### DIFF
--- a/kraken/lib/src/rendering/paragraph.dart
+++ b/kraken/lib/src/rendering/paragraph.dart
@@ -567,6 +567,12 @@ class KrakenRenderParagraph extends RenderBox
     if (lineHeight != null) {
       // Adjust text paint offset of each line according to line-height.
       for (int i = 0; i < _lineTextPainters.length; i++) {
+        // _lineTextPainters and _lineOffset may not have the same length in some edge cases
+        // cause _lineTextPainters is computed from [getBoxesForSelection] api while
+        // _lineOffset is computed from [computeLineMetrics] api.
+        // Add protection here to prevent access the overflow index of _lineOffset list.
+        if (i >= _lineOffset.length) continue;
+
         TextPainter _lineTextPainter = _lineTextPainters[i];
         Offset lineOffset = Offset(offset.dx, offset.dy + _lineOffset[i]);
         _lineTextPainter.paint(context.canvas, lineOffset);


### PR DESCRIPTION
由于 Flutter 的 line-height 逻辑与 Web 不一致，Kraken 渲染 line-height 的逻辑是：
1. 将 text 拆分成多行，生成多行 textPainters 数组。
2. 根据 lineMetrics 生成每行 offset 的 lineOffset 数组。
3. 在 paint 时每行 textPainter 会对应每行的 lineOffset 分别进行 paint。

由于 step 1 和 step 2 并不是同一个 api 计算出来的，在某些 edge case 下可能会出现 textPainters 的 length 大于 lineOffset length 的情况，因此在 step 3 中加上保护，保证 textPainters 与 lineOffset 一一对应。