### PR TITLE
Fix/body overflow

### DIFF
--- a/kraken/lib/src/dom/element.dart
+++ b/kraken/lib/src/dom/element.dart
@@ -1349,7 +1349,7 @@ abstract class Element
   void _applyDefaultStyle(CSSStyleDeclaration style) {
     if (_defaultStyle.isNotEmpty) {
       _defaultStyle.forEach((propertyName, value) {
-        style.setProperty(propertyName, value);
+        setStyleProperty(propertyName, value);
       });
     }
   }
@@ -1358,7 +1358,7 @@ abstract class Element
     if (inlineStyle.isNotEmpty) {
       inlineStyle.forEach((propertyName, value) {
         // Force inline style to be applied as important priority.
-        style.setProperty(propertyName, value, true);
+        setStyleProperty(propertyName, value, true);
       });
     }
   }
@@ -1374,7 +1374,7 @@ abstract class Element
             if (rule is CSSStyleRule && rule.selectorText == (classSelectorPrefix + className)) {
               var sheetStyle = rule.style;
               for (String propertyName in sheetStyle.keys) {
-                style.setProperty(propertyName, sheetStyle[propertyName], false);
+                setStyleProperty(propertyName, sheetStyle[propertyName], false);
               }
             }
           }
@@ -1395,7 +1395,7 @@ abstract class Element
   void setInlineStyle(String property, String value) {
     // Current only for mark property is setting by inline style.
     inlineStyle[property] = value;
-    style.setProperty(property, value, true);
+    setStyleProperty(property, value, true);
   }
 
   void applyStyle(CSSStyleDeclaration style) {
@@ -1418,11 +1418,15 @@ abstract class Element
       if (diffs.isNotEmpty) {
         // Update render style.
         diffs.forEach((String propertyName, String? value) {
-          style.setProperty(propertyName, value);
+          setStyleProperty(propertyName, value);
         });
         style.flushPendingProperties();
       }
     }
+  }
+
+  void setStyleProperty(String propertyName, String? value, [bool? isImportant]) {
+    style.setProperty(propertyName, value, isImportant);
   }
 
   void recalculateNestedStyle() {

--- a/kraken/lib/src/dom/element.dart
+++ b/kraken/lib/src/dom/element.dart
@@ -1349,7 +1349,7 @@ abstract class Element
   void _applyDefaultStyle(CSSStyleDeclaration style) {
     if (_defaultStyle.isNotEmpty) {
       _defaultStyle.forEach((propertyName, value) {
-        setStyleProperty(propertyName, value);
+        style.setProperty(propertyName, value);
       });
     }
   }
@@ -1358,7 +1358,7 @@ abstract class Element
     if (inlineStyle.isNotEmpty) {
       inlineStyle.forEach((propertyName, value) {
         // Force inline style to be applied as important priority.
-        setStyleProperty(propertyName, value, true);
+        style.setProperty(propertyName, value, true);
       });
     }
   }
@@ -1374,7 +1374,7 @@ abstract class Element
             if (rule is CSSStyleRule && rule.selectorText == (classSelectorPrefix + className)) {
               var sheetStyle = rule.style;
               for (String propertyName in sheetStyle.keys) {
-                setStyleProperty(propertyName, sheetStyle[propertyName], false);
+                style.setProperty(propertyName, sheetStyle[propertyName], false);
               }
             }
           }
@@ -1395,7 +1395,7 @@ abstract class Element
   void setInlineStyle(String property, String value) {
     // Current only for mark property is setting by inline style.
     inlineStyle[property] = value;
-    setStyleProperty(property, value, true);
+    style.setProperty(property, value, true);
   }
 
   void applyStyle(CSSStyleDeclaration style) {
@@ -1418,15 +1418,11 @@ abstract class Element
       if (diffs.isNotEmpty) {
         // Update render style.
         diffs.forEach((String propertyName, String? value) {
-          setStyleProperty(propertyName, value);
+          style.setProperty(propertyName, value);
         });
         style.flushPendingProperties();
       }
     }
-  }
-
-  void setStyleProperty(String propertyName, String? value, [bool? isImportant]) {
-    style.setProperty(propertyName, value, isImportant);
   }
 
   void recalculateNestedStyle() {

--- a/kraken/lib/src/dom/elements/body.dart
+++ b/kraken/lib/src/dom/elements/body.dart
@@ -22,4 +22,18 @@ class BodyElement extends Element {
 
     super.addEventListener(eventType, eventHandler);
   }
+
+  @override
+  void setRenderStyle(String property, String present) {
+    // UAs must apply the overflow-* values set on the root element to the viewport when the root element’s display value is not none.
+    // However, when the root element is an [HTML] html element (including XML syntax for HTML) whose overflow value is visible (in both axes),
+    // and that element has as a child a body element whose display value is also not none,
+    // user agents must instead apply the overflow-* values of the first such child element to the viewport.
+    // The element from which the value is propagated must then have a used overflow value of visible.
+    // https://drafts.csswg.org/css-overflow-3/#overflow-propagation
+    if (property == OVERFLOW || property == OVERFLOW_X || property == OVERFLOW_Y) {
+      ownerDocument.documentElement?.setRenderStyle(property, present);
+    }
+    super.setRenderStyle(property, present);
+  }
 }

--- a/kraken/lib/src/dom/elements/body.dart
+++ b/kraken/lib/src/dom/elements/body.dart
@@ -25,11 +25,7 @@ class BodyElement extends Element {
 
   @override
   void setRenderStyle(String property, String present) {
-    // UAs must apply the overflow-* values set on the root element to the viewport when the root element’s display value is not none.
-    // However, when the root element is an [HTML] html element (including XML syntax for HTML) whose overflow value is visible (in both axes),
-    // and that element has as a child a body element whose display value is also not none,
-    // user agents must instead apply the overflow-* values of the first such child element to the viewport.
-    // The element from which the value is propagated must then have a used overflow value of visible.
+    // The overflow of body should apply to html.
     // https://drafts.csswg.org/css-overflow-3/#overflow-propagation
     if (property == OVERFLOW || property == OVERFLOW_X || property == OVERFLOW_Y) {
       ownerDocument.documentElement?.setRenderStyle(property, present);

--- a/kraken/lib/src/dom/elements/body.dart
+++ b/kraken/lib/src/dom/elements/body.dart
@@ -29,6 +29,7 @@ class BodyElement extends Element {
     // https://drafts.csswg.org/css-overflow-3/#overflow-propagation
     if (property == OVERFLOW || property == OVERFLOW_X || property == OVERFLOW_Y) {
       ownerDocument.documentElement?.setRenderStyle(property, present);
+      return;
     }
     super.setRenderStyle(property, present);
   }

--- a/kraken/lib/src/dom/elements/body.dart
+++ b/kraken/lib/src/dom/elements/body.dart
@@ -25,12 +25,16 @@ class BodyElement extends Element {
 
   @override
   void setRenderStyle(String property, String present) {
-    // The overflow of body should apply to html.
-    // https://drafts.csswg.org/css-overflow-3/#overflow-propagation
-    if (property == OVERFLOW || property == OVERFLOW_X || property == OVERFLOW_Y) {
-      ownerDocument.documentElement?.setRenderStyle(property, present);
-      return;
+    switch (property) {
+      // The overflow of body should apply to html.
+      // https://drafts.csswg.org/css-overflow-3/#overflow-propagation
+      case OVERFLOW:
+      case OVERFLOW_X:
+      case OVERFLOW_Y:
+        ownerDocument.documentElement?.setRenderStyle(property, present);
+        break;
+      default:
+        super.setRenderStyle(property, present);
     }
-    super.setRenderStyle(property, present);
   }
 }


### PR DESCRIPTION
close #1365 

原因是 rax-modal 的原理是设置一个 fixed 的蒙层，并且设置 body 为 overflow hidden，在 web 下， body 上的 overflow 会被代理到 html 上面以使其 overflow hidden 无法继续 scroll。

https://drafts.csswg.org/css-overflow-3/#overflow-propagation