### PR TITLE
refactor: not to treat ext as content type, excluding kbc

### DIFF
--- a/kraken/lib/src/launcher/controller.dart
+++ b/kraken/lib/src/launcher/controller.dart
@@ -1207,13 +1207,13 @@ class KrakenController {
       _view.document.parsing = true;
 
       Uint8List data = entrypoint.data!;
-      if (entrypoint.isHTML) {
-        parseHTML(contextId, await resolveStringFromData(data));
-      } else if (entrypoint.isJavascript) {
+      if (entrypoint.isJavascript) {
         // Prefer sync decode in loading entrypoint.
         evaluateScripts(contextId, await resolveStringFromData(data, preferSync: true), url: url);
       } else if (entrypoint.isBytecode) {
         evaluateQuickjsByteCode(contextId, data);
+      } else if (entrypoint.isHTML) {
+        parseHTML(contextId, await resolveStringFromData(data));
       } else {
         // The resource type can not be evaluated.
         throw FlutterError('Can\'t evaluate content of $url');

--- a/kraken/lib/src/launcher/controller.dart
+++ b/kraken/lib/src/launcher/controller.dart
@@ -1214,6 +1214,14 @@ class KrakenController {
         evaluateQuickjsByteCode(contextId, data);
       } else if (entrypoint.isHTML) {
         parseHTML(contextId, await resolveStringFromData(data));
+      } else if (entrypoint.contentType.primaryType == 'text') {
+        // Fallback treating text content as JavaScript.
+        try {
+          evaluateScripts(contextId, await resolveStringFromData(data, preferSync: true), url: url);
+        } catch (error) {
+          print('Fallback to execute JavaScript content of $url');
+          rethrow;
+        }
       } else {
         // The resource type can not be evaluated.
         throw FlutterError('Can\'t evaluate content of $url');

--- a/kraken/lib/src/launcher/launcher.dart
+++ b/kraken/lib/src/launcher/launcher.dart
@@ -11,7 +11,19 @@ import 'package:kraken/kraken.dart';
 
 typedef ConnectedCallback = void Function();
 
+const String BUNDLE_URL = 'KRAKEN_BUNDLE_URL';
+const String BUNDLE_PATH = 'KRAKEN_BUNDLE_PATH';
+const String ENABLE_DEBUG = 'KRAKEN_ENABLE_DEBUG';
+const String ENABLE_PERFORMANCE_OVERLAY = 'KRAKEN_ENABLE_PERFORMANCE_OVERLAY';
 const _white = Color(0xFFFFFFFF);
+
+String? getBundleURLFromEnv() {
+  return Platform.environment[BUNDLE_URL];
+}
+
+String? getBundlePathFromEnv() {
+  return Platform.environment[BUNDLE_PATH];
+}
 
 void launch({
   KrakenBundle? bundle,


### PR DESCRIPTION
Not to treat url `https://path/to/file.html` as an HTML content, because it may be not.   

Just specified by the `content-type` headers.  

> Excluding kbc1, it's useful for most http server that did not recognize a .kbc1 file, simply treat some.kbc1 file as the bytecode format.