### PR TITLE
fix: event handlers removal with once time

### DIFF
--- a/bridge/bindings/qjs/dom/event_target.cc
+++ b/bridge/bindings/qjs/dom/event_target.cc
@@ -417,7 +417,7 @@ void EventTargetInstance::setAttributesEventHandler(JSString* p, JSValue value) 
   } else {
     m_eventHandlerMap.erase(atom);
     JS_FreeAtom(m_ctx, atom);
-    // When evaluate scripts like 'element.onclick = null', we needs to remove the event handlers callbacks
+    // When evaluate scripts like 'element.onclick = null', we needs to remove the event handlers callbacks.
     operation = SetAttributeEventHandlerOperation::kRemoveEventListener;
   }
 

--- a/bridge/bindings/qjs/dom/event_target.cc
+++ b/bridge/bindings/qjs/dom/event_target.cc
@@ -409,10 +409,7 @@ void EventTargetInstance::setAttributesEventHandler(JSString* p, JSValue value) 
   memcpy(eventType, &p->u.str8[2], p->len + 1 - 2);
   JSAtom atom = JS_NewAtom(m_ctx, eventType);
 
-  enum SetAttributeEventHandlerOperation {
-    kAddEventListener,
-    kRemoveEventListener
-  };
+  enum SetAttributeEventHandlerOperation { kAddEventListener, kRemoveEventListener };
 
   SetAttributeEventHandlerOperation operation;
   if (JS_IsFunction(m_ctx, value)) {

--- a/integration_tests/specs/dom/events/event.ts
+++ b/integration_tests/specs/dom/events/event.ts
@@ -376,7 +376,7 @@ describe('Event', () => {
     expect(e.type).toBe(type);
   });
 
-  it('Event Level 0 removal', (done) => {
+  it('Event Level 0 removal', () => {
     var el = createElement('div', {
       style: {
         width: '100px',
@@ -403,7 +403,7 @@ describe('Event', () => {
     expect(ret).toEqual('12');
   });
 
-  it('Event Level 2 listen multi-times', (done) => {
+  it('Event Level 2 listen multi-times', () => {
     var el = createElement('div', {
       style: {
         width: '100px',
@@ -426,7 +426,7 @@ describe('Event', () => {
     expect(ret).toEqual('12');
   });
 
-  it('Event Level 2 listen multi-times with removal', (done) => {
+  it('Event Level 2 listen multi-times with removal', () => {
     var el = createElement('div', {
       style: {
         width: '100px',
@@ -451,4 +451,24 @@ describe('Event', () => {
 
     expect(ret).toEqual('');
   });
+
+  it('Add multi event types', () => {
+      var el = createElement('div', {
+        style: {
+          width: '100px',
+          height: '100px',
+          background: 'red'
+        }
+      });
+      let ret = '';
+      function fn1() {
+        ret += '1';
+      }
+      el.addEventListener('click', fn1);
+      el.addEventListener('scroll', fn1);
+
+      el.click();
+
+      expect(ret).toEqual('1');
+    });
 });

--- a/integration_tests/specs/dom/events/event.ts
+++ b/integration_tests/specs/dom/events/event.ts
@@ -166,7 +166,7 @@ describe('Event', () => {
     block.style.width = '100px';
     block.style.height = '100px';
     block.style.backgroundColor = 'green';
-    block.addEventListener('click', () => clickCount++); 
+    block.addEventListener('click', () => clickCount++);
 
     const block2 =document.createElement('div');
     block2.style.width = '100px';
@@ -201,7 +201,7 @@ describe('Event', () => {
     block.style.width = '300px';
     block.style.height = '50px';
     block.style.backgroundColor = 'green';
-    block.addEventListener('click', () => clickCount++); 
+    block.addEventListener('click', () => clickCount++);
     container.appendChild(block);
 
     await simulateClick(50, 20);
@@ -225,7 +225,7 @@ describe('Event', () => {
     block.style.width = '300px';
     block.style.height = '50px';
     block.style.backgroundColor = 'green';
-    block.addEventListener('click', () => clickCount++); 
+    block.addEventListener('click', () => clickCount++);
     container.appendChild(block);
 
     await simulateClick(50, 20);
@@ -248,7 +248,7 @@ describe('Event', () => {
     block.style.width = '300px';
     block.style.height = '50px';
     block.style.backgroundColor = 'green';
-    block.addEventListener('click', () => clickCount++); 
+    block.addEventListener('click', () => clickCount++);
     container.appendChild(block);
 
     await simulateClick(50, 20);
@@ -374,5 +374,81 @@ describe('Event', () => {
     const e = document.createEvent('Event');
     e.initEvent(type, true, true);
     expect(e.type).toBe(type);
+  });
+
+  it('Event Level 0 removal', (done) => {
+    var el = createElement('div', {
+      style: {
+        width: '100px',
+        height: '100px',
+        background: 'red'
+      }
+    });
+    let ret = '';
+    function fn1() {
+      ret += '1';
+    }
+    function fn2() {
+      ret += '2';
+    }
+    el.onclick = fn1;
+    el.click();
+
+    el.onclick = null;
+    el.click();
+
+    el.onclick = fn2;
+    el.click();
+
+    expect(ret).toEqual('12');
+  });
+
+  it('Event Level 2 listen multi-times', (done) => {
+    var el = createElement('div', {
+      style: {
+        width: '100px',
+        height: '100px',
+        background: 'red'
+      }
+    });
+    let ret = '';
+    function fn1() {
+      ret += '1';
+    }
+    function fn2() {
+      ret += '2';
+    }
+    el.addEventListener('click', fn1);
+    el.addEventListener('click', fn1);
+    el.addEventListener('click', fn2);
+    el.click();
+
+    expect(ret).toEqual('12');
+  });
+
+  it('Event Level 2 listen multi-times with removal', (done) => {
+    var el = createElement('div', {
+      style: {
+        width: '100px',
+        height: '100px',
+        background: 'red'
+      }
+    });
+    let ret = '';
+    function fn1() {
+      ret += '1';
+    }
+    function fn2() {
+      ret += '2';
+    }
+    el.addEventListener('click', fn1);
+    el.addEventListener('click', fn1);
+    el.addEventListener('click', fn2);
+
+    el.removeEventListener('click', fn1);
+    el.removeEventListener('click', fn2);
+    el.click();
+
+    expect(ret).toEqual('');
   });
 });

--- a/kraken/lib/src/bridge/binding.dart
+++ b/kraken/lib/src/bridge/binding.dart
@@ -142,10 +142,30 @@ abstract class BindingBridge {
   }
 
   static void listenEvent(EventTarget target, String type) {
+    assert(_debugShouldNotListenMultiTimes(target, type), '$target $type');
     target.addEventListener(type, _dispatchBindingEvent);
   }
 
   static void unlistenEvent(EventTarget target, String type) {
+    assert(_debugShouldNotUnlistenEmpty(target, type), '$target $type');
     target.removeEventListener(type, _dispatchBindingEvent);
+  }
+
+  static bool _debugShouldNotListenMultiTimes(EventTarget target, String type) {
+    Map<String, List<EventHandler>> eventHandlers = target.getEventHandlers();
+    List<EventHandler>? handlers = eventHandlers[type];
+    if (handlers != null) {
+      return !handlers.contains(_dispatchBindingEvent);
+    }
+    return true;
+  }
+
+  static bool _debugShouldNotUnlistenEmpty(EventTarget target, String type) {
+    Map<String, List<EventHandler>> eventHandlers = target.getEventHandlers();
+    List<EventHandler>? handlers = eventHandlers[type];
+    if (handlers != null) {
+      return handlers.contains(_dispatchBindingEvent);
+    }
+    return false;
   }
 }

--- a/kraken/lib/src/bridge/binding.dart
+++ b/kraken/lib/src/bridge/binding.dart
@@ -142,12 +142,14 @@ abstract class BindingBridge {
   }
 
   static void listenEvent(EventTarget target, String type) {
-    assert(_debugShouldNotListenMultiTimes(target, type), '$target $type');
+    assert(_debugShouldNotListenMultiTimes(target, type),
+      'Failed to listen event \'$type\' for $target, for which is already bound.');
     target.addEventListener(type, _dispatchBindingEvent);
   }
 
   static void unlistenEvent(EventTarget target, String type) {
-    assert(_debugShouldNotUnlistenEmpty(target, type), '$target $type');
+    assert(_debugShouldNotUnlistenEmpty(target, type),
+      'Failed to unlisten event \'$type\' for $target, for which is already unbound.');
     target.removeEventListener(type, _dispatchBindingEvent);
   }
 


### PR DESCRIPTION
1. Bridge 在调用 UICommand::addEvent 与 UICommand::remveEvent 时都应当考虑当前 EventTarget 已经没有监听器的情况
2. 在 Bridge/binding.dart 增加了 assert 帮助提早发现多次监听或重复取消监听的情况
3. 增加了测试用例