### PR TITLE
:bug: fix: handlePointerEvent

### DIFF
--- a/kraken/lib/src/gesture/gesture_dispatcher.dart
+++ b/kraken/lib/src/gesture/gesture_dispatcher.dart
@@ -186,7 +186,7 @@ class GestureDispatcher {
 
 
   void handlePointerEvent(PointerEvent event) {
-    if (event is PointerDownEvent || event is PointerUpEvent || event is PointerMoveEvent || event is PointerCancelEvent) {
+    if (!(event is PointerDownEvent || event is PointerUpEvent || event is PointerMoveEvent || event is PointerCancelEvent)) {
       // Only basic Point events are handled, other event does nothing and returns directly such as hover and scroll.
       return;
     }

--- a/kraken/lib/src/gesture/gesture_dispatcher.dart
+++ b/kraken/lib/src/gesture/gesture_dispatcher.dart
@@ -186,8 +186,8 @@ class GestureDispatcher {
 
 
   void handlePointerEvent(PointerEvent event) {
-    if (event is PointerHoverEvent) {
-      // Hover does nothing and returns directly.
+    if (event is PointerDownEvent || event is PointerUpEvent || event is PointerMoveEvent || event is PointerCancelEvent) {
+      // Only basic Point events are handled, other event does nothing and returns directly such as hover and scroll.
       return;
     }
 


### PR DESCRIPTION
一个偶现的错误，handlePointerEvent 这个函数只处理 基本的 point 事件，也就是 up、down、cancel 以及 move，其余的类似 hover 事件加入会使得 toTouch 时的 list 数据异常而导致 use a null value。

![image](https://user-images.githubusercontent.com/17812136/165248837-432f590c-5efa-47dc-b31d-61c373f3ab29.png)

![image](https://user-images.githubusercontent.com/17812136/165248983-6512ba5b-7008-491b-9e7e-5061a64a5863.png)

