### PR TITLE
Fix/html scroll value

### DIFF
--- a/kraken/lib/src/css/overflow.dart
+++ b/kraken/lib/src/css/overflow.dart
@@ -138,7 +138,7 @@ mixin ElementOverflowMixin on ElementBase {
         case CSSOverflowType.auto:
         case CSSOverflowType.scroll:
           // If the render has been offset when previous overflow is auto or scroll, _scrollableY should not reset.
-          if (renderBoxModel.scrollOffsetX == null) {
+          if (_scrollableX == null) {
             _scrollableX = KrakenScrollable(axisDirection: AxisDirection.right, scrollListener: scrollListener);
             renderBoxModel.scrollOffsetX = _scrollableX!.position;
           }
@@ -173,7 +173,7 @@ mixin ElementOverflowMixin on ElementBase {
         case CSSOverflowType.auto:
         case CSSOverflowType.scroll:
           // If the render has been offset when previous overflow is auto or scroll, _scrollableY should not reset.
-          if (renderBoxModel.scrollOffsetY == null) {
+          if (_scrollableY == null) {
             _scrollableY = KrakenScrollable(axisDirection: AxisDirection.down, scrollListener: scrollListener);
             renderBoxModel.scrollOffsetY = _scrollableY!.position;
           }

--- a/kraken/lib/src/css/overflow.dart
+++ b/kraken/lib/src/css/overflow.dart
@@ -165,6 +165,7 @@ mixin ElementOverflowMixin on ElementBase {
       switch(overflowY) {
         case CSSOverflowType.hidden:
           // @TODO: Content of overflow hidden can be scrolled programmatically.
+          // If the render has been offset when previous overflow is auto or scroll, _scrollableY should not reset.
           if (renderBoxModel.scrollOffsetY == null) {
             _scrollableY = null;
           }

--- a/kraken/lib/src/css/overflow.dart
+++ b/kraken/lib/src/css/overflow.dart
@@ -131,17 +131,20 @@ mixin ElementOverflowMixin on ElementBase {
       RenderBoxModel renderBoxModel = this.renderBoxModel!;
       CSSOverflowType overflowX = renderStyle.effectiveOverflowX;
       switch(overflowX) {
-        case CSSOverflowType.hidden:
-          // @TODO: Content of overflow hidden can be scrolled programmatically.
-          _scrollableX = null;
-          break;
         case CSSOverflowType.clip:
           _scrollableX = null;
           break;
+        case CSSOverflowType.hidden:
         case CSSOverflowType.auto:
         case CSSOverflowType.scroll:
-          _scrollableX = KrakenScrollable(axisDirection: AxisDirection.right, scrollListener: scrollListener);
-          renderBoxModel.scrollOffsetX = _scrollableX!.position;
+          // If the render has been offset when previous overflow is auto or scroll, _scrollableY should not reset.
+          if (renderBoxModel.scrollOffsetX == null) {
+            _scrollableX = KrakenScrollable(axisDirection: AxisDirection.right, scrollListener: scrollListener);
+            renderBoxModel.scrollOffsetX = _scrollableX!.position;
+          }
+          // Reset canDrag by overflow because hidden is can't drag.
+          bool canDrag = overflowX != CSSOverflowType.hidden;
+          _scrollableX!.setCanDrag(canDrag);
           break;
         case CSSOverflowType.visible:
         default:

--- a/kraken/lib/src/css/overflow.dart
+++ b/kraken/lib/src/css/overflow.dart
@@ -165,15 +165,19 @@ mixin ElementOverflowMixin on ElementBase {
       switch(overflowY) {
         case CSSOverflowType.hidden:
           // @TODO: Content of overflow hidden can be scrolled programmatically.
-          _scrollableY = null;
+          if (renderBoxModel.scrollOffsetY == null) {
+            _scrollableY = null;
+          }
           break;
         case CSSOverflowType.clip:
           _scrollableY = null;
           break;
         case CSSOverflowType.auto:
         case CSSOverflowType.scroll:
-          _scrollableY = KrakenScrollable(axisDirection: AxisDirection.down, scrollListener: scrollListener);
-          renderBoxModel.scrollOffsetY = _scrollableY!.position;
+          if (renderBoxModel.scrollOffsetY == null) {
+            _scrollableY = KrakenScrollable(axisDirection: AxisDirection.down, scrollListener: scrollListener);
+            renderBoxModel.scrollOffsetY = _scrollableY!.position;
+          }
           break;
         case CSSOverflowType.visible:
         default:
@@ -282,6 +286,8 @@ mixin ElementOverflowMixin on ElementBase {
         _detachScrollingContentBox();
       }
     }
+
+
   }
 
   void updateScrollingContentBox() {

--- a/kraken/lib/src/css/overflow.dart
+++ b/kraken/lib/src/css/overflow.dart
@@ -163,22 +163,20 @@ mixin ElementOverflowMixin on ElementBase {
       RenderBoxModel renderBoxModel = this.renderBoxModel!;
       CSSOverflowType overflowY = renderStyle.effectiveOverflowY;
       switch(overflowY) {
-        case CSSOverflowType.hidden:
-          // @TODO: Content of overflow hidden can be scrolled programmatically.
-          // If the render has been offset when previous overflow is auto or scroll, _scrollableY should not reset.
-          if (renderBoxModel.scrollOffsetY == null) {
-            _scrollableY = null;
-          }
-          break;
         case CSSOverflowType.clip:
           _scrollableY = null;
           break;
+        case CSSOverflowType.hidden:
         case CSSOverflowType.auto:
         case CSSOverflowType.scroll:
+          // If the render has been offset when previous overflow is auto or scroll, _scrollableY should not reset.
           if (renderBoxModel.scrollOffsetY == null) {
             _scrollableY = KrakenScrollable(axisDirection: AxisDirection.down, scrollListener: scrollListener);
             renderBoxModel.scrollOffsetY = _scrollableY!.position;
           }
+          // Reset canDrag by overflow because hidden is can't drag.
+          bool canDrag = overflowY != CSSOverflowType.hidden;
+          _scrollableY!.setCanDrag(canDrag);
           break;
         case CSSOverflowType.visible:
         default:

--- a/kraken/lib/src/css/overflow.dart
+++ b/kraken/lib/src/css/overflow.dart
@@ -288,8 +288,6 @@ mixin ElementOverflowMixin on ElementBase {
         _detachScrollingContentBox();
       }
     }
-
-
   }
 
   void updateScrollingContentBox() {

--- a/kraken/lib/src/dom/element.dart
+++ b/kraken/lib/src/dom/element.dart
@@ -540,9 +540,9 @@ abstract class Element
   /// Normally element in scroll box will not repaint on scroll because of repaint boundary optimization
   /// So it needs to manually mark element needs paint and add scroll offset in paint stage
   void _applyFixedChildrenOffset(double scrollOffset, AxisDirection axisDirection) {
-    // Only root element has fixed children
+    // Only root element has fixed children.
     if (this == ownerDocument.documentElement && renderBoxModel != null) {
-      RenderBoxModel layoutBox = (renderBoxModel as RenderLayoutBox).renderScrollingContent ?? renderBoxModel!;
+      RenderBoxModel layoutBox = renderBoxModel!;
       for (RenderBoxModel child in layoutBox.fixedChildren) {
         // Save scrolling offset for paint
         if (axisDirection == AxisDirection.down) {
@@ -1657,7 +1657,7 @@ Element? _findContainingBlock(Element child, Element viewportElement) {
 
 // Cache fixed renderObject to root element
 void _addFixedChild(RenderBoxModel childRenderBoxModel, RenderLayoutBox rootRenderLayoutBox) {
-  rootRenderLayoutBox = rootRenderLayoutBox.renderScrollingContent ?? rootRenderLayoutBox;
+  // rootRenderLayoutBox = rootRenderLayoutBox.renderScrollingContent ?? rootRenderLayoutBox;
   List<RenderBoxModel> fixedChildren = rootRenderLayoutBox.fixedChildren;
   if (!fixedChildren.contains(childRenderBoxModel)) {
     fixedChildren.add(childRenderBoxModel);
@@ -1666,7 +1666,7 @@ void _addFixedChild(RenderBoxModel childRenderBoxModel, RenderLayoutBox rootRend
 
 // Remove non fixed renderObject from root element
 void _removeFixedChild(RenderBoxModel childRenderBoxModel, RenderLayoutBox rootRenderLayoutBox) {
-  rootRenderLayoutBox = rootRenderLayoutBox.renderScrollingContent ?? rootRenderLayoutBox;
+  // rootRenderLayoutBox = rootRenderLayoutBox.renderScrollingContent ?? rootRenderLayoutBox;
   List<RenderBoxModel> fixedChildren = rootRenderLayoutBox.fixedChildren;
   if (fixedChildren.contains(childRenderBoxModel)) {
     fixedChildren.remove(childRenderBoxModel);

--- a/kraken/lib/src/dom/element.dart
+++ b/kraken/lib/src/dom/element.dart
@@ -499,7 +499,7 @@ abstract class Element
       renderBoxModel.clearIntersectionChangeListeners();
 
       // Remove fixed children from root when element disposed.
-      _removeFixedChild(renderBoxModel, ownerDocument.documentElement!._renderLayoutBox!);
+      _removeFixedChild(renderBoxModel, ownerDocument.viewport!);
 
       // Remove renderBox.
       renderBoxModel.detachFromContainingBlock();
@@ -540,10 +540,10 @@ abstract class Element
   /// Normally element in scroll box will not repaint on scroll because of repaint boundary optimization
   /// So it needs to manually mark element needs paint and add scroll offset in paint stage
   void _applyFixedChildrenOffset(double scrollOffset, AxisDirection axisDirection) {
+    RenderViewportBox? viewport = ownerDocument.viewport;
     // Only root element has fixed children.
-    if (this == ownerDocument.documentElement && renderBoxModel != null) {
-      RenderBoxModel layoutBox = renderBoxModel!;
-      for (RenderBoxModel child in layoutBox.fixedChildren) {
+    if (this == ownerDocument.documentElement && viewport != null) {
+      for (RenderBoxModel child in viewport.fixedChildren) {
         // Save scrolling offset for paint
         if (axisDirection == AxisDirection.down) {
           child.scrollingOffsetY = scrollOffset;
@@ -646,7 +646,7 @@ abstract class Element
       RenderBoxModel _renderBoxModel = renderBoxModel!;
       // Remove fixed children before convert to non repaint boundary renderObject
       if (currentPosition != CSSPositionType.fixed) {
-        _removeFixedChild(_renderBoxModel, ownerDocument.documentElement!._renderLayoutBox!);
+        _removeFixedChild(_renderBoxModel, ownerDocument.viewport!);
       }
 
       // Find the renderBox of its containing block.
@@ -665,7 +665,7 @@ abstract class Element
 
       // Add fixed children after convert to repaint boundary renderObject.
       if (currentPosition == CSSPositionType.fixed) {
-        _addFixedChild(renderBoxModel!, ownerDocument.documentElement!._renderLayoutBox!);
+        _addFixedChild(renderBoxModel!, ownerDocument.viewport!);
       }
     }
 
@@ -1656,16 +1656,16 @@ Element? _findContainingBlock(Element child, Element viewportElement) {
 }
 
 // Cache fixed renderObject to root element
-void _addFixedChild(RenderBoxModel childRenderBoxModel, RenderLayoutBox rootRenderLayoutBox) {
-  List<RenderBoxModel> fixedChildren = rootRenderLayoutBox.fixedChildren;
+void _addFixedChild(RenderBoxModel childRenderBoxModel, RenderViewportBox viewport) {
+  List<RenderBoxModel> fixedChildren = viewport.fixedChildren;
   if (!fixedChildren.contains(childRenderBoxModel)) {
     fixedChildren.add(childRenderBoxModel);
   }
 }
 
 // Remove non fixed renderObject from root element
-void _removeFixedChild(RenderBoxModel childRenderBoxModel, RenderLayoutBox rootRenderLayoutBox) {
-  List<RenderBoxModel> fixedChildren = rootRenderLayoutBox.fixedChildren;
+void _removeFixedChild(RenderBoxModel childRenderBoxModel, RenderViewportBox viewport) {
+  List<RenderBoxModel> fixedChildren = viewport.fixedChildren;
   if (fixedChildren.contains(childRenderBoxModel)) {
     fixedChildren.remove(childRenderBoxModel);
   }

--- a/kraken/lib/src/dom/element.dart
+++ b/kraken/lib/src/dom/element.dart
@@ -1657,7 +1657,6 @@ Element? _findContainingBlock(Element child, Element viewportElement) {
 
 // Cache fixed renderObject to root element
 void _addFixedChild(RenderBoxModel childRenderBoxModel, RenderLayoutBox rootRenderLayoutBox) {
-  // rootRenderLayoutBox = rootRenderLayoutBox.renderScrollingContent ?? rootRenderLayoutBox;
   List<RenderBoxModel> fixedChildren = rootRenderLayoutBox.fixedChildren;
   if (!fixedChildren.contains(childRenderBoxModel)) {
     fixedChildren.add(childRenderBoxModel);
@@ -1666,7 +1665,6 @@ void _addFixedChild(RenderBoxModel childRenderBoxModel, RenderLayoutBox rootRend
 
 // Remove non fixed renderObject from root element
 void _removeFixedChild(RenderBoxModel childRenderBoxModel, RenderLayoutBox rootRenderLayoutBox) {
-  // rootRenderLayoutBox = rootRenderLayoutBox.renderScrollingContent ?? rootRenderLayoutBox;
   List<RenderBoxModel> fixedChildren = rootRenderLayoutBox.fixedChildren;
   if (fixedChildren.contains(childRenderBoxModel)) {
     fixedChildren.remove(childRenderBoxModel);

--- a/kraken/lib/src/dom/elements/html.dart
+++ b/kraken/lib/src/dom/elements/html.dart
@@ -31,6 +31,7 @@ class HTMLElement extends Element {
   @override
   void setRenderStyle(String property, String present) {
     switch (property) {
+    // Visible should be interpreted as auto and clip should be interpreted as hidden when overflow apply to html.
     // https://drafts.csswg.org/css-overflow-3/#overflow-propagation
       case OVERFLOW:
       case OVERFLOW_X:

--- a/kraken/lib/src/dom/elements/html.dart
+++ b/kraken/lib/src/dom/elements/html.dart
@@ -27,4 +27,21 @@ class HTMLElement extends Element {
     }
     super.dispatchEvent(event);
   }
+
+  @override
+  void setRenderStyle(String property, String present) {
+    switch (property) {
+    // https://drafts.csswg.org/css-overflow-3/#overflow-propagation
+      case OVERFLOW:
+      case OVERFLOW_X:
+      case OVERFLOW_Y:
+        if (present == VISIBLE || present == '') {
+          present = AUTO;
+        } else if (present == CLIP) {
+          present = HIDDEN;
+        }
+        break;
+    }
+    super.setRenderStyle(property, present);
+  }
 }

--- a/kraken/lib/src/launcher/controller.dart
+++ b/kraken/lib/src/launcher/controller.dart
@@ -251,6 +251,9 @@ class KrakenViewController
     // FIXME: for break circle reference
     viewport.controller = null;
 
+    // Clear renderObjects in list when disposed to avoid memory leak.
+    viewport.fixedChildren.clear();
+
     debugDOMTreeChanged = null;
 
     _teardownObserver();

--- a/kraken/lib/src/rendering/box_model.dart
+++ b/kraken/lib/src/rendering/box_model.dart
@@ -616,6 +616,9 @@ class RenderBoxModel extends RenderBox
       opacityAlwaysNeedsCompositing();
   }
 
+  // Cache all the fixed children of renderBoxModel of root element
+  List<RenderBoxModel> fixedChildren = [];
+
   RenderPositionPlaceholder? renderPositionPlaceholder;
 
   bool _debugShouldPaintOverlay = false;
@@ -687,9 +690,6 @@ class RenderBoxModel extends RenderBox
     }
   }
 
-  // Cache all the fixed children of renderBoxModel of root element
-  List<RenderBoxModel> fixedChildren = [];
-
   // Position of sticky element changes between relative and fixed of scroll container
   StickyPositionType stickyStatus = StickyPositionType.relative;
 
@@ -738,6 +738,8 @@ class RenderBoxModel extends RenderBox
 
       // Copy renderPositionHolder
       ..renderPositionPlaceholder = renderPositionPlaceholder
+
+      ..fixedChildren = fixedChildren
 
       // Copy parentData
       ..parentData = parentData;

--- a/kraken/lib/src/rendering/box_model.dart
+++ b/kraken/lib/src/rendering/box_model.dart
@@ -616,9 +616,6 @@ class RenderBoxModel extends RenderBox
       opacityAlwaysNeedsCompositing();
   }
 
-  // Cache all the fixed children of renderBoxModel of root element
-  List<RenderBoxModel> fixedChildren = [];
-
   RenderPositionPlaceholder? renderPositionPlaceholder;
 
   bool _debugShouldPaintOverlay = false;
@@ -738,8 +735,6 @@ class RenderBoxModel extends RenderBox
 
       // Copy renderPositionHolder
       ..renderPositionPlaceholder = renderPositionPlaceholder
-
-      ..fixedChildren = fixedChildren
 
       // Copy parentData
       ..parentData = parentData;
@@ -1359,11 +1354,6 @@ class RenderBoxModel extends RenderBox
       // Call dispose method of renderBoxModel when it is detached from tree.
       super.dispose();
     });
-
-    // Clear renderObjects in list when disposed to avoid memory leak
-    if (fixedChildren.isNotEmpty) {
-      fixedChildren.clear();
-    }
 
     // Dispose scroll behavior
     disposeScrollable();

--- a/kraken/lib/src/rendering/viewport.dart
+++ b/kraken/lib/src/rendering/viewport.dart
@@ -17,7 +17,7 @@ class RenderViewportBox extends RenderProxyBox
     this.controller = controller;
   }
 
-  // Cache all the fixed children of renderBoxModel of root element
+  // Cache all the fixed children of renderBoxModel of root element.
   List<RenderBoxModel> fixedChildren = [];
 
   @override

--- a/kraken/lib/src/rendering/viewport.dart
+++ b/kraken/lib/src/rendering/viewport.dart
@@ -17,6 +17,9 @@ class RenderViewportBox extends RenderProxyBox
     this.controller = controller;
   }
 
+  // Cache all the fixed children of renderBoxModel of root element
+  List<RenderBoxModel> fixedChildren = [];
+
   @override
   bool get isRepaintBoundary => true;
 


### PR DESCRIPTION
* 标准中提到会在设置 viewport 的 overflow 时会修改值。 https://drafts.csswg.org/css-overflow-3/#overflow-propagation
* 修复当 overflow 改变时（上一个值为scroll 并且已滚动部分距离）的位置问题。
* 修复了 overflow 改变时设置了 fixed 的元素定位问题。
* 将 fixedChildren 移到 viewport 上。