### PR TITLE
Fix/custom element item layout

### DIFF
--- a/kraken/lib/src/css/render_style.dart
+++ b/kraken/lib/src/css/render_style.dart
@@ -638,6 +638,7 @@ class CSSRenderStyle
           RenderStyle? ancestorRenderStyle = _findAncestorWithNoDisplayInline();
           // Should ignore renderStyle of display inline when searching for ancestors to stretch width.
           if (ancestorRenderStyle != null) {
+            // If parentElement is WidgetElement, should not search for ancestors and get maxWidth of constraints for logicalWidth.
             if (ancestorRenderStyle.target.renderObjectManagerType == RenderObjectManagerType.FLUTTER_ELEMENT && renderBoxModel!.parent is RenderBox) {
               RenderBox renderBox = renderBoxModel!.parent as RenderBox;
               logicalWidth = renderBox.constraints.maxWidth;
@@ -1132,6 +1133,7 @@ class CSSRenderStyle
     RenderStyle renderStyle = this;
     RenderStyle? parentRenderStyle = renderStyle.parent;
     while(parentRenderStyle != null) {
+      // If ancestor element is WidgetElement, should return it because should get maxWidth of constraints for logicalWidth.
       if (parentRenderStyle.effectiveDisplay != CSSDisplay.inline || parentRenderStyle.target.renderObjectManagerType == RenderObjectManagerType.FLUTTER_ELEMENT) {
         break;
       }

--- a/kraken/lib/src/css/render_style.dart
+++ b/kraken/lib/src/css/render_style.dart
@@ -638,7 +638,13 @@ class CSSRenderStyle
           RenderStyle? ancestorRenderStyle = _findAncestorWithNoDisplayInline();
           // Should ignore renderStyle of display inline when searching for ancestors to stretch width.
           if (ancestorRenderStyle != null) {
-            logicalWidth = ancestorRenderStyle.contentBoxLogicalWidth;
+            if (ancestorRenderStyle.target.renderObjectManagerType == RenderObjectManagerType.FLUTTER_ELEMENT && renderBoxModel!.parent is RenderBox) {
+              RenderBox renderBox = renderBoxModel!.parent as RenderBox;
+              logicalWidth = renderBox.constraints.maxWidth;
+            } else {
+              logicalWidth = ancestorRenderStyle.contentBoxLogicalWidth;
+            }
+
             // Should subtract horizontal margin of own from its parent content width.
             if (logicalWidth != null) {
               logicalWidth -= renderStyle.margin.horizontal;
@@ -1126,7 +1132,7 @@ class CSSRenderStyle
     RenderStyle renderStyle = this;
     RenderStyle? parentRenderStyle = renderStyle.parent;
     while(parentRenderStyle != null) {
-      if (parentRenderStyle.effectiveDisplay != CSSDisplay.inline) {
+      if (parentRenderStyle.effectiveDisplay != CSSDisplay.inline || parentRenderStyle.target.renderObjectManagerType == RenderObjectManagerType.FLUTTER_ELEMENT) {
         break;
       }
       parentRenderStyle = parentRenderStyle.parent;

--- a/kraken/lib/src/css/render_style.dart
+++ b/kraken/lib/src/css/render_style.dart
@@ -644,7 +644,7 @@ class CSSRenderStyle
 
             if (ancestorRenderStyle.target.renderObjectManagerType == RenderObjectManagerType.FLUTTER_ELEMENT && renderObject is RenderBox) {
               try {
-                // When renderObject has not layouted, get constraints will trigger assets.
+                // When renderObject has not layouted, get constraints will trigger assert.
                 // Such as image resize will get _styleWidth and call this function before layout.
                 logicalWidth = renderObject.constraints.maxWidth;
               } catch(e) {

--- a/kraken/lib/src/css/render_style.dart
+++ b/kraken/lib/src/css/render_style.dart
@@ -639,9 +639,9 @@ class CSSRenderStyle
           // Should ignore renderStyle of display inline when searching for ancestors to stretch width.
           if (ancestorRenderStyle != null) {
             // If parentElement is WidgetElement, should not search for ancestors and get maxWidth of constraints for logicalWidth.
-            if (ancestorRenderStyle.target.renderObjectManagerType == RenderObjectManagerType.FLUTTER_ELEMENT && renderBoxModel!.parent is RenderBox) {
-              RenderBox renderBox = renderBoxModel!.parent as RenderBox;
-              logicalWidth = renderBox.constraints.maxWidth;
+            RenderObject? renderObject = renderBoxModel!.parent as RenderObject;
+            if (ancestorRenderStyle.target.renderObjectManagerType == RenderObjectManagerType.FLUTTER_ELEMENT && renderObject is RenderBox && renderObject.hasSize) {
+              logicalWidth = renderObject.constraints.maxWidth;
             } else {
               logicalWidth = ancestorRenderStyle.contentBoxLogicalWidth;
             }

--- a/kraken/lib/src/css/render_style.dart
+++ b/kraken/lib/src/css/render_style.dart
@@ -640,8 +640,16 @@ class CSSRenderStyle
           if (ancestorRenderStyle != null) {
             // If parentElement is WidgetElement, should not search for ancestors and get maxWidth of constraints for logicalWidth.
             RenderObject? renderObject = renderBoxModel!.parent as RenderObject;
-            if (ancestorRenderStyle.target.renderObjectManagerType == RenderObjectManagerType.FLUTTER_ELEMENT && renderObject is RenderBox && renderObject.hasSize) {
-              logicalWidth = renderObject.constraints.maxWidth;
+
+
+            if (ancestorRenderStyle.target.renderObjectManagerType == RenderObjectManagerType.FLUTTER_ELEMENT && renderObject is RenderBox) {
+              try {
+                // When renderObject has not layouted, get constraints will trigger assets.
+                // Such as image resize will get _styleWidth and call this function before layout.
+                logicalWidth = renderObject.constraints.maxWidth;
+              } catch(e) {
+                logicalWidth = ancestorRenderStyle.contentBoxLogicalWidth;
+              }
             } else {
               logicalWidth = ancestorRenderStyle.contentBoxLogicalWidth;
             }

--- a/kraken/lib/src/widget/element_to_widget_adaptor.dart
+++ b/kraken/lib/src/widget/element_to_widget_adaptor.dart
@@ -2,7 +2,9 @@
  * Copyright (C) 2022-present The Kraken authors. All rights reserved.
  */
 import 'package:flutter/widgets.dart';
+import 'package:kraken/css.dart';
 import 'package:kraken/dom.dart' as dom;
+import 'package:kraken/rendering.dart';
 
 class KrakenElementToWidgetAdaptor extends RenderObjectWidget {
   final dom.Node _krakenNode;
@@ -19,7 +21,13 @@ class KrakenElementToWidgetAdaptor extends RenderObjectWidget {
 
   @override
   RenderObject createRenderObject(BuildContext context) {
-    return _krakenNode.renderer!;
+    if (_krakenNode is dom.Element) {
+      RenderFlowLayout renderFlowLayout = RenderFlowLayout(renderStyle: CSSRenderStyle(target: _krakenNode as dom.Element));
+      renderFlowLayout.insert(_krakenNode.renderer!);
+      return renderFlowLayout;
+    } else {
+      return _krakenNode.renderer!;
+    }
   }
 }
 

--- a/kraken/lib/src/widget/element_to_widget_adaptor.dart
+++ b/kraken/lib/src/widget/element_to_widget_adaptor.dart
@@ -21,6 +21,8 @@ class KrakenElementToWidgetAdaptor extends RenderObjectWidget {
 
   @override
   RenderObject createRenderObject(BuildContext context) {
+    // Children of custom element need RenderFlowLayout nesting,
+    // otherwise the parent render layout will not be called when setting properties.
     if (_krakenNode is dom.Element) {
       RenderFlowLayout renderFlowLayout = RenderFlowLayout(renderStyle: CSSRenderStyle(target: _krakenNode as dom.Element));
       renderFlowLayout.insert(_krakenNode.renderer!);

--- a/kraken/lib/src/widget/element_to_widget_adaptor.dart
+++ b/kraken/lib/src/widget/element_to_widget_adaptor.dart
@@ -24,7 +24,8 @@ class KrakenElementToWidgetAdaptor extends RenderObjectWidget {
     // Children of custom element need RenderFlowLayout nesting,
     // otherwise the parent render layout will not be called when setting properties.
     if (_krakenNode is dom.Element) {
-      RenderFlowLayout renderFlowLayout = RenderFlowLayout(renderStyle: CSSRenderStyle(target: _krakenNode as dom.Element));
+      CSSRenderStyle renderStyle = CSSRenderStyle(target: _krakenNode as dom.Element);
+      RenderFlowLayout renderFlowLayout = RenderFlowLayout(renderStyle: renderStyle);
       renderFlowLayout.insert(_krakenNode.renderer!);
       return renderFlowLayout;
     } else {


### PR DESCRIPTION
close #1391 

Custom element 的子节点需要一层 RenderFlowLayout 嵌套，否则会导致设置属性时无法触发父 render object 的 layout 流程导致无法撑开。

以及约束需要取父 renderBoxModel 的约束，保证子元素不向上递归寻找而逃出容器。