### PR TITLE
fix: event concurrent exception

### DIFF
--- a/kraken/lib/src/dom/event_target.dart
+++ b/kraken/lib/src/dom/event_target.dart
@@ -64,7 +64,9 @@ abstract class EventTarget extends BindingObject {
     if (existHandler != null) {
       // Modify currentTarget before the handler call, otherwise currentTarget may be modified by the previous handler.
       event.currentTarget = this;
-      for (EventHandler handler in existHandler) {
+      // To avoid concurrent exception while prev handler modify the original handler list, causing list iteration
+      // with error, copy the handlers here.
+      for (EventHandler handler in [...existHandler]) {
         handler(event);
       }
       event.currentTarget = null;


### PR DESCRIPTION
修复触发事件时产生的 concurrent 异常   

当派发事件时, 前一个监听器同步修改了监听器 list, 会导致遍历 list 过程异常