### PR TITLE
fix: dispose

### DIFF
--- a/kraken/lib/src/dom/document.dart
+++ b/kraken/lib/src/dom/document.dart
@@ -192,7 +192,6 @@ class Document extends Node {
 
   @override
   void dispose() {
-    _viewport?.dispose();
     _viewport = null;
     gestureListener = null;
     widgetDelegate = null;

--- a/kraken/lib/src/widget/text_control.dart
+++ b/kraken/lib/src/widget/text_control.dart
@@ -27,23 +27,23 @@ typedef OnControllerCreated = void Function(KrakenController controller);
 
 /// Delegate methods of widget
 class WidgetDelegate {
-  GetContext getContext;
-  RequestFocus requestFocus;
-  GetTargetPlatform getTargetPlatform;
-  GetCursorColor getCursorColor;
-  GetSelectionColor getSelectionColor;
-  GetCursorRadius getCursorRadius;
-  GetTextSelectionControls getTextSelectionControls;
+  final GetContext getContext;
+  final RequestFocus requestFocus;
+  final GetTargetPlatform getTargetPlatform;
+  final GetCursorColor getCursorColor;
+  final GetSelectionColor getSelectionColor;
+  final GetCursorRadius getCursorRadius;
+  final GetTextSelectionControls getTextSelectionControls;
 
-  WidgetDelegate(
-      this.getContext,
-      this.requestFocus,
-      this.getTargetPlatform,
-      this.getCursorColor,
-      this.getSelectionColor,
-      this.getCursorRadius,
-      this.getTextSelectionControls,
-      );
+  const WidgetDelegate(
+    this.getContext,
+    this.requestFocus,
+    this.getTargetPlatform,
+    this.getCursorColor,
+    this.getSelectionColor,
+    this.getCursorRadius,
+    this.getTextSelectionControls,
+  );
 }
 
 // Widget involves actions of text control elements(input, textarea).


### PR DESCRIPTION
- 修复 viewport 被多次 dispose 的问题
  - 原因是 Document 在被 GC 时会触发其 dispose(), 在这个方法里还调用了 viewport 的 dispose()，接着在 State unmount() 中又调用了 viewport 的 dispose，导致多次触发
  - 正常情况下 dispose 遵循谁创建谁销毁原则，RenderViewportBox 是 controller 创建的，但是其是 RenderObject，故又受到 Widget Framework 的控制，这里 dispose 必须是被 framework 触发