### PR TITLE
fix: include algorithm

### DIFF
--- a/bridge/bindings/qjs/dom/event_type_names.cc
+++ b/bridge/bindings/qjs/dom/event_type_names.cc
@@ -3,6 +3,7 @@
  */
 
 #include "event_type_names.h"
+#include <algorithm>
 #include <vector>
 
 namespace kraken::binding::qjs {


### PR DESCRIPTION
[std::find](http://en.cppreference.com/w/cpp/algorithm/find) is defined in the <algorithm> header. Add to the beginning:

```cpp
#include <algorithm>
```