### PR TITLE
refactor: make entrypoint load with sync decoding

### DIFF
--- a/kraken/lib/src/foundation/convert.dart
+++ b/kraken/lib/src/foundation/convert.dart
@@ -6,7 +6,7 @@ import 'dart:convert';
 
 import 'package:flutter/foundation.dart';
 
-FutureOr<String> resolveStringFromData(final List<int> data, { Codec codec = utf8, bool preferSync = true }) async {
+FutureOr<String> resolveStringFromData(final List<int> data, { Codec codec = utf8, bool preferSync = false }) async {
   if (codec == utf8) {
     return _resolveUtf8StringFromData(data, preferSync);
   } else {
@@ -14,11 +14,11 @@ FutureOr<String> resolveStringFromData(final List<int> data, { Codec codec = utf
   }
 }
 
-Future<String> _resolveUtf8StringFromData(final List<int> data, [bool sync = true]) async {
+Future<String> _resolveUtf8StringFromData(final List<int> data, [bool preferSync = false]) async {
   // reference: https://github.com/flutter/flutter/blob/master/packages/flutter/lib/src/services/asset_bundle.dart#L71
   // 50 KB of data should take 2-3 ms to parse on a Moto G4, and about 400 μs
   // on a Pixel 4.
-  if (sync || data.length < 50 * 1024) {
+  if (preferSync || data.length < 50 * 1024) {
     return utf8.decode(data);
   }
   // For strings larger than 50 KB, run the computation in an isolate to

--- a/kraken/lib/src/foundation/convert.dart
+++ b/kraken/lib/src/foundation/convert.dart
@@ -6,19 +6,19 @@ import 'dart:convert';
 
 import 'package:flutter/foundation.dart';
 
-FutureOr<String> resolveStringFromData(final List<int> data, { Codec codec = utf8 }) async {
+FutureOr<String> resolveStringFromData(final List<int> data, { Codec codec = utf8, bool preferSync = true }) async {
   if (codec == utf8) {
-    return _resolveUtf8StringFromData(data);
+    return _resolveUtf8StringFromData(data, preferSync);
   } else {
     return codec.decode(data);
   }
 }
 
-Future<String> _resolveUtf8StringFromData(final List<int> data) async {
+Future<String> _resolveUtf8StringFromData(final List<int> data, [bool sync = true]) async {
   // reference: https://github.com/flutter/flutter/blob/master/packages/flutter/lib/src/services/asset_bundle.dart#L71
   // 50 KB of data should take 2-3 ms to parse on a Moto G4, and about 400 μs
   // on a Pixel 4.
-  if (data.length < 50 * 1024) {
+  if (sync || data.length < 50 * 1024) {
     return utf8.decode(data);
   }
   // For strings larger than 50 KB, run the computation in an isolate to

--- a/kraken/lib/src/launcher/controller.dart
+++ b/kraken/lib/src/launcher/controller.dart
@@ -1210,7 +1210,8 @@ class KrakenController {
       if (entrypoint.isHTML) {
         parseHTML(contextId, await resolveStringFromData(data));
       } else if (entrypoint.isJavascript) {
-        evaluateScripts(contextId, await resolveStringFromData(data), url: url);
+        // Prefer sync decode in loading entrypoint.
+        evaluateScripts(contextId, await resolveStringFromData(data, preferSync: true), url: url);
       } else if (entrypoint.isBytecode) {
         evaluateQuickjsByteCode(contextId, data);
       } else {


### PR DESCRIPTION
Close #1340 

给 `resolveStringFromData` 方法增加一个参数 `preferSync`，用以指定是否尽量使用同步 decode 加快编解码的速度  

对于加载 entrypoint 来说需要尽量使用同步，以尽快展示页面，对于异步的脚本或样式可以使用异步的方式避免阻塞进程