### PR TITLE
Fix/custom element widget null

### DIFF
--- a/kraken/lib/src/dom/element.dart
+++ b/kraken/lib/src/dom/element.dart
@@ -766,7 +766,7 @@ abstract class Element
 
   /// Unmount [renderBoxModel].
   @override
-  void unmountRenderObject({ bool deep = true, bool keepFixedAlive = false, needDispose = true }) {
+  void unmountRenderObject({ bool deep = true, bool keepFixedAlive = false, needDisposeSelf = true }) {
     // Ignore the fixed element to unmount render object.
     // It's useful for sliver manager to unmount child render object, but excluding fixed elements.
     if (keepFixedAlive && renderStyle.position == CSSPositionType.fixed) {
@@ -783,7 +783,7 @@ abstract class Element
     }
 
     didDetachRenderer();
-    if (needDispose) {
+    if (needDisposeSelf) {
       renderBoxModel?.dispose();
     }
 

--- a/kraken/lib/src/dom/element.dart
+++ b/kraken/lib/src/dom/element.dart
@@ -785,8 +785,9 @@ abstract class Element
     didDetachRenderer();
     if (needDispose) {
       renderBoxModel?.dispose();
-      renderBoxModel = null;
     }
+
+    renderBoxModel = null;
   }
 
   @override

--- a/kraken/lib/src/dom/element.dart
+++ b/kraken/lib/src/dom/element.dart
@@ -766,7 +766,7 @@ abstract class Element
 
   /// Unmount [renderBoxModel].
   @override
-  void unmountRenderObject({ bool deep = true, bool keepFixedAlive = false, callDispose = true }) {
+  void unmountRenderObject({ bool deep = true, bool keepFixedAlive = false, bool dispose = true }) {
     // Ignore the fixed element to unmount render object.
     // It's useful for sliver manager to unmount child render object, but excluding fixed elements.
     if (keepFixedAlive && renderStyle.position == CSSPositionType.fixed) {
@@ -783,7 +783,7 @@ abstract class Element
     }
 
     didDetachRenderer();
-    if (callDispose) {
+    if (dispose) {
       renderBoxModel?.dispose();
     }
 

--- a/kraken/lib/src/dom/element.dart
+++ b/kraken/lib/src/dom/element.dart
@@ -766,7 +766,7 @@ abstract class Element
 
   /// Unmount [renderBoxModel].
   @override
-  void unmountRenderObject({ bool deep = true, bool keepFixedAlive = false, needDisposeSelf = true }) {
+  void unmountRenderObject({ bool deep = true, bool keepFixedAlive = false, callDispose = true }) {
     // Ignore the fixed element to unmount render object.
     // It's useful for sliver manager to unmount child render object, but excluding fixed elements.
     if (keepFixedAlive && renderStyle.position == CSSPositionType.fixed) {
@@ -783,7 +783,7 @@ abstract class Element
     }
 
     didDetachRenderer();
-    if (needDisposeSelf) {
+    if (callDispose) {
       renderBoxModel?.dispose();
     }
 

--- a/kraken/lib/src/dom/element.dart
+++ b/kraken/lib/src/dom/element.dart
@@ -766,7 +766,7 @@ abstract class Element
 
   /// Unmount [renderBoxModel].
   @override
-  void unmountRenderObject({ bool deep = true, bool keepFixedAlive = false }) {
+  void unmountRenderObject({ bool deep = true, bool keepFixedAlive = false, needDispose = true }) {
     // Ignore the fixed element to unmount render object.
     // It's useful for sliver manager to unmount child render object, but excluding fixed elements.
     if (keepFixedAlive && renderStyle.position == CSSPositionType.fixed) {
@@ -783,8 +783,10 @@ abstract class Element
     }
 
     didDetachRenderer();
-    renderBoxModel?.dispose();
-    renderBoxModel = null;
+    if (needDispose) {
+      renderBoxModel?.dispose();
+      renderBoxModel = null;
+    }
   }
 
   @override

--- a/kraken/lib/src/widget/element_to_widget_adaptor.dart
+++ b/kraken/lib/src/widget/element_to_widget_adaptor.dart
@@ -49,21 +49,18 @@ class KrakenElementToFlutterElementAdaptor extends RenderObjectElement {
 
   @override
   void unmount() {
-    // The function unmountRenderObject should be called before unmount,otherwise members can't be accessed.
-    (widget._krakenNode as dom.Element).unmountRenderObject();
+    // The member widget will be set to null when Flutter element unmount called, should save it.
     dom.Element ele = (widget._krakenNode as dom.Element);
-
-    // The function unmountRenderObject should be called before unmount, otherwise members can't be accessed.
-    ele.unmountRenderObject(needDispose: false, deep: true);
 
     super.unmount();
 
-    ele.renderBoxModel = null;
+    // Flutter element unmount call dispose of _renderObject, so we should not call dispose in unmountRenderObject.
+    ele.unmountRenderObject(needDispose: false, deep: true);
   }
 
-  // @override
-  // void insertRenderObjectChild(RenderObject child, Object? slot) {}
+  @override
+  void insertRenderObjectChild(RenderObject child, Object? slot) {}
 
-  // @override
-  // void moveRenderObjectChild(covariant RenderObject child, covariant Object? oldSlot, covariant Object? newSlot) {}
+  @override
+  void moveRenderObjectChild(covariant RenderObject child, covariant Object? oldSlot, covariant Object? newSlot) {}
 }

--- a/kraken/lib/src/widget/element_to_widget_adaptor.dart
+++ b/kraken/lib/src/widget/element_to_widget_adaptor.dart
@@ -55,7 +55,7 @@ class KrakenElementToFlutterElementAdaptor extends RenderObjectElement {
     super.unmount();
 
     // Flutter element unmount call dispose of _renderObject, so we should not call dispose in unmountRenderObject.
-    ele.unmountRenderObject(needDispose: false, deep: true);
+    ele.unmountRenderObject(needDisposeSelf: false, deep: true);
   }
 
   @override

--- a/kraken/lib/src/widget/element_to_widget_adaptor.dart
+++ b/kraken/lib/src/widget/element_to_widget_adaptor.dart
@@ -51,7 +51,7 @@ class KrakenElementToFlutterElementAdaptor extends RenderObjectElement {
   void unmount() {
     // Flutter element unmount call dispose of _renderObject, so we should not call dispose in unmountRenderObject.
     dom.Element element = (widget._krakenNode as dom.Element);
-    element.unmountRenderObject(callDispose: false, deep: true);
+    element.unmountRenderObject(dispose: false);
 
     super.unmount();
   }

--- a/kraken/lib/src/widget/element_to_widget_adaptor.dart
+++ b/kraken/lib/src/widget/element_to_widget_adaptor.dart
@@ -49,8 +49,8 @@ class KrakenElementToFlutterElementAdaptor extends RenderObjectElement {
 
   @override
   void unmount() {
-    super.unmount();
     (widget._krakenNode as dom.Element).unmountRenderObject();
+    super.unmount();
   }
 
   @override

--- a/kraken/lib/src/widget/element_to_widget_adaptor.dart
+++ b/kraken/lib/src/widget/element_to_widget_adaptor.dart
@@ -49,13 +49,11 @@ class KrakenElementToFlutterElementAdaptor extends RenderObjectElement {
 
   @override
   void unmount() {
-    // The member widget will be set to null when Flutter element unmount called, should save it.
+    // Flutter element unmount call dispose of _renderObject, so we should not call dispose in unmountRenderObject.
     dom.Element ele = (widget._krakenNode as dom.Element);
+    ele.unmountRenderObject(needDisposeSelf: false, deep: true);
 
     super.unmount();
-
-    // Flutter element unmount call dispose of _renderObject, so we should not call dispose in unmountRenderObject.
-    ele.unmountRenderObject(needDisposeSelf: false, deep: true);
   }
 
   @override

--- a/kraken/lib/src/widget/element_to_widget_adaptor.dart
+++ b/kraken/lib/src/widget/element_to_widget_adaptor.dart
@@ -50,8 +50,8 @@ class KrakenElementToFlutterElementAdaptor extends RenderObjectElement {
   @override
   void unmount() {
     // Flutter element unmount call dispose of _renderObject, so we should not call dispose in unmountRenderObject.
-    dom.Element ele = (widget._krakenNode as dom.Element);
-    ele.unmountRenderObject(needDisposeSelf: false, deep: true);
+    dom.Element element = (widget._krakenNode as dom.Element);
+    element.unmountRenderObject(needDisposeSelf: false, deep: true);
 
     super.unmount();
   }

--- a/kraken/lib/src/widget/element_to_widget_adaptor.dart
+++ b/kraken/lib/src/widget/element_to_widget_adaptor.dart
@@ -51,9 +51,19 @@ class KrakenElementToFlutterElementAdaptor extends RenderObjectElement {
   void unmount() {
     // The function unmountRenderObject should be called before unmount,otherwise members can't be accessed.
     (widget._krakenNode as dom.Element).unmountRenderObject();
+    dom.Element ele = (widget._krakenNode as dom.Element);
+
+    // The function unmountRenderObject should be called before unmount, otherwise members can't be accessed.
+    ele.unmountRenderObject(needDispose: false, deep: true);
+
     super.unmount();
+
+    ele.renderBoxModel = null;
   }
 
-  @override
-  void insertRenderObjectChild(RenderObject child, Object? slot) {}
+  // @override
+  // void insertRenderObjectChild(RenderObject child, Object? slot) {}
+
+  // @override
+  // void moveRenderObjectChild(covariant RenderObject child, covariant Object? oldSlot, covariant Object? newSlot) {}
 }

--- a/kraken/lib/src/widget/element_to_widget_adaptor.dart
+++ b/kraken/lib/src/widget/element_to_widget_adaptor.dart
@@ -51,7 +51,7 @@ class KrakenElementToFlutterElementAdaptor extends RenderObjectElement {
   void unmount() {
     // Flutter element unmount call dispose of _renderObject, so we should not call dispose in unmountRenderObject.
     dom.Element element = (widget._krakenNode as dom.Element);
-    element.unmountRenderObject(needDisposeSelf: false, deep: true);
+    element.unmountRenderObject(callDispose: false, deep: true);
 
     super.unmount();
   }

--- a/kraken/lib/src/widget/element_to_widget_adaptor.dart
+++ b/kraken/lib/src/widget/element_to_widget_adaptor.dart
@@ -49,6 +49,7 @@ class KrakenElementToFlutterElementAdaptor extends RenderObjectElement {
 
   @override
   void unmount() {
+    // The function unmountRenderObject should be called before unmount,otherwise members can't be accessed.
     (widget._krakenNode as dom.Element).unmountRenderObject();
     super.unmount();
   }


### PR DESCRIPTION
close #1369

* unmount 方法调用后，Flutter element 上的 widget 成员会被置为 null，导致访问不到。
* 修复 KrakenElementToFlutterElementAdaptor 销毁 render object 断言异常，KrakenElementToFlutterElementAdaptor 在 Flutter Element 的 unmount 时会调用对应的 render object（其实由于已经劫持了 createdRenderObject 所以该 render object 就是 Kraken Node 所创建的 Render Object），所以需要调用 unmountRenderObject 通过调用 didAttach 等生命钩子保证一些具体 Element 的行为正确的同时，子节点是普通 Kraken Node（基于性能以及内存考虑不创建KrakenElementToFlutterElementAdaptor）， 所以需要通过 deep 来进行 unmountRenderObject。