### PR TITLE
[fix] 修改前端kraken.methodChannel.addMethodCallHandler的回调中直接更新data，页面不更新问题。

### DIFF
--- a/bridge/polyfill/src/method-channel.ts
+++ b/bridge/polyfill/src/method-channel.ts
@@ -33,9 +33,11 @@ export const methodChannel = {
 };
 
 export function triggerMethodCallHandler(method: string, args: any) {
-  if (methodCallHandlers.length > 0) {
-    for (let handler of methodCallHandlers) {
-      handler(method, args);
+  setTimeout(() => {
+    if (methodCallHandlers.length > 0) {
+      for (let handler of methodCallHandlers) {
+        handler(method, args);
+      }
     }
-  }
+  }, 0);
 }


### PR DESCRIPTION
如以下demo，不添加setTimeout的话nativecallmessage发生更新以后不会触发页面更新:
```javascript
data() {
    return {
      nativecallmessage: "111",
      style,
    };
  },
  methods: {
    addMethodCallHandler() {
      console.error("native call:", "addNativeCallHandler");
      kraken.methodChannel.addMethodCallHandler((method, args) => {
        var _this = this
        setTimeout(() => {
          _this.nativecallmessage = "method->" + method + ", args->" + args;
        }, 10);
        console.log("native call:", this.nativecallmessage);
      });
    },
```