### PR TITLE
[fix] kraken not support relative protocol 

### DIFF
--- a/kraken/lib/src/dom/elements/head.dart
+++ b/kraken/lib/src/dom/elements/head.dart
@@ -32,7 +32,7 @@ class LinkElement extends Element {
   LinkElement([BindingContext? context]) : super(context, defaultStyle: _defaultStyle);
 
   Uri? _resolvedHyperlink;
-  Map<String, bool> _stylesheetLoaded = {};
+  final Map<String, bool> _stylesheetLoaded = {};
 
   // Bindings.
   @override

--- a/kraken/lib/src/launcher/controller.dart
+++ b/kraken/lib/src/launcher/controller.dart
@@ -1034,12 +1034,12 @@ class KrakenController {
     return completer.future;
   }
 
-  Uri? get _uri {
+  String? get _url {
     HistoryModule historyModule = module.moduleManager.getModule<HistoryModule>('History')!;
-    return historyModule.stackTop?.resolvedUri;
+    return historyModule.stackTop?.url;
   }
 
-  String get url => _uri?.toString() ?? '';
+  String get url => _url ?? '';
 
   _addHistory(KrakenBundle bundle) {
     HistoryModule historyModule =


### PR DESCRIPTION
[fix] kraken not support relative protocol
由于HistoryModule的_replaceState过程中重新构建了bundle,此bundle未resolve,导致resolvedUri为空。