### PR TITLE
Fix/remove event listener

### DIFF
--- a/bridge/bindings/qjs/dom/event_target.cc
+++ b/bridge/bindings/qjs/dom/event_target.cc
@@ -124,7 +124,7 @@ JSValue EventTarget::removeEventListener(JSContext* ctx, JSValue this_val, int a
     JS_FreeValue(ctx, callback);
   }
 
-  if (eventHandlers.empty() && eventTargetInstance->m_eventHandlerMap.contains(eventType)) {
+  if (eventHandlers.empty() && !eventTargetInstance->m_eventHandlerMap.contains(eventType)) {
     // Dart needs to be notified for handles is empty.
     int32_t contextId = eventTargetInstance->prototype()->contextId();
 

--- a/integration_tests/specs/dom/nodes/event-target.ts
+++ b/integration_tests/specs/dom/nodes/event-target.ts
@@ -171,4 +171,32 @@ describe('DOM EventTarget', () => {
     expect(shouldNotBeTrue).toEqual(false);
   });
 
+
+  it('removeEventListener should work', (done) => {
+    let num = 0;
+    var ele = createElement('div', {
+      style: {
+        width: '100px',
+        height: '100px',
+        background: 'red'
+      }
+    });
+    document.body.appendChild(ele);
+    ele.addEventListener('click', fn1);
+    ele.removeEventListener('click', fn1);
+    ele.addEventListener('click', fn2);
+
+    function fn1() {
+      num++;
+    }
+
+    function fn2() {
+      num++;
+      expect(num).toEqual(1);
+      done();
+    }
+
+    ele.click();
+  });
+
 });


### PR DESCRIPTION
react <Demo onClick={()=>{}}> 重复触发 render 就会异常了，原因是removeEventListener 在 bridge 的判断条件有误，无法正常从 dart 侧移出，导致无法移出监听函数。

